### PR TITLE
AI search: support multi-ayah range retrieval

### DIFF
--- a/ClaudeAPI.js
+++ b/ClaudeAPI.js
@@ -20,8 +20,9 @@ var UNIFIED_SYSTEM_PROMPT =
   'Given a user request, determine the intent and return ONLY a raw JSON object. ' +
   'No markdown fences, no explanation, no extra text — just the JSON.\n\n' +
   'Actions:\n\n' +
-  '1. fetch_ayah — user wants a specific ayah by reference number, surah name, or well-known verse name:\n' +
-  '{"action":"fetch_ayah","surah":2,"ayah":255}\n\n' +
+  '1. fetch_ayah — user wants a specific ayah or consecutive range by reference:\n' +
+  'Single: {"action":"fetch_ayah","surah":2,"ayah":255}\n' +
+  'Range:  {"action":"fetch_ayah","surah":3,"ayahStart":190,"ayahEnd":194}\n\n' +
   '2. search — user wants to find verses (by Arabic text, topic, theme, or meaning):\n' +
   'For Arabic Quranic text to search in the corpus:\n' +
   '{"action":"search","query":"بسم الله الرحمن","language":"arabic"}\n' +
@@ -32,7 +33,8 @@ var UNIFIED_SYSTEM_PROMPT =
   '{"action":"clarify","message":"Your clarifying question here"}\n\n' +
   'Rules:\n' +
   '- Return ONLY the raw JSON object.\n' +
-  '- For fetch_ayah: you must know the exact surah (1-114) and ayah number.\n' +
+  '- For fetch_ayah: you must know the exact surah (1-114) and ayah number(s). ' +
+  'Use "ayah" for a single verse, or "ayahStart" and "ayahEnd" for a consecutive range.\n' +
   '- For Arabic input: determine if it is Quranic text to search for (use search with language "arabic") ' +
   'or a conversational question in Arabic (interpret the intent and respond accordingly). ' +
   'If genuinely unsure, use clarify.\n' +
@@ -178,7 +180,9 @@ function performAISearch(messages) {
   var response;
   switch (classified.action) {
     case 'fetch_ayah':
-      response = insertDirectAyah(classified.surah, classified.ayah, classified.ayah);
+      var ayahStart = classified.ayahStart || classified.ayah;
+      var ayahEnd = classified.ayahEnd || classified.ayah || ayahStart;
+      response = insertDirectAyah(classified.surah, ayahStart, ayahEnd);
       break;
     case 'search':
       response = _handleSearchRouting(classified);

--- a/tests/ClaudeAPI.test.gs
+++ b/tests/ClaudeAPI.test.gs
@@ -58,6 +58,14 @@ function runClaudeAPITests() {
     expect(parsed.ayah).toBe(255);
   });
 
+  it('parses a fetch_ayah range JSON object with ayahStart/ayahEnd', function () {
+    var parsed = _parseClassificationResponse('{"action":"fetch_ayah","surah":3,"ayahStart":190,"ayahEnd":194}');
+    expect(parsed.action).toBe('fetch_ayah');
+    expect(parsed.surah).toBe(3);
+    expect(parsed.ayahStart).toBe(190);
+    expect(parsed.ayahEnd).toBe(194);
+  });
+
   it('parses a search JSON object with language arabic', function () {
     var parsed = _parseClassificationResponse('{"action":"search","query":"بسم الله","language":"arabic"}');
     expect(parsed.action).toBe('search');
@@ -342,6 +350,22 @@ function runClaudeAPITests() {
       if (result.type === 'clarify') return; // acceptable if Claude still needs more info
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
       expect(result.results.length).toBeGreaterThan(0);
+    });
+
+    it('performAISearch("show me Al-Imran 190 to 194") returns range results (live API)', function () {
+      var result = performAISearch([{ role: 'user', content: 'show me Al-Imran 190 to 194' }]);
+      if (result.type === 'clarify') return; // acceptable
+      if (result.type === 'error') throw new Error('Got error: ' + result.error);
+      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.results[0].surah).toBe(3);
+    });
+
+    it('performAISearch("give me the last 3 ayahs of surah Al-Baqarah") returns results (live API)', function () {
+      var result = performAISearch([{ role: 'user', content: 'give me the last 3 ayahs of surah Al-Baqarah' }]);
+      if (result.type === 'clarify') return; // acceptable
+      if (result.type === 'error') throw new Error('Got error: ' + result.error);
+      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.results[0].surah).toBe(2);
     });
 
     it('processUnifiedQuery delegates to performAISearch (live API)', function () {


### PR DESCRIPTION
Closes #34

## Summary
- Extend `fetch_ayah` action in Claude's system prompt to support `ayahStart`/`ayahEnd` for consecutive ranges
- Update handler to pass range fields to `insertDirectAyah` (backward compatible with single `ayah`)
- Add unit test for range parsing and live API integration tests

## Test plan
- [ ] AI search: "show me Al-Imran 190 to 194" → range block
- [ ] AI search: contextual range query (e.g., morning adhkar from Al-Imran) → range block
- [ ] AI search: "show me ayat al kursi" → single ayah (backward compatible)
- [ ] AI search: "verses about patience" → semantic search (unchanged)
- [ ] Insert button on AI range results → inserts with ornaments
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)