### PR TITLE
Support ayah range preview in direct insert tab

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -120,7 +120,7 @@ function insertAyahRange(rangeData, formatState, settings) {
     paragraphsToInsert.push({
       text: '\u201C' + translationText + '\u201D (' +
             surahNameEn + ' ' + rangeData.surah + ':' +
-            rangeData.ayahStart + ' - ' + rangeData.ayahEnd + ')',
+            rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
       align: DocumentApp.HorizontalAlignment.CENTER
     });
   } else {

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -71,3 +71,74 @@ function insertAyah(ayahData, formatState, settings) {
   var message = fontWarning ? 'Ayah inserted. ' + fontWarning : 'Ayah inserted.';
   return { success: true, message: message };
 }
+
+/**
+ * Inserts a pre-assembled ayah range into the document.
+ * If no cursor is set, appends at the end of the document.
+ * @param {Object} rangeData - { surah, ayahStart, ayahEnd, arabicText, translationText, surahNameArabic, surahNameEnglish }
+ * @param {Object} formatState - { fontName, fontSize, bold, textColor }
+ * @param {Object} settings - { showTranslation }
+ * @return {Object} { success: boolean, message?: string }
+ */
+function insertAyahRange(rangeData, formatState, settings) {
+  if (!rangeData || !rangeData.surah || !rangeData.ayahStart) {
+    return { success: false, message: 'Invalid range data.' };
+  }
+
+  var doc    = DocumentApp.getActiveDocument();
+  var body   = doc.getBody();
+  var cursor = doc.getCursor();
+
+  var showTranslation = settings && settings.showTranslation !== false;
+  var arabicText      = rangeData.arabicText || '';
+  var translationText = rangeData.translationText || '';
+  var surahNameAr     = rangeData.surahNameArabic || '';
+  var surahNameEn     = rangeData.surahNameEnglish || '';
+  var ayahStartAr     = toArabicIndic(rangeData.ayahStart);
+  var ayahEndAr       = toArabicIndic(rangeData.ayahEnd);
+
+  var insertIndex;
+  if (cursor) {
+    var cursorElement = cursor.getElement();
+    var parent = cursorElement.getParent();
+    while (parent && parent.getType() !== DocumentApp.ElementType.PARAGRAPH) {
+      parent = parent.getParent();
+    }
+    var cursorParagraph = parent ? parent.asParagraph() : body.getParagraphs()[0];
+    insertIndex = body.getChildIndex(cursorParagraph) + 1;
+  } else {
+    insertIndex = body.getNumChildren();
+  }
+
+  var paragraphsToInsert = [];
+  if (showTranslation && translationText) {
+    paragraphsToInsert.push({
+      text: '\uFD3F ' + arabicText + ' \uFD3E',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true
+    });
+    paragraphsToInsert.push({
+      text: '\u201C' + translationText + '\u201D (' +
+            surahNameEn + ' ' + rangeData.surah + ':' +
+            rangeData.ayahStart + ' - ' + rangeData.ayahEnd + ')',
+      align: DocumentApp.HorizontalAlignment.CENTER
+    });
+  } else {
+    paragraphsToInsert.push({
+      text: '\uFD3F ' + arabicText + ' \uFD3E [' +
+            surahNameAr + ': ' + ayahStartAr + ' - ' + ayahEndAr + ']',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true
+    });
+  }
+
+  var fontWarning = null;
+  for (var i = 0; i < paragraphsToInsert.length; i++) {
+    var p = body.insertParagraph(insertIndex + i, paragraphsToInsert[i].text);
+    p.setAlignment(paragraphsToInsert[i].align);
+    if (paragraphsToInsert[i].rtl) p.setLeftToRight(false);
+    fontWarning = applyFormat(p.editAsText(), formatState) || fontWarning;
+  }
+
+  return { success: true, message: fontWarning ? 'Range inserted. ' + fontWarning : 'Range inserted.' };
+}

--- a/sidebar/components/tab-direct-insert.html
+++ b/sidebar/components/tab-direct-insert.html
@@ -20,7 +20,7 @@
         </select>
       </div>
     </div>
-    <button type="button" class="btn-primary btn-block" id="btn-direct-insert">Insert</button>
+    <button type="button" class="btn-primary btn-block" id="btn-direct-insert">Preview</button>
   </div>
   <div id="direct-insert-results" class="results-list"></div>
   <div id="direct-insert-empty" class="empty-state hidden"></div>

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -47,6 +47,7 @@
   .result-card .ref-arabic { font-size: 13px; direction: rtl; text-align: right; color: #555; margin-bottom: 4px; font-family: Amiri, serif; }
   .result-card .ref-english { font-size: 11px; color: #888; margin-top: 4px; margin-bottom: 2px; }
   .result-card .arabic { font-size: 18px; direction: rtl; text-align: right; font-family: Amiri, serif; margin: 8px 0; line-height: 1.8; }
+  .result-card .arabic.range-block { line-height: 2.2; white-space: normal; word-break: normal; }
   .result-card mark { background: #fff59d; padding: 0 2px; }
   .result-card .translation { font-size: 12px; color: #555; margin: 6px 0 0; line-height: 1.5; }
   .result-card .btn-insert-result { margin-top: 8px; padding: 6px 12px; font-size: 12px; }

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -294,6 +294,12 @@
 
   function renderResults(containerEl, results, type) {
     containerEl.innerHTML = '';
+
+    if (type === 'range' && results.length > 1) {
+      renderRangeBlock(containerEl, results);
+      return;
+    }
+
     var font = formatState.fontName || 'Amiri';
     var showTrans = _settings.showTranslation !== false;
 
@@ -301,7 +307,7 @@
       var card = document.createElement('div');
       card.className = 'result-card';
 
-      var arabicRef = 'سورة ' + escapeHtml(r.surahNameArabic || '') + ' ' + toArabicIndicClient(r.ayah);
+      var arabicRef = escapeHtml(r.surahNameArabic || '') + ' ' + toArabicIndicClient(r.ayah);
       var englishRef = escapeHtml((r.surahNameEnglish || 'Surah') + ' ' + r.surah + ':' + r.ayah);
       var arabicHtml = escapeHtml(r.arabicText);
 
@@ -327,6 +333,35 @@
       card.innerHTML = html;
       containerEl.appendChild(card);
     });
+  }
+
+  function renderRangeBlock(containerEl, results) {
+    var font  = formatState.fontName || 'Amiri';
+    var first = results[0];
+    var last  = results[results.length - 1];
+
+    var concatenated = results.map(function(r) {
+      return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
+    }).join(' ');
+
+    var arabicRef = escapeHtml(first.surahNameArabic || '') +
+                    ' ' + toArabicIndicClient(first.ayah) +
+                    ' - ' + toArabicIndicClient(last.ayah);
+    var englishRef = escapeHtml(
+      (first.surahNameEnglish || 'Surah') + ' ' +
+      first.surah + ':' + first.ayah + '-' + last.ayah
+    );
+
+    var card = document.createElement('div');
+    card.className = 'result-card';
+    card.innerHTML =
+      '<div class="ref-arabic">' + arabicRef + '</div>' +
+      '<div class="arabic range-block" style="font-family:' + escapeHtml(font) + ',serif">' +
+        escapeHtml(concatenated) +
+      '</div>' +
+      '<div class="ref-english">' + englishRef + '</div>';
+
+    containerEl.appendChild(card);
   }
 
   function onInsertClick(e) {

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -10,6 +10,7 @@
   };
 
   var _settings = {};
+  var _currentRange = null;
   var saveDebounceTimer = null;
   var SAVE_DEBOUNCE_MS = 500;
 
@@ -345,6 +346,16 @@
       return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
     }).join(' ');
 
+    _currentRange = {
+      surah:            first.surah,
+      ayahStart:        first.ayah,
+      ayahEnd:          last.ayah,
+      arabicText:       concatenated,
+      translationText:  results.map(function(r) { return r.translationText || ''; }).join(' '),
+      surahNameArabic:  first.surahNameArabic  || '',
+      surahNameEnglish: first.surahNameEnglish || ''
+    };
+
     var arabicRef = escapeHtml(first.surahNameArabic || '') +
                     ' ' + toArabicIndicClient(first.ayah) +
                     ' - ' + toArabicIndicClient(last.ayah);
@@ -370,6 +381,8 @@
       }
     }
 
+    html += '<button type="button" class="btn-primary btn-insert-result btn-insert-range">Insert</button>';
+
     var card = document.createElement('div');
     card.className = 'result-card';
     card.innerHTML = html;
@@ -379,6 +392,12 @@
   function onInsertClick(e) {
     var btn = e.target;
     if (btn.tagName !== 'BUTTON' || !btn.classList.contains('btn-insert-result')) return;
+
+    if (btn.classList.contains('btn-insert-range')) {
+      handleRangeInsertClick(btn);
+      return;
+    }
+
     var surah = parseInt(btn.getAttribute('data-surah'), 10);
     var ayah = parseInt(btn.getAttribute('data-ayah'), 10);
     if (!surah || !ayah) return;
@@ -415,6 +434,30 @@
         btn.classList.remove('btn-loading');
       })
       .getAyahForInsert(surah, ayah, style);
+  }
+
+  function handleRangeInsertClick(btn) {
+    if (!_currentRange) return;
+
+    btn.disabled = true;
+    btn.classList.add('btn-loading');
+
+    var fs = window.getFormatState ? window.getFormatState() : {};
+
+    google.script.run
+      .withSuccessHandler(function(result) {
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
+        if (result && !result.success) {
+          console.warn('Range insert warning:', result.message);
+        }
+      })
+      .withFailureHandler(function(err) {
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
+        console.error('Range insert failed:', err);
+      })
+      .insertAyahRange(_currentRange, fs, _settings);
   }
 
   function setupTextarea(el, onSubmit) {
@@ -581,6 +624,7 @@
     if (ayahEnd) { ayahEnd.innerHTML = '<option value="">To</option>'; ayahEnd.disabled = true; }
     if (resultsEl) resultsEl.innerHTML = '';
     if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
+    _currentRange = null;
   }
 
   // ─── Exact Search Tab ────────────────────────────────────────────────────────

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -339,6 +339,7 @@
     var font  = formatState.fontName || 'Amiri';
     var first = results[0];
     var last  = results[results.length - 1];
+    var showTrans = _settings.showTranslation !== false;
 
     var concatenated = results.map(function(r) {
       return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
@@ -349,18 +350,29 @@
                     ' - ' + toArabicIndicClient(last.ayah);
     var englishRef = escapeHtml(
       (first.surahNameEnglish || 'Surah') + ' ' +
-      first.surah + ':' + first.ayah + '-' + last.ayah
+      first.surah + ':' + first.ayah + ' - ' + last.ayah
     );
 
-    var card = document.createElement('div');
-    card.className = 'result-card';
-    card.innerHTML =
+    var html =
       '<div class="ref-arabic">' + arabicRef + '</div>' +
       '<div class="arabic range-block" style="font-family:' + escapeHtml(font) + ',serif">' +
         escapeHtml(concatenated) +
       '</div>' +
       '<div class="ref-english">' + englishRef + '</div>';
 
+    if (showTrans) {
+      var translationConcatenated = results.map(function(r) {
+        return escapeHtml(r.translationText || '');
+      }).join(' ');
+
+      if (translationConcatenated.trim()) {
+        html += '<div class="translation">' + translationConcatenated + '</div>';
+      }
+    }
+
+    var card = document.createElement('div');
+    card.className = 'result-card';
+    card.innerHTML = html;
     containerEl.appendChild(card);
   }
 

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -361,7 +361,7 @@
                     ' - ' + toArabicIndicClient(last.ayah);
     var englishRef = escapeHtml(
       (first.surahNameEnglish || 'Surah') + ' ' +
-      first.surah + ':' + first.ayah + ' - ' + last.ayah
+      first.surah + ':' + first.ayah + '-' + last.ayah
     );
 
     var html =


### PR DESCRIPTION
Closes #32

Renders range results from `insertDirectAyah` as a single concatenated RTL Arabic block instead of individual per-ayah cards.

## Changes
- `renderResults`: add branch for `type === 'range'`, new `renderRangeBlock` function
- Remove `سورة` prefix from Arabic references in both single and range cards
- `.range-block` CSS for looser line-height on multi-ayah text