### PR TITLE
Client-side Uthmani cache for synchronous ayah lookups

### DIFF
--- a/sidebar/components/tab-direct-insert.html
+++ b/sidebar/components/tab-direct-insert.html
@@ -22,6 +22,7 @@
     </div>
     <button type="button" class="btn-primary btn-block" id="btn-direct-insert">Preview</button>
   </div>
+  <div id="uthmani-cache-status" class="cache-status hidden"></div>
   <div id="direct-insert-results" class="results-list"></div>
   <div id="direct-insert-empty" class="empty-state hidden"></div>
 </div>

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -58,6 +58,10 @@
   /* Loading and empty states */
   @keyframes spin { to { transform: rotate(360deg); } }
   .empty-state { color: #666; font-size: 13px; padding: 24px 16px; text-align: center; }
+  .cache-status { display: flex; align-items: center; gap: 8px; padding: 6px 16px; font-size: 12px; }
+  .cache-status-text { color: #888; }
+  .cache-status-error { color: #c0392b; }
+  .cache-status-retry { font-size: 12px; padding: 2px 8px; border: 1px solid #c0392b; border-radius: 4px; background: none; color: #c0392b; cursor: pointer; }
 
   /* Startup overlay */
   .startup-overlay { position: absolute; inset: 0; background: #fff; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 200; gap: 12px; }

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -14,6 +14,13 @@
   var saveDebounceTimer = null;
   var SAVE_DEBOUNCE_MS = 500;
 
+  // ─── Uthmani Cache ───────────────────────────────────────────────────────────
+  // null = not started, 'loading' = fetch in flight, Object = ready
+
+  var _uthmaniCache = null;
+  var _uthmaniCallbacks = [];
+  var UTHMANI_URL = 'https://tarazis97.github.io/tasneef-data/quran/uthmani.json';
+
   // ─── Format Bar ──────────────────────────────────────────────────────────────
 
   function debouncedSave() {
@@ -248,6 +255,10 @@
     panels.forEach(function(panel) {
       panel.classList.toggle('active', panel.id === 'panel-' + tabId);
     });
+
+    if (tabId === 'direct-insert') {
+      ensureUthmaniCache(); // no-op if already loading or loaded
+    }
   }
 
   function clearActiveTab() {
@@ -472,6 +483,80 @@
         onSubmit();
       }
     });
+  }
+
+  function _setUthmaniStatus(state) {
+    var el = document.getElementById('uthmani-cache-status');
+    if (!el) return;
+    if (state === 'ready') {
+      el.classList.add('hidden');
+      el.innerHTML = '';
+      return;
+    }
+    el.classList.remove('hidden');
+    if (state === 'loading') {
+      el.innerHTML = '<span class="cache-status-text">Loading Quran text\u2026</span>';
+    } else if (state === 'error') {
+      el.innerHTML =
+        '<span class="cache-status-text cache-status-error">Failed to load Quran text.</span>' +
+        '<button type="button" class="cache-status-retry">Retry</button>';
+      el.querySelector('.cache-status-retry').addEventListener('click', function() {
+        ensureUthmaniCache();
+      });
+    }
+  }
+
+  /**
+   * Ensures uthmani.json is fetched and cached in _uthmaniCache.
+   * Fetches at most once; subsequent calls are no-ops or queue callbacks.
+   * @param {Function} [onReady] - called with the cache object when ready
+   * @param {Function} [onError] - called with the error if fetch fails
+   */
+  function ensureUthmaniCache(onReady, onError) {
+    if (_uthmaniCache && _uthmaniCache !== 'loading') {
+      if (onReady) onReady(_uthmaniCache);
+      return;
+    }
+    if (_uthmaniCache === 'loading') {
+      if (onReady || onError) _uthmaniCallbacks.push({ onReady: onReady, onError: onError });
+      return;
+    }
+    // First call — begin fetch
+    _uthmaniCache = 'loading';
+    if (onReady || onError) _uthmaniCallbacks.push({ onReady: onReady, onError: onError });
+
+    _setUthmaniStatus('loading');
+
+    fetch(UTHMANI_URL)
+      .then(function(resp) {
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        return resp.json();
+      })
+      .then(function(data) {
+        _uthmaniCache = data;
+        _setUthmaniStatus('ready');
+        var cbs = _uthmaniCallbacks.splice(0);
+        cbs.forEach(function(cb) { if (cb.onReady) cb.onReady(data); });
+      })
+      .catch(function(err) {
+        console.error('Uthmani cache fetch failed:', err);
+        _uthmaniCache = null; // reset so retry is possible
+        _setUthmaniStatus('error');
+        var cbs = _uthmaniCallbacks.splice(0);
+        cbs.forEach(function(cb) { if (cb.onError) cb.onError(err); });
+      });
+  }
+
+  /**
+   * Synchronous O(1) lookup of a single ayah from the client-side cache.
+   * Returns null if the cache is not yet ready.
+   * @param {number} surahNum
+   * @param {number} ayahNum
+   * @return {{surah, ayah, text}|null}
+   */
+  function lookupUthmaniAyah(surahNum, ayahNum) {
+    if (!_uthmaniCache || _uthmaniCache === 'loading') return null;
+    return _uthmaniCache[surahNum + ':' + ayahNum] || null;
   }
 
   // ─── Direct Insert Tab ───────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #36

## Summary
- Fetches `uthmani.json` from GitHub Pages on first Insert tab activation (which happens at sidebar startup)
- Caches the full Quran in memory as a flat `"surah:ayah"` → verse object map for O(1) lookups
- Exposes `ensureUthmaniCache(onReady, onError)` for deferred callbacks and `lookupUthmaniAyah(surahNum, ayahNum)` for synchronous lookups
- Shows a subtle loading indicator while fetching; on error, shows a message with a Retry button
- No server-side code changed

## Test plan
- [ ] Open sidebar → DevTools Network → confirm one `uthmani.json` GET fires on load
- [ ] Switch away from Insert tab and back → confirm no second fetch
- [ ] In DevTools console: `_uthmaniCache['2:255']` returns Ayat al-Kursi verse object
- [ ] Block `tarazis97.github.io` in DevTools → error message + Retry button appear; clicking Retry re-fetches
- [ ] Existing Preview/Insert flow works without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)