### PR TITLE
Polish UX: global loading spinner and skeleton loaders

### DIFF
--- a/sidebar/components/tab-ai-search.html
+++ b/sidebar/components/tab-ai-search.html
@@ -5,10 +5,6 @@
   <div id="ai-search-results" class="results-list"></div>
   <div id="ai-search-clarify" class="clarify-message hidden"></div>
   <div id="ai-search-empty" class="empty-state hidden"></div>
-  <div id="ai-search-loading" class="search-loading hidden">
-    <span class="spinner"></span>
-    <span>Thinking…</span>
-  </div>
   <div class="tab-input-area">
     <div class="tab-input-wrap">
       <textarea id="ai-search-query" rows="2" placeholder="Describe what you're looking for…"></textarea>

--- a/sidebar/components/tab-direct-insert.html
+++ b/sidebar/components/tab-direct-insert.html
@@ -24,8 +24,4 @@
   </div>
   <div id="direct-insert-results" class="results-list"></div>
   <div id="direct-insert-empty" class="empty-state hidden"></div>
-  <div id="direct-insert-loading" class="search-loading hidden">
-    <span class="spinner"></span>
-    <span>Fetching…</span>
-  </div>
 </div>

--- a/sidebar/components/tab-exact-search.html
+++ b/sidebar/components/tab-exact-search.html
@@ -1,10 +1,6 @@
 <div class="tab-panel" id="panel-exact-search">
   <div id="exact-search-results" class="results-list"></div>
   <div id="exact-search-empty" class="empty-state hidden"></div>
-  <div id="exact-search-loading" class="search-loading hidden">
-    <span class="spinner"></span>
-    <span>Searching…</span>
-  </div>
   <div class="tab-input-area">
     <div class="tab-input-wrap">
       <textarea id="exact-search-query" rows="2" placeholder="Enter Arabic text to search…" dir="rtl"></textarea>

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -1,7 +1,7 @@
 <style>
   * { box-sizing: border-box; }
   body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 13px; color: #333; background: #fff; }
-  .sidebar { display: flex; flex-direction: column; height: 100vh; width: 350px; max-width: 100%; }
+  .sidebar { display: flex; flex-direction: column; height: 100vh; width: 350px; max-width: 100%; position: relative; }
 
   .header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #e0e0e0; flex-shrink: 0; }
   .header-brand { display: flex; align-items: center; gap: 8px; }
@@ -55,10 +55,27 @@
   .clarify-message { padding: 12px 16px; margin: 8px 16px; background: #f5f5f5; border-radius: 8px; font-size: 13px; color: #333; line-height: 1.5; }
 
   /* Loading and empty states */
-  .search-loading { display: flex; align-items: center; gap: 8px; padding: 16px; font-size: 13px; color: #666; }
-  .search-loading .spinner { display: inline-block; width: 16px; height: 16px; border: 2px solid #e0e0e0; border-top-color: #2e7d32; border-radius: 50%; animation: spin 0.8s linear infinite; }
   @keyframes spin { to { transform: rotate(360deg); } }
   .empty-state { color: #666; font-size: 13px; padding: 24px 16px; text-align: center; }
+
+  /* Startup overlay */
+  .startup-overlay { position: absolute; inset: 0; background: #fff; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 200; gap: 12px; }
+  .startup-spinner { width: 32px; height: 32px; border: 3px solid #e0e0e0; border-top-color: #2e7d32; border-radius: 50%; animation: spin 0.8s linear infinite; }
+  .startup-text { font-size: 13px; color: #888; }
+
+  /* Skeleton cards */
+  .skeleton-card { border: 1px solid #e0e0e0; border-radius: 4px; padding: 12px; margin-bottom: 8px; }
+  .skeleton-line { height: 12px; background: #e0e0e0; border-radius: 3px; margin-bottom: 8px; animation: skeleton-pulse 1.4s ease-in-out infinite; }
+  .skeleton-line:last-child { margin-bottom: 0; }
+  .sk-short { width: 40%; }
+  .sk-arabic { height: 20px; width: 85%; margin-left: auto; }
+  .sk-medium { width: 70%; }
+  .sk-long { width: 100%; }
+  @keyframes skeleton-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+  /* Insert button loading spinner */
+  .btn-insert-result.btn-loading { color: transparent; pointer-events: none; position: relative; }
+  .btn-insert-result.btn-loading::after { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 12px; height: 12px; border: 2px solid rgba(255,255,255,0.5); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; }
 
   /* Input area pinned to bottom of tab */
   .tab-input-area { flex-shrink: 0; padding: 12px 16px; border-top: 1px solid #e0e0e0; background: #fff; }

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -164,8 +164,13 @@
         var showTranslation = trans ? trans.checked : true;
         var key = apiKeyInput ? apiKeyInput.value.trim() : '';
 
+        btnSave.disabled = true;
+        btnSave.textContent = 'Saving…';
+
         google.script.run
           .withSuccessHandler(function() {
+            btnSave.disabled = false;
+            btnSave.textContent = 'Save';
             // Save API key only if the user typed something
             if (key) {
               google.script.run
@@ -178,6 +183,8 @@
             showSavedMessage('Settings saved!', false);
           })
           .withFailureHandler(function() {
+            btnSave.disabled = false;
+            btnSave.textContent = 'Save';
             showSavedMessage('Failed to save settings.', true);
           })
           .saveSettings({ showTranslation: showTranslation });
@@ -258,6 +265,19 @@
 
   // ─── Shared Helpers ──────────────────────────────────────────────────────────
 
+  function makeSkeleton(count) {
+    var html = '';
+    for (var i = 0; i < count; i++) {
+      html += '<div class="skeleton-card">' +
+        '<div class="skeleton-line sk-short"></div>' +
+        '<div class="skeleton-line sk-arabic"></div>' +
+        '<div class="skeleton-line sk-medium"></div>' +
+        '<div class="skeleton-line sk-long"></div>' +
+        '</div>';
+    }
+    return html;
+  }
+
   function escapeHtml(s) {
     if (!s) return '';
     var d = document.createElement('div');
@@ -317,26 +337,36 @@
     if (!surah || !ayah) return;
 
     btn.disabled = true;
+    btn.classList.add('btn-loading');
     var style = _settings.arabicStyle || 'uthmani';
 
     google.script.run
       .withSuccessHandler(function(ayahData) {
-        if (!ayahData) { btn.disabled = false; return; }
+        if (!ayahData) {
+          btn.disabled = false;
+          btn.classList.remove('btn-loading');
+          return;
+        }
         var fs = window.getFormatState ? window.getFormatState() : {};
         google.script.run
           .withSuccessHandler(function(result) {
             btn.disabled = false;
+            btn.classList.remove('btn-loading');
             if (result && !result.success) {
               console.warn('Insert warning:', result.message);
             }
           })
           .withFailureHandler(function(err) {
             btn.disabled = false;
+            btn.classList.remove('btn-loading');
             console.error('Insert failed:', err);
           })
           .insertAyah(ayahData, fs, _settings);
       })
-      .withFailureHandler(function() { btn.disabled = false; })
+      .withFailureHandler(function() {
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
+      })
       .getAyahForInsert(surah, ayah, style);
   }
 
@@ -365,7 +395,6 @@
     var btnInsert = document.getElementById('btn-direct-insert');
     var resultsEl = document.getElementById('direct-insert-results');
     var emptyEl = document.getElementById('direct-insert-empty');
-    var loadingEl = document.getElementById('direct-insert-loading');
 
     // Load surah list
     google.script.run
@@ -451,19 +480,18 @@
         return;
       }
 
-      resultsEl.innerHTML = '';
+      resultsEl.innerHTML = makeSkeleton(3);
       emptyEl.classList.add('hidden');
-      loadingEl.classList.remove('hidden');
       btnInsert.disabled = true;
 
       google.script.run
         .withSuccessHandler(function(response) {
-          loadingEl.classList.add('hidden');
+          resultsEl.innerHTML = '';
           btnInsert.disabled = false;
           handleDirectInsertResponse(response);
         })
         .withFailureHandler(function(err) {
-          loadingEl.classList.add('hidden');
+          resultsEl.innerHTML = '';
           btnInsert.disabled = false;
           emptyEl.textContent = 'Something went wrong. Please try again.';
           emptyEl.classList.remove('hidden');
@@ -501,13 +529,11 @@
     var ayahEnd = document.getElementById('ayah-end');
     var resultsEl = document.getElementById('direct-insert-results');
     var emptyEl = document.getElementById('direct-insert-empty');
-    var loadingEl = document.getElementById('direct-insert-loading');
     if (surahSelect) surahSelect.value = '';
     if (ayahStart) { ayahStart.innerHTML = '<option value="">From</option>'; ayahStart.disabled = true; }
     if (ayahEnd) { ayahEnd.innerHTML = '<option value="">To</option>'; ayahEnd.disabled = true; }
     if (resultsEl) resultsEl.innerHTML = '';
     if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
-    if (loadingEl) loadingEl.classList.add('hidden');
   }
 
   // ─── Exact Search Tab ────────────────────────────────────────────────────────
@@ -517,7 +543,6 @@
     var btnSearch = document.getElementById('btn-exact-search');
     var resultsEl = document.getElementById('exact-search-results');
     var emptyEl = document.getElementById('exact-search-empty');
-    var loadingEl = document.getElementById('exact-search-loading');
 
     function setEnabled(enabled) {
       if (btnSearch) btnSearch.disabled = !enabled;
@@ -528,19 +553,18 @@
       var query = queryEl ? queryEl.value.trim() : '';
       if (!query) return;
 
-      resultsEl.innerHTML = '';
+      resultsEl.innerHTML = makeSkeleton(3);
       emptyEl.classList.add('hidden');
-      loadingEl.classList.remove('hidden');
       setEnabled(false);
 
       google.script.run
         .withSuccessHandler(function(response) {
-          loadingEl.classList.add('hidden');
+          resultsEl.innerHTML = '';
           setEnabled(true);
           handleExactSearchResponse(response);
         })
         .withFailureHandler(function() {
-          loadingEl.classList.add('hidden');
+          resultsEl.innerHTML = '';
           setEnabled(true);
           emptyEl.textContent = 'Something went wrong. Please try again.';
           emptyEl.classList.remove('hidden');
@@ -577,11 +601,9 @@
     var queryEl = document.getElementById('exact-search-query');
     var resultsEl = document.getElementById('exact-search-results');
     var emptyEl = document.getElementById('exact-search-empty');
-    var loadingEl = document.getElementById('exact-search-loading');
     if (queryEl) { queryEl.value = ''; queryEl.style.height = 'auto'; }
     if (resultsEl) resultsEl.innerHTML = '';
     if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
-    if (loadingEl) loadingEl.classList.add('hidden');
   }
 
   // ─── AI Search Tab ───────────────────────────────────────────────────────────
@@ -594,7 +616,6 @@
     var resultsEl = document.getElementById('ai-search-results');
     var clarifyEl = document.getElementById('ai-search-clarify');
     var emptyEl = document.getElementById('ai-search-empty');
-    var loadingEl = document.getElementById('ai-search-loading');
     var noKeyEl = document.getElementById('ai-no-key');
 
     function setEnabled(enabled) {
@@ -626,14 +647,14 @@
       _conversationMessages.push({ role: 'user', content: query });
 
       clearAIResults();
-      loadingEl.classList.remove('hidden');
+      resultsEl.innerHTML = makeSkeleton(3);
       setEnabled(false);
 
       var messagesToSend = getLastMessages(3);
 
       google.script.run
         .withSuccessHandler(function(response) {
-          loadingEl.classList.add('hidden');
+          resultsEl.innerHTML = '';
           setEnabled(true);
 
           if (response && response.rawResponse) {
@@ -643,7 +664,7 @@
           handleAIResponse(response);
         })
         .withFailureHandler(function() {
-          loadingEl.classList.add('hidden');
+          resultsEl.innerHTML = '';
           setEnabled(true);
           _conversationMessages.pop();
           emptyEl.textContent = 'Something went wrong. Please try again.';
@@ -705,27 +726,33 @@
     var resultsEl = document.getElementById('ai-search-results');
     var clarifyEl = document.getElementById('ai-search-clarify');
     var emptyEl = document.getElementById('ai-search-empty');
-    var loadingEl = document.getElementById('ai-search-loading');
     var noKeyEl = document.getElementById('ai-no-key');
     if (queryEl) { queryEl.value = ''; queryEl.style.height = 'auto'; queryEl.focus(); }
     if (resultsEl) resultsEl.innerHTML = '';
     if (clarifyEl) { clarifyEl.classList.add('hidden'); clarifyEl.textContent = ''; }
     if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
-    if (loadingEl) loadingEl.classList.add('hidden');
     if (noKeyEl) noKeyEl.classList.add('hidden');
   }
 
   // ─── Init ────────────────────────────────────────────────────────────────────
 
   function init() {
+    var pendingInit = 2;
+    function onInitDone() {
+      if (--pendingInit <= 0) {
+        var overlay = document.getElementById('startup-overlay');
+        if (overlay) overlay.classList.add('hidden');
+      }
+    }
+
     google.script.run
-      .withSuccessHandler(onSettingsLoaded)
-      .withFailureHandler(function() { applyFormatStateToUI(); })
+      .withSuccessHandler(function(s) { onSettingsLoaded(s); onInitDone(); })
+      .withFailureHandler(function() { applyFormatStateToUI(); onInitDone(); })
       .getSettings();
 
     google.script.run
-      .withSuccessHandler(onFontsLoaded)
-      .withFailureHandler(function() {})
+      .withSuccessHandler(function(f) { onFontsLoaded(f); onInitDone(); })
+      .withFailureHandler(function() { onInitDone(); })
       .getArabicFonts();
 
     initFormatBar();

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -7,6 +7,11 @@
 </head>
 <body>
   <div class="sidebar">
+    <div id="startup-overlay" class="startup-overlay">
+      <div class="startup-spinner"></div>
+      <span class="startup-text">Loading…</span>
+    </div>
+
     <header class="header">
       <div class="header-brand">
         <?!= include('sidebar/components/logo-img') ?>


### PR DESCRIPTION
## Summary

- Full-page startup overlay with spinner while `getSettings()` and `getArabicFonts()` resolve
- Skeleton cards (pulsing placeholder cards) in results area during search/fetch operations, replacing the old spinner+text divs below the list
- Spinner inside Insert result buttons during `getAyahForInsert` + `insertAyah`
- "Saving…" disabled state on Settings save button during `saveSettings`

Closes #30