### PR TITLE
Ayah insertion & settings overhaul

### DIFF
--- a/SettingsService.js
+++ b/SettingsService.js
@@ -79,12 +79,29 @@ function getClaudeApiKey() {
 }
 
 /**
+ * Returns true if a Claude API key has been stored, false otherwise.
+ * Use this instead of getClaudeApiKey() when you only need to check existence
+ * (avoids sending the key value to the client).
+ * @return {boolean}
+ */
+function hasClaudeApiKey() {
+  var key = PropertiesService.getUserProperties()
+    .getProperty(PROPERTY_KEYS.CLAUDE_API_KEY);
+  return !!(key && key.length > 0);
+}
+
+/**
  * Persists the Claude API key to User Properties.
+ * Pass an empty string or null to delete the stored key.
  * @param {string} key - The API key to store.
  */
 function setClaudeApiKey(key) {
-  PropertiesService.getUserProperties()
-    .setProperty(PROPERTY_KEYS.CLAUDE_API_KEY, key);
+  var props = PropertiesService.getUserProperties();
+  if (!key || key.trim().length === 0) {
+    props.deleteProperty(PROPERTY_KEYS.CLAUDE_API_KEY);
+  } else {
+    props.setProperty(PROPERTY_KEYS.CLAUDE_API_KEY, key.trim());
+  }
 }
 
 /**

--- a/sidebar/components/settings-panel.html
+++ b/sidebar/components/settings-panel.html
@@ -7,10 +7,6 @@
   <div class="settings-section">
     <label>Insert content</label>
     <div class="settings-check">
-      <input type="checkbox" id="insert-arabic" checked>
-      <label for="insert-arabic">Arabic text</label>
-    </div>
-    <div class="settings-check">
       <input type="checkbox" id="insert-translation" checked>
       <label for="insert-translation">Translation</label>
     </div>
@@ -20,8 +16,10 @@
     <label for="claude-api-key">Claude API key</label>
     <input type="text" id="claude-api-key" placeholder="sk-ant-..." data-masked>
     <p class="hint">Required for all queries (browse, search, AI)</p>
-    <div class="settings-save-row">
-      <button type="button" class="btn-primary" id="btn-save-api-key">Save</button>
-    </div>
+  </div>
+
+  <div class="settings-save-row">
+    <button type="button" class="btn-primary" id="btn-save-settings">Save</button>
+    <p id="settings-saved-msg" class="settings-saved-msg hidden"></p>
   </div>
 </div>

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -92,7 +92,10 @@
   .settings-section input[type="text"][data-masked] { font-family: monospace; }
   .settings-radio, .settings-check { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; cursor: pointer; }
   .settings-radio input, .settings-check input { margin: 0; }
-  .settings-save-row { display: flex; gap: 8px; align-items: center; margin-top: 8px; }
+  .settings-save-row { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+  .settings-saved-msg { font-size: 12px; margin: 0; }
+  .settings-saved-msg.success { color: #2e7d32; }
+  .settings-saved-msg.error { color: #c62828; }
 
   .hidden { display: none !important; }
 </style>

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -130,16 +130,15 @@
   function loadSettingsIntoPanel() {
     google.script.run
       .withSuccessHandler(function(s) {
-        var arabic = document.getElementById('insert-arabic');
         var trans = document.getElementById('insert-translation');
         var apiKey = document.getElementById('claude-api-key');
-        if (arabic) arabic.checked = s.insertArabic !== false;
         if (trans) trans.checked = s.showTranslation !== false;
         if (apiKey) {
-          google.script.run.withSuccessHandler(function(k) {
-            apiKey.value = k || '';
-            apiKey.placeholder = k ? '••••••••••' : 'sk-ant-...';
-          }).getClaudeApiKey();
+          // Never populate the input with the actual key value — check existence only
+          google.script.run.withSuccessHandler(function(hasKey) {
+            apiKey.value = '';
+            apiKey.placeholder = hasKey ? '••••••••••' : 'sk-ant-...';
+          }).hasClaudeApiKey();
         }
       })
       .withFailureHandler(function() {})
@@ -147,28 +146,41 @@
   }
 
   function initSettingsPanelHandlers() {
-    var arabic = document.getElementById('insert-arabic');
     var trans = document.getElementById('insert-translation');
-    var btnSave = document.getElementById('btn-save-api-key');
+    var btnSave = document.getElementById('btn-save-settings');
     var apiKeyInput = document.getElementById('claude-api-key');
+    var savedMsg = document.getElementById('settings-saved-msg');
 
-    if (arabic) {
-      arabic.addEventListener('change', function() {
-        google.script.run.withFailureHandler(function(){}).saveSetting('insertArabic', arabic.checked);
-      });
+    function showSavedMessage(text, isError) {
+      if (!savedMsg) return;
+      savedMsg.textContent = text;
+      savedMsg.className = 'settings-saved-msg ' + (isError ? 'error' : 'success');
+      savedMsg.classList.remove('hidden');
+      setTimeout(function() { savedMsg.classList.add('hidden'); }, 3000);
     }
-    if (trans) {
-      trans.addEventListener('change', function() {
-        google.script.run.withFailureHandler(function(){}).saveSetting('showTranslation', trans.checked);
-      });
-    }
-    if (btnSave && apiKeyInput) {
+
+    if (btnSave) {
       btnSave.addEventListener('click', function() {
-        var key = apiKeyInput.value.trim();
+        var showTranslation = trans ? trans.checked : true;
+        var key = apiKeyInput ? apiKeyInput.value.trim() : '';
+
         google.script.run
-          .withSuccessHandler(function() { apiKeyInput.placeholder = 'Saved'; })
-          .withFailureHandler(function() {})
-          .setClaudeApiKey(key);
+          .withSuccessHandler(function() {
+            // Save API key only if the user typed something
+            if (key) {
+              google.script.run
+                .withSuccessHandler(function() {
+                  if (apiKeyInput) { apiKeyInput.value = ''; apiKeyInput.placeholder = '••••••••••'; }
+                })
+                .withFailureHandler(function() {})
+                .setClaudeApiKey(key);
+            }
+            showSavedMessage('Settings saved!', false);
+          })
+          .withFailureHandler(function() {
+            showSavedMessage('Failed to save settings.', true);
+          })
+          .saveSettings({ showTranslation: showTranslation });
       });
     }
   }

--- a/tests/SettingsService.test.gs
+++ b/tests/SettingsService.test.gs
@@ -1,0 +1,126 @@
+/**
+ * GAS-native tests for SettingsService.gs
+ * Run from Apps Script editor: select runSettingsServiceTests, click Run.
+ * View results in View → Logs.
+ *
+ * Note: These tests write to real User Properties and clean up after themselves.
+ */
+
+function runSettingsServiceTests() {
+  var passed = 0;
+  var failed = 0;
+  var results = [];
+
+  function it(label, fn) {
+    try {
+      fn();
+      results.push('  ✓ ' + label);
+      passed++;
+    } catch (e) {
+      results.push('  ✗ ' + label + '\n      → ' + (e.message || e));
+      failed++;
+    }
+  }
+
+  function expect(actual) {
+    return {
+      toBe: function (expected) {
+        if (actual !== expected) {
+          throw new Error('Expected ' + JSON.stringify(expected) + ' but got ' + JSON.stringify(actual));
+        }
+      },
+      toBeTruthy: function () {
+        if (!actual) throw new Error('Expected truthy but got ' + JSON.stringify(actual));
+      },
+      toBeFalsy: function () {
+        if (actual) throw new Error('Expected falsy but got ' + JSON.stringify(actual));
+      },
+      toBeNull: function () {
+        if (actual !== null) throw new Error('Expected null but got ' + JSON.stringify(actual));
+      }
+    };
+  }
+
+  // ─── hasClaudeApiKey ──────────────────────────────────────────────────────
+
+  results.push('\nhasClaudeApiKey()');
+
+  it('returns false when no key is stored', function () {
+    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
+    expect(hasClaudeApiKey()).toBeFalsy();
+  });
+
+  it('returns true after storing a key', function () {
+    PropertiesService.getUserProperties().setProperty('claude_api_key', 'sk-ant-test-key');
+    expect(hasClaudeApiKey()).toBeTruthy();
+    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
+  });
+
+  // ─── setClaudeApiKey ──────────────────────────────────────────────────────
+
+  results.push('\nsetClaudeApiKey()');
+
+  it('stores a key and can be retrieved', function () {
+    setClaudeApiKey('sk-ant-example');
+    expect(getClaudeApiKey()).toBe('sk-ant-example');
+    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
+  });
+
+  it('trims whitespace before storing', function () {
+    setClaudeApiKey('  sk-ant-trimmed  ');
+    expect(getClaudeApiKey()).toBe('sk-ant-trimmed');
+    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
+  });
+
+  it('deletes the key when passed an empty string', function () {
+    setClaudeApiKey('sk-ant-to-delete');
+    setClaudeApiKey('');
+    expect(getClaudeApiKey()).toBeNull();
+  });
+
+  it('deletes the key when passed a whitespace-only string', function () {
+    setClaudeApiKey('sk-ant-to-delete');
+    setClaudeApiKey('   ');
+    expect(getClaudeApiKey()).toBeNull();
+  });
+
+  it('deletes the key when passed null', function () {
+    setClaudeApiKey('sk-ant-to-delete');
+    setClaudeApiKey(null);
+    expect(getClaudeApiKey()).toBeNull();
+  });
+
+  // ─── getSettings / saveSetting defaults ──────────────────────────────────
+
+  results.push('\ngetSettings() defaults');
+
+  it('showTranslation defaults to true', function () {
+    PropertiesService.getUserProperties().deleteProperty('setting_showTranslation');
+    var s = getSettings();
+    expect(s.showTranslation).toBe(true);
+  });
+
+  it('saveSetting persists showTranslation false', function () {
+    saveSetting('showTranslation', false);
+    var s = getSettings();
+    expect(s.showTranslation).toBe(false);
+    PropertiesService.getUserProperties().deleteProperty('setting_showTranslation');
+  });
+
+  it('saveSetting rejects unknown keys', function () {
+    try {
+      saveSetting('unknownKey', true);
+      throw new Error('Expected an error but none was thrown');
+    } catch (e) {
+      if (e.message.indexOf('Unknown setting key') === -1) throw e;
+    }
+  });
+
+  results.push('\n─────────────────────────────────────────');
+  results.push('Results: ' + passed + ' passed, ' + failed + ' failed');
+  Logger.log(results.join('\n'));
+
+  if (failed > 0) {
+    throw new Error(failed + ' test(s) failed — see Logs for details');
+  }
+}


### PR DESCRIPTION
## Summary
- Remove Arabic checkbox (Arabic insertion is always on)
- Replace individual auto-save listeners with a single Save button
- Show temporary "Settings saved!" confirmation below the button
- Add `hasClaudeApiKey()` — checks key existence without exposing value to DOM
- Fix `setClaudeApiKey()` to delete the property when given empty/null input
- Add `SettingsService.test.gs` covering key storage, deletion, and defaults

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)