### PR TITLE
Remove unused settings: insert position, translation edition, reference format

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -4,10 +4,10 @@
  */
 
 /**
- * Inserts an ayah into the document.
+ * Inserts an ayah into the document at the cursor position.
  * @param {Object} ayahData - { surah, ayah, surahNameArabic, surahNameEnglish, textUthmani, textSimple, translationText }
  * @param {Object} formatState - { fontName, fontSize, bold, textColor }
- * @param {Object} settings - { insertMode, showTranslation, arabicStyle }
+ * @param {Object} settings - { showTranslation, arabicStyle }
  * @return {Object} { success: boolean, message?: string }
  */
 function insertAyah(ayahData, formatState, settings) {
@@ -24,7 +24,6 @@ function insertAyah(ayahData, formatState, settings) {
 
   var arabicStyle = (settings && settings.arabicStyle) || 'uthmani';
   var showTranslation = settings && settings.showTranslation !== false;
-  var insertMode = (settings && settings.insertMode) || 'cursor';
 
   var arabicText = (arabicStyle === 'uthmani' && ayahData.textUthmani)
     ? ayahData.textUthmani
@@ -34,33 +33,13 @@ function insertAyah(ayahData, formatState, settings) {
   var surahNameEn = ayahData.surahNameEnglish || '';
   var ayahNumAr = toArabicIndic(ayahData.ayah);
 
-  var insertIndex;
-  var found = null;
-  var tagParagraph = null;
-
-  if (insertMode === 'inserttag') {
-    found = body.findText('\\[insert\\]');
-    if (!found) {
-      insertMode = 'cursor';
-    } else {
-      var textEl = found.getElement();
-      var startOffset = found.getStartOffset();
-      var endOffset = found.getEndOffsetInclusive();
-      tagParagraph = textEl.getParent().asParagraph();
-      textEl.asText().deleteText(startOffset, endOffset);
-      insertIndex = body.getChildIndex(tagParagraph);
-    }
+  var cursorElement = cursor.getElement();
+  var parent = cursorElement.getParent();
+  while (parent && parent.getType() !== DocumentApp.ElementType.PARAGRAPH) {
+    parent = parent.getParent();
   }
-
-  if (insertMode !== 'inserttag' || !tagParagraph) {
-    var cursorElement = cursor.getElement();
-    var parent = cursorElement.getParent();
-    while (parent && parent.getType() !== DocumentApp.ElementType.PARAGRAPH) {
-      parent = parent.getParent();
-    }
-    var cursorParagraph = parent ? parent.asParagraph() : body.getParagraphs()[0];
-    insertIndex = body.getChildIndex(cursorParagraph) + 1;
-  }
+  var cursorParagraph = parent ? parent.asParagraph() : body.getParagraphs()[0];
+  var insertIndex = body.getChildIndex(cursorParagraph) + 1;
 
   var paragraphsToInsert = [];
   if (showTranslation && translationText) {
@@ -82,25 +61,11 @@ function insertAyah(ayahData, formatState, settings) {
   }
 
   var fontWarning = null;
-  if (insertMode === 'inserttag' && tagParagraph) {
-    tagParagraph.clear();
-    tagParagraph.appendText(paragraphsToInsert[0].text);
-    tagParagraph.setAlignment(paragraphsToInsert[0].align);
-    if (paragraphsToInsert[0].rtl) tagParagraph.setLeftToRight(false);
-    fontWarning = applyFormat(tagParagraph.editAsText(), formatState) || fontWarning;
-    for (var j = 1; j < paragraphsToInsert.length; j++) {
-      var p = body.insertParagraph(insertIndex + j, paragraphsToInsert[j].text);
-      p.setAlignment(paragraphsToInsert[j].align);
-      if (paragraphsToInsert[j].rtl) p.setLeftToRight(false);
-      fontWarning = applyFormat(p.editAsText(), formatState) || fontWarning;
-    }
-  } else {
-    for (var i = 0; i < paragraphsToInsert.length; i++) {
-      var p = body.insertParagraph(insertIndex + i, paragraphsToInsert[i].text);
-      p.setAlignment(paragraphsToInsert[i].align);
-      if (paragraphsToInsert[i].rtl) p.setLeftToRight(false);
-      fontWarning = applyFormat(p.editAsText(), formatState) || fontWarning;
-    }
+  for (var i = 0; i < paragraphsToInsert.length; i++) {
+    var p = body.insertParagraph(insertIndex + i, paragraphsToInsert[i].text);
+    p.setAlignment(paragraphsToInsert[i].align);
+    if (paragraphsToInsert[i].rtl) p.setLeftToRight(false);
+    fontWarning = applyFormat(p.editAsText(), formatState) || fontWarning;
   }
 
   var message = fontWarning ? 'Ayah inserted. ' + fontWarning : 'Ayah inserted.';

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -7,11 +7,8 @@
 var AI_SEARCH_DAILY_LIMIT = 100;
 
 var SETTINGS_DEFAULTS = {
-  insertMode: 'cursor',       // "cursor" | "newline" | "inserttag"
   showTranslation: true,
   insertArabic: true,
-  showReference: true,
-  translationEdition: 'sahih', // maps to quranapi edition key
   arabicStyle: 'uthmani',     // "uthmani" | "simple"
   fontName: 'Amiri',
   fontSize: 18,

--- a/sidebar/components/settings-panel.html
+++ b/sidebar/components/settings-panel.html
@@ -5,30 +5,6 @@
   </h2>
 
   <div class="settings-section">
-    <label>Insert position</label>
-    <div class="settings-radio">
-      <input type="radio" name="insertMode" id="insert-cursor" value="cursor" checked>
-      <label for="insert-cursor">At cursor position</label>
-    </div>
-    <div class="settings-radio">
-      <input type="radio" name="insertMode" id="insert-newline" value="newline">
-      <label for="insert-newline">New line after cursor</label>
-    </div>
-    <div class="settings-radio">
-      <input type="radio" name="insertMode" id="insert-tag" value="inserttag">
-      <label for="insert-tag">At [insert] tag</label>
-    </div>
-    <p class="hint">Place [insert] anywhere in your doc. Tasneef will replace it with the ayah.</p>
-  </div>
-
-  <div class="settings-section">
-    <label for="translation-edition">Default translation</label>
-    <select id="translation-edition">
-      <option value="sahih" selected>Saheeh International</option>
-    </select>
-  </div>
-
-  <div class="settings-section">
     <label>Insert content</label>
     <div class="settings-check">
       <input type="checkbox" id="insert-arabic" checked>
@@ -38,17 +14,6 @@
       <input type="checkbox" id="insert-translation" checked>
       <label for="insert-translation">Translation</label>
     </div>
-    <div class="settings-check">
-      <input type="checkbox" id="insert-reference" checked>
-      <label for="insert-reference">Reference (surah:ayah)</label>
-    </div>
-  </div>
-
-  <div class="settings-section">
-    <label for="reference-format">Reference format</label>
-    <select id="reference-format">
-      <option value="surah-ayah">Surah Name Chapter:Verse</option>
-    </select>
   </div>
 
   <div class="settings-section">

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -132,21 +132,11 @@
   function loadSettingsIntoPanel() {
     google.script.run
       .withSuccessHandler(function(s) {
-        var cursor = document.getElementById('insert-cursor');
-        var newline = document.getElementById('insert-newline');
-        var tag = document.getElementById('insert-tag');
-        var edition = document.getElementById('translation-edition');
         var arabic = document.getElementById('insert-arabic');
         var trans = document.getElementById('insert-translation');
-        var ref = document.getElementById('insert-reference');
         var apiKey = document.getElementById('claude-api-key');
-        if (cursor) cursor.checked = (s.insertMode === 'cursor');
-        if (newline) newline.checked = (s.insertMode === 'newline');
-        if (tag) tag.checked = (s.insertMode === 'inserttag');
-        if (edition) edition.value = s.translationEdition || 'sahih';
         if (arabic) arabic.checked = s.insertArabic !== false;
         if (trans) trans.checked = s.showTranslation !== false;
-        if (ref) ref.checked = s.showReference !== false;
         if (apiKey) {
           google.script.run.withSuccessHandler(function(k) {
             apiKey.value = k || '';
@@ -159,25 +149,10 @@
   }
 
   function initSettingsPanelHandlers() {
-    var insertRadios = document.querySelectorAll('input[name="insertMode"]');
-    var edition = document.getElementById('translation-edition');
     var arabic = document.getElementById('insert-arabic');
     var trans = document.getElementById('insert-translation');
-    var ref = document.getElementById('insert-reference');
     var btnSave = document.getElementById('btn-save-api-key');
     var apiKeyInput = document.getElementById('claude-api-key');
-
-    insertRadios.forEach(function(r) {
-      r.addEventListener('change', function() {
-        google.script.run.withFailureHandler(function(){}).saveSetting('insertMode', r.value);
-      });
-    });
-
-    if (edition) {
-      edition.addEventListener('change', function() {
-        google.script.run.withFailureHandler(function(){}).saveSetting('translationEdition', edition.value);
-      });
-    }
 
     if (arabic) {
       arabic.addEventListener('change', function() {
@@ -187,11 +162,6 @@
     if (trans) {
       trans.addEventListener('change', function() {
         google.script.run.withFailureHandler(function(){}).saveSetting('showTranslation', trans.checked);
-      });
-    }
-    if (ref) {
-      ref.addEventListener('change', function() {
-        google.script.run.withFailureHandler(function(){}).saveSetting('showReference', ref.checked);
       });
     }
 


### PR DESCRIPTION
## Summary
- Removed **Insert position** setting and all `inserttag`/`newline` logic — always inserts on a new line after cursor
- Removed **Default translation** setting — API default (Sahih International) is used
- Removed **Reference format** section and `showReference` toggle — current behavior is kept as-is
- Cleaned up settings panel UI, `SettingsService.js` defaults, and sidebar event handlers

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)