### PR TITLE
Update search result cards: bilingual metadata and conditional translation display

### DIFF
--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -44,7 +44,8 @@
   /* Results scroll area */
   .results-list { flex: 1; overflow-y: auto; padding: 16px; min-height: 0; }
   .result-card { padding: 12px; border: 1px solid #e0e0e0; border-radius: 4px; margin-bottom: 8px; font-size: 12px; }
-  .result-card .ref { font-weight: 600; margin-bottom: 4px; }
+  .result-card .ref-arabic { font-size: 13px; direction: rtl; text-align: right; color: #555; margin-bottom: 4px; font-family: Amiri, serif; }
+  .result-card .ref-english { font-size: 11px; color: #888; margin-top: 4px; margin-bottom: 2px; }
   .result-card .arabic { font-size: 18px; direction: rtl; text-align: right; font-family: Amiri, serif; margin: 8px 0; line-height: 1.8; }
   .result-card mark { background: #fff59d; padding: 0 2px; }
   .result-card .translation { font-size: 12px; color: #555; margin: 6px 0 0; line-height: 1.5; }

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -265,6 +265,13 @@
     return d.innerHTML;
   }
 
+  var _ARABIC_INDIC = ['٠','١','٢','٣','٤','٥','٦','٧','٨','٩'];
+  function toArabicIndicClient(num) {
+    return String(Math.floor(Number(num) || 0)).replace(/[0-9]/g, function(d) {
+      return _ARABIC_INDIC[+d];
+    });
+  }
+
   function renderResults(containerEl, results, type) {
     containerEl.innerHTML = '';
     var font = formatState.fontName || 'Amiri';
@@ -274,7 +281,8 @@
       var card = document.createElement('div');
       card.className = 'result-card';
 
-      var refLabel = (r.surahNameEnglish || 'Surah') + ' ' + r.surah + ':' + r.ayah;
+      var arabicRef = 'سورة ' + escapeHtml(r.surahNameArabic || '') + ' ' + toArabicIndicClient(r.ayah);
+      var englishRef = escapeHtml((r.surahNameEnglish || 'Surah') + ' ' + r.surah + ':' + r.ayah);
       var arabicHtml = escapeHtml(r.arabicText);
 
       if (type === 'search' && r.matchStart != null && r.matchEnd != null && r.matchEnd > r.matchStart) {
@@ -285,8 +293,9 @@
       }
 
       var html =
-        '<div class="ref">' + escapeHtml(refLabel) + '</div>' +
-        '<div class="arabic" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>';
+        '<div class="ref-arabic">' + arabicRef + '</div>' +
+        '<div class="arabic" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
+        '<div class="ref-english">' + englishRef + '</div>';
 
       if (showTrans && r.translationText) {
         html += '<div class="translation">' + escapeHtml(r.translationText) + '</div>';


### PR DESCRIPTION
Closes #28

## Summary
- Search result cards now show Arabic surah name + ayah number (Eastern Arabic numerals) above the Arabic text
- English surah name + reference appears below the Arabic text
- English translation is only rendered when the "Translation" setting is enabled

## Test plan
- [ ] Run an AI search — verify `سورة البقرة ٣` style label appears above Arabic text
- [ ] Run an exact search — verify same bilingual metadata layout
- [ ] Disable "Translation" in settings → save → search again → confirm translation is hidden
- [ ] Re-enable "Translation" → confirm it reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)