### PR TITLE
Fix: Translation citation format and alignment

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -70,12 +70,8 @@ function insertAyah(ayahData, formatState, settings) {
       rtl: true
     });
     paragraphsToInsert.push({
-      text: translationText,
-      align: DocumentApp.HorizontalAlignment.LEFT
-    });
-    paragraphsToInsert.push({
-      text: '[' + surahNameEn + ' ' + ayahData.surah + ':' + ayahData.ayah + ']',
-      align: DocumentApp.HorizontalAlignment.LEFT
+      text: '\u201C' + translationText + '\u201D (' + surahNameEn + ' ' + ayahData.surah + ':' + ayahData.ayah + ')',
+      align: DocumentApp.HorizontalAlignment.CENTER
     });
   } else {
     paragraphsToInsert.push({

--- a/QuranAPI.js
+++ b/QuranAPI.js
@@ -22,7 +22,7 @@ function getSurahListFromQuranApi() {
       list.push({
         number: i + 1,
         nameArabic: s.surahNameArabic || '',
-        nameEnglish: s.surahNameTranslation || s.surahName || '',
+        nameEnglish: s.surahName || '',
         ayahCount: s.totalAyah || 0
       });
     }
@@ -58,7 +58,7 @@ function getAyahFromQuranApi(surahNum, ayahNum, style) {
       surah: json.surahNo || surahNum,
       ayah: json.ayahNo || ayahNum,
       surahNameArabic: json.surahNameArabic || '',
-      surahNameEnglish: json.surahNameTranslation || json.surahName || '',
+      surahNameEnglish: json.surahName || '',
       arabicText: arabicText,
       textUthmani: arabic1,
       textSimple: arabic2,


### PR DESCRIPTION
## Summary
- Merged translation and citation into a single centered paragraph: `"translation" (SurahName Surah:Ayah)`
- Wrapped translation in Unicode curly quotes (`\u201C` / `\u201D`)
- Used surah transliteration name (e.g., "Al-Baqara") instead of English meaning ("The Cow")

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)