### PR TITLE
Client-side Imlaei cache with pre-normalized search index

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -8,4 +8,4 @@ README.md
 .clasp.json
 sidebar/assets/**
 package.json
-tests/makeClientCache.test.js
+tests/*.test.js

--- a/client/normalizeArabic.html
+++ b/client/normalizeArabic.html
@@ -1,0 +1,85 @@
+/**
+ * Client-side Arabic normalization utilities.
+ * Exact port of the server-side functions in QuranData.js.
+ * Intended to be included once inside a <script> block (see sidebar/sidebar.html).
+ */
+
+var TASHKEEL_RANGES = [
+  [0x0610, 0x061A], // Arabic signs
+  [0x064B, 0x065F], // Fatha, Damma, Kasra, etc.
+  [0x0670],         // Superscript alif
+  [0x06D6, 0x06DC], // Small high signs
+  [0x06DF, 0x06E4], // Small high signs
+  [0x06E7, 0x06E8], // Small high Yeh, Hamza
+  [0x06EA, 0x06ED]  // Empty centre, etc.
+];
+
+/**
+ * @param {number} code - Unicode code point
+ * @return {boolean} true if the code point is a tashkeel/diacritic
+ */
+function _isInTashkeelRange(code) {
+  for (var r = 0; r < TASHKEEL_RANGES.length; r++) {
+    var range = TASHKEEL_RANGES[r];
+    if (range.length === 1) {
+      if (code === range[0]) return true;
+    } else if (code >= range[0] && code <= range[1]) return true;
+  }
+  return false;
+}
+
+/**
+ * Strips tashkeel and normalizes alef variants for search comparison.
+ * @param {string} text - Raw Arabic text
+ * @return {string} Normalized text
+ */
+function normalizeArabic(text) {
+  if (!text || typeof text !== 'string') return '';
+  var result = '';
+  for (var i = 0; i < text.length; i++) {
+    var code = text.charCodeAt(i);
+    if (_isInTashkeelRange(code)) continue;
+    var ch = text.charAt(i);
+    if (ch === '\u0622' || ch === '\u0623' || ch === '\u0625' || ch === '\u0671') ch = '\u0627'; // آ أ إ ٱ → ا
+    result += ch;
+  }
+  return result;
+}
+
+/**
+ * @param {string} str
+ * @return {boolean} true if the string contains Arabic characters (U+0600–U+06FF)
+ */
+function _hasArabicChars(str) {
+  for (var i = 0; i < str.length; i++) {
+    var c = str.charCodeAt(i);
+    if (c >= 0x0600 && c <= 0x06FF) return true;
+  }
+  return false;
+}
+
+/**
+ * Maps a match position in normalized text back to the original (with tashkeel).
+ * @param {string} original - Original Arabic text
+ * @param {number} normStart - Start index in normalized text
+ * @param {number} normLen - Length of match in normalized text
+ * @return {{start: number, end: number}} Indices in original text
+ */
+function _mapNormalizedToOriginal(original, normStart, normLen) {
+  if (!original || normStart < 0 || normLen <= 0) return { start: 0, end: 0 };
+  var normIdx = 0;
+  var origStart = -1;
+  var origEnd = -1;
+  for (var i = 0; i < original.length; i++) {
+    if (_isInTashkeelRange(original.charCodeAt(i))) continue;
+    if (normIdx === normStart) origStart = i;
+    normIdx++;
+    if (normIdx === normStart + normLen) {
+      origEnd = i + 1;
+      break;
+    }
+  }
+  if (origStart < 0) origStart = 0;
+  if (origEnd < 0) origEnd = original.length;
+  return { start: origStart, end: origEnd };
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "tasneef-ai",
   "private": true,
   "scripts": {
-    "test": "npm run test:client",
-    "test:client": "node tests/makeClientCache.test.js"
+    "test": "npm run test:client && npm run test:normalize",
+    "test:client": "node tests/makeClientCache.test.js",
+    "test:normalize": "node tests/normalizeArabic.test.js"
   }
 }

--- a/sidebar/components/tab-exact-search.html
+++ b/sidebar/components/tab-exact-search.html
@@ -1,4 +1,5 @@
 <div class="tab-panel" id="panel-exact-search">
+  <div id="imlaei-cache-status" class="cache-status hidden"></div>
   <div id="exact-search-results" class="results-list"></div>
   <div id="exact-search-empty" class="empty-state hidden"></div>
   <div class="tab-input-area">

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -98,6 +98,9 @@
   .btn-secondary { padding: 8px 16px; background: #f5f5f5; color: #333; border: 1px solid #ccc; border-radius: 4px; font-size: 13px; cursor: pointer; }
   .btn-secondary:hover { background: #e8e8e8; }
 
+  .btn-show-more { display: block; width: 100%; padding: 10px; margin-top: 4px; border: 1px dashed #ccc; border-radius: 4px; background: none; color: #2e7d32; font-size: 13px; cursor: pointer; text-align: center; }
+  .btn-show-more:hover { background: #f5f5f5; border-color: #2e7d32; }
+
   .btn-icon { padding: 8px; border: none; background: none; cursor: pointer; color: #666; border-radius: 4px; font-size: 16px; }
   .btn-icon:hover { background: #f0f0f0; color: #333; }
 

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -129,6 +129,53 @@
     _imlaeiCacheApi.ensure(onReady, onError);
   }
 
+  // ─── Client-side exact search against imlaei cache ──
+
+  var SEARCH_RESULT_CAP = 50;
+  var EXACT_PAGE_SIZE = 20;
+  var EXACT_DEBOUNCE_MS = 200;
+  var EXACT_MIN_CHARS = 2;
+
+  /**
+   * Synchronous client-side search against the pre-normalized imlaei corpus.
+   * Must be called after imlaei cache is loaded (ensure resolves synchronously post-load).
+   * @param {string} query - Raw Arabic search text
+   * @return {Array<{surah, ayah, surahNameArabic, surahNameEnglish, arabicText}>}
+   */
+  function searchImlaeiClient(query) {
+    if (!query || typeof query !== 'string') return [];
+    query = query.trim();
+    if (!query) return [];
+
+    var data = null;
+    _imlaeiCacheApi.ensure(function(d) { data = d; });
+    if (!data) return [];
+
+    var normalizedQuery = normalizeArabic(query);
+    if (!normalizedQuery) return [];
+
+    var results = [];
+    var raw = data.raw;
+    var normalized = data.normalized;
+
+    for (var key in normalized) {
+      if (results.length >= SEARCH_RESULT_CAP) break;
+      if (normalized[key].indexOf(normalizedQuery) < 0) continue;
+
+      var verse = raw[key];
+      var surahMeta = _surahList.find(function(s) { return s.number === verse.surah; });
+      results.push({
+        surah: verse.surah,
+        ayah: verse.ayah,
+        surahNameArabic: surahMeta ? surahMeta.nameArabic : '',
+        surahNameEnglish: surahMeta ? surahMeta.nameEnglish : '',
+        arabicText: verse.text || ''
+      });
+    }
+
+    return results;
+  }
+
   var _refreshDirectInsert = null;   // set by initDirectInsertTab, called by initFormatBar
 
   // ─── Format Bar ──────────────────────────────────────────────────────────────
@@ -754,66 +801,137 @@
 
   // ─── Exact Search Tab ────────────────────────────────────────────────────────
 
+  var _exactSearchAllResults = [];
+  var _exactSearchPage = 0;
+
   function initExactSearchTab() {
     var queryEl = document.getElementById('exact-search-query');
     var btnSearch = document.getElementById('btn-exact-search');
     var resultsEl = document.getElementById('exact-search-results');
     var emptyEl = document.getElementById('exact-search-empty');
-
-    function setEnabled(enabled) {
-      if (btnSearch) btnSearch.disabled = !enabled;
-      if (queryEl) queryEl.disabled = !enabled;
-    }
+    var debounceTimer = null;
 
     function doExactSearch() {
+      if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+
       var query = queryEl ? queryEl.value.trim() : '';
-      if (!query) return;
-
-      resultsEl.innerHTML = makeSkeleton(3);
-      emptyEl.classList.add('hidden');
-      setEnabled(false);
-
-      google.script.run
-        .withSuccessHandler(function(response) {
-          resultsEl.innerHTML = '';
-          setEnabled(true);
-          handleExactSearchResponse(response);
-        })
-        .withFailureHandler(function() {
-          resultsEl.innerHTML = '';
-          setEnabled(true);
-          emptyEl.textContent = 'Something went wrong. Please try again.';
+      if (!query) {
+        _exactSearchAllResults = [];
+        _exactSearchPage = 0;
+        if (resultsEl) resultsEl.innerHTML = '';
+        if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
+        return;
+      }
+      if (query.length < EXACT_MIN_CHARS) {
+        _exactSearchAllResults = [];
+        _exactSearchPage = 0;
+        if (resultsEl) resultsEl.innerHTML = '';
+        if (emptyEl) {
+          emptyEl.textContent = 'Type at least ' + EXACT_MIN_CHARS + ' characters\u2026';
           emptyEl.classList.remove('hidden');
-        })
-        .performExactSearch(query);
+        }
+        return;
+      }
+
+      _exactSearchAllResults = searchImlaeiClient(query);
+      _exactSearchPage = 0;
+      renderExactPage(resultsEl, emptyEl);
     }
 
-    function handleExactSearchResponse(response) {
-      if (!response) {
-        emptyEl.textContent = 'No response received.';
-        emptyEl.classList.remove('hidden');
+    function renderExactPage(container, emptyState) {
+      if (_exactSearchPage === 0) {
+        container.innerHTML = '';
+      }
+
+      if (_exactSearchAllResults.length === 0 && _exactSearchPage === 0) {
+        emptyState.textContent = 'No exact matches found.';
+        emptyState.classList.remove('hidden');
         return;
       }
-      if (response.type === 'error') {
-        emptyEl.textContent = response.error;
-        emptyEl.classList.remove('hidden');
-        return;
+      emptyState.classList.add('hidden');
+
+      var oldBtn = container.querySelector('.btn-show-more');
+      if (oldBtn) oldBtn.remove();
+
+      var start = _exactSearchPage * EXACT_PAGE_SIZE;
+      var end = Math.min(start + EXACT_PAGE_SIZE, _exactSearchAllResults.length);
+      var font = formatState.fontName || 'Amiri';
+
+      for (var i = start; i < end; i++) {
+        var r = _exactSearchAllResults[i];
+        var card = document.createElement('div');
+        card.className = 'result-card';
+
+        var arabicRef = escapeHtml(r.surahNameArabic || '') + ' ' + toArabicIndicClient(r.ayah);
+        var englishRef = escapeHtml((r.surahNameEnglish || 'Surah') + ' ' + r.surah + ':' + r.ayah);
+
+        card.innerHTML =
+          '<div class="ref-arabic">' + arabicRef + '</div>' +
+          '<div class="arabic" style="font-family:' + escapeHtml(font) + ',serif">' + escapeHtml(r.arabicText) + '</div>' +
+          '<div class="ref-english">' + englishRef + '</div>' +
+          '<button type="button" class="btn-primary btn-insert-result" ' +
+            'data-surah="' + r.surah + '" data-ayah="' + r.ayah + '">Insert</button>';
+
+        container.appendChild(card);
       }
-      var results = response.results || [];
-      if (!results.length) {
-        emptyEl.textContent = response.message || 'No results found.';
-        emptyEl.classList.remove('hidden');
-        return;
+
+      _exactSearchPage++;
+
+      if (end < _exactSearchAllResults.length) {
+        var remaining = _exactSearchAllResults.length - end;
+        var showMore = document.createElement('button');
+        showMore.type = 'button';
+        showMore.className = 'btn-show-more';
+        showMore.textContent = 'Show more (' + remaining + ' remaining)';
+        showMore.addEventListener('click', function() {
+          renderExactPage(container, emptyState);
+        });
+        container.appendChild(showMore);
       }
-      renderResults(resultsEl, results, 'search');
     }
 
-    setupTextarea(queryEl, doExactSearch);
+    queryEl.addEventListener('input', function() {
+      queryEl.style.height = 'auto';
+      queryEl.style.height = Math.min(queryEl.scrollHeight, 120) + 'px';
+
+      var val = queryEl.value;
+      if (!val || !val.trim()) {
+        if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+        _exactSearchAllResults = [];
+        _exactSearchPage = 0;
+        if (resultsEl) resultsEl.innerHTML = '';
+        if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
+        return;
+      }
+      if (val.trim().length < EXACT_MIN_CHARS) {
+        if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+        _exactSearchAllResults = [];
+        _exactSearchPage = 0;
+        if (resultsEl) resultsEl.innerHTML = '';
+        if (emptyEl) {
+          emptyEl.textContent = 'Type at least ' + EXACT_MIN_CHARS + ' characters\u2026';
+          emptyEl.classList.remove('hidden');
+        }
+        return;
+      }
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(doExactSearch, EXACT_DEBOUNCE_MS);
+    });
+
+    queryEl.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        doExactSearch();
+      }
+    });
+
     if (btnSearch) btnSearch.addEventListener('click', doExactSearch);
     if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
   }
 
   function clearExactSearch() {
+    _exactSearchAllResults = [];
+    _exactSearchPage = 0;
     var queryEl = document.getElementById('exact-search-query');
     var resultsEl = document.getElementById('exact-search-results');
     var emptyEl = document.getElementById('exact-search-empty');

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -17,6 +17,7 @@
   // ─── Cache URLs ──────────────────────────────────────────────────────────────
 
   var UTHMANI_URL     = 'https://tarazis97.github.io/tasneef-data/quran/uthmani.json';
+  var IMLAEI_URL      = 'https://tarazis97.github.io/tasneef-data/quran/imlaei-simple.json';
   var TRANSLATION_URL = 'https://quranapi.pages.dev/api/english.json';
 
   // ─── Client-side Quran / translation caches (makeClientCache from sidebar/client-cache) ──
@@ -96,6 +97,36 @@
    */
   function lookupTranslation(surahNum, ayahNum) {
     return _translationCacheApi.lookup(surahNum, ayahNum);
+  }
+
+  // ─── Client-side Imlaei (simple) cache with pre-normalized index ──
+
+  function _parseImlaeiData(rawMap) {
+    var raw = {};
+    var normalized = {};
+    for (var key in rawMap) {
+      raw[key] = rawMap[key];
+      normalized[key] = normalizeArabic((rawMap[key].text || ''));
+    }
+    return { raw: raw, normalized: normalized };
+  }
+
+  var _imlaeiCacheApi = makeClientCache({
+    url: IMLAEI_URL,
+    statusElId: 'imlaei-cache-status',
+    loadingMsg: 'Loading search index\u2026',
+    errorMsg: 'Failed to load search index.',
+    parseData: _parseImlaeiData,
+    logLabel: 'Imlaei cache'
+  });
+
+  /**
+   * Ensures imlaei-simple.json is fetched, parsed, and the normalized index is built.
+   * @param {Function} [onReady]
+   * @param {Function} [onError]
+   */
+  function ensureImlaeiCache(onReady, onError) {
+    _imlaeiCacheApi.ensure(onReady, onError);
   }
 
   var _refreshDirectInsert = null;   // set by initDirectInsertTab, called by initFormatBar
@@ -342,6 +373,9 @@
     if (tabId === 'direct-insert') {
       ensureUthmaniCache();      // no-op if already loading or loaded
       ensureTranslationCache();  // fires in parallel with uthmani fetch
+    }
+    if (tabId === 'exact-search') {
+      ensureImlaeiCache();       // no-op if already loading or loaded
     }
   }
 
@@ -919,7 +953,7 @@
   // ─── Init ────────────────────────────────────────────────────────────────────
 
   function init() {
-    var pendingInit = 4;
+    var pendingInit = 5;
     function onInitDone() {
       if (--pendingInit <= 0) {
         var overlay = document.getElementById('startup-overlay');
@@ -939,6 +973,7 @@
 
     ensureUthmaniCache(onInitDone, onInitDone);
     ensureTranslationCache(onInitDone, onInitDone);
+    ensureImlaeiCache(onInitDone, onInitDone);
 
     initFormatBar();
     initSettings();

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -44,6 +44,7 @@
 
   <script>
   <?!= include('client/makeClientCache') ?>
+  <?!= include('client/normalizeArabic') ?>
   </script>
   <?!= include('sidebar/sidebar-js') ?>
 </body>

--- a/tests/normalizeArabic.test.js
+++ b/tests/normalizeArabic.test.js
@@ -1,0 +1,223 @@
+'use strict';
+
+/**
+ * Node tests for client/normalizeArabic.html (client-side Arabic normalization).
+ * Run: npm run test:normalize
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const NORMALIZE_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'client', 'normalizeArabic.html'),
+  'utf8'
+);
+
+function loadModule() {
+  const sandbox = { console };
+  vm.createContext(sandbox);
+  vm.runInContext(NORMALIZE_SRC, sandbox);
+  return sandbox;
+}
+
+function runTests() {
+  const tests = [];
+
+  function it(label, fn) {
+    tests.push({ label: label, fn: fn });
+  }
+
+  // ─── normalizeArabic ────────────────────────────────────────────────────────
+
+  it('returns empty string for null/undefined/non-string', function () {
+    const m = loadModule();
+    assert.strictEqual(m.normalizeArabic(null), '');
+    assert.strictEqual(m.normalizeArabic(undefined), '');
+    assert.strictEqual(m.normalizeArabic(123), '');
+    assert.strictEqual(m.normalizeArabic(''), '');
+  });
+
+  it('strips fatha, damma, kasra, and other tashkeel', function () {
+    const m = loadModule();
+    // بِسْمِ → بسم (strip kasra U+0650, sukun U+0652, kasra U+0650)
+    var input = '\u0628\u0650\u0633\u0652\u0645\u0650';
+    assert.strictEqual(m.normalizeArabic(input), '\u0628\u0633\u0645');
+  });
+
+  it('strips superscript alif (U+0670)', function () {
+    const m = loadModule();
+    // رحمٰن → رحمن
+    var input = '\u0631\u062D\u0645\u0670\u0646';
+    assert.strictEqual(m.normalizeArabic(input), '\u0631\u062D\u0645\u0646');
+  });
+
+  it('collapses alef-madda (U+0622) to plain alef', function () {
+    const m = loadModule();
+    assert.strictEqual(m.normalizeArabic('\u0622'), '\u0627');
+  });
+
+  it('collapses alef-hamza-above (U+0623) to plain alef', function () {
+    const m = loadModule();
+    assert.strictEqual(m.normalizeArabic('\u0623'), '\u0627');
+  });
+
+  it('collapses alef-hamza-below (U+0625) to plain alef', function () {
+    const m = loadModule();
+    assert.strictEqual(m.normalizeArabic('\u0625'), '\u0627');
+  });
+
+  it('collapses alef-wasla (U+0671) to plain alef', function () {
+    const m = loadModule();
+    assert.strictEqual(m.normalizeArabic('\u0671'), '\u0627');
+  });
+
+  it('preserves non-Arabic characters unchanged', function () {
+    const m = loadModule();
+    assert.strictEqual(m.normalizeArabic('hello 123'), 'hello 123');
+  });
+
+  it('handles mixed Arabic text with tashkeel and alef variants', function () {
+    const m = loadModule();
+    // ٱلرَّحْمَـٰنِ → الرحمـن  (alef-wasla → alef, strip tashkeel)
+    var input = '\u0671\u0644\u0631\u064E\u0651\u062D\u0652\u0645\u064E\u0640\u0670\u0646\u0650';
+    var expected = '\u0627\u0644\u0631\u062D\u0645\u0640\u0646';
+    assert.strictEqual(m.normalizeArabic(input), expected);
+  });
+
+  // ─── _isInTashkeelRange ─────────────────────────────────────────────────────
+
+  it('identifies fatha (U+064E) as tashkeel', function () {
+    const m = loadModule();
+    assert.strictEqual(m._isInTashkeelRange(0x064E), true);
+  });
+
+  it('identifies superscript alif (U+0670) as tashkeel', function () {
+    const m = loadModule();
+    assert.strictEqual(m._isInTashkeelRange(0x0670), true);
+  });
+
+  it('does not flag plain alef (U+0627) as tashkeel', function () {
+    const m = loadModule();
+    assert.strictEqual(m._isInTashkeelRange(0x0627), false);
+  });
+
+  it('does not flag Latin A (U+0041) as tashkeel', function () {
+    const m = loadModule();
+    assert.strictEqual(m._isInTashkeelRange(0x0041), false);
+  });
+
+  // ─── _hasArabicChars ────────────────────────────────────────────────────────
+
+  it('detects Arabic in mixed text', function () {
+    const m = loadModule();
+    assert.strictEqual(m._hasArabicChars('hello \u0628 world'), true);
+  });
+
+  it('returns false for pure Latin text', function () {
+    const m = loadModule();
+    assert.strictEqual(m._hasArabicChars('hello world'), false);
+  });
+
+  it('returns false for empty string', function () {
+    const m = loadModule();
+    assert.strictEqual(m._hasArabicChars(''), false);
+  });
+
+  // ─── _mapNormalizedToOriginal ───────────────────────────────────────────────
+
+  it('maps indices correctly when no tashkeel present', function () {
+    const m = loadModule();
+    var result = m._mapNormalizedToOriginal('abcdef', 2, 3);
+    assert.strictEqual(result.start, 2);
+    assert.strictEqual(result.end, 5);
+  });
+
+  it('maps indices across tashkeel characters', function () {
+    const m = loadModule();
+    // Original: بِسْمِ  (b, kasra, s, sukun, m, kasra)
+    // Normalized: بسم (indices 0,1,2)
+    var original = '\u0628\u0650\u0633\u0652\u0645\u0650';
+    // Match normalized index 1 (س), length 1
+    var result = m._mapNormalizedToOriginal(original, 1, 1);
+    assert.strictEqual(result.start, 2); // index of س in original
+    assert.strictEqual(result.end, 3);   // one past س (before sukun)
+  });
+
+  it('returns {0,0} for invalid inputs', function () {
+    const m = loadModule();
+    var r1 = m._mapNormalizedToOriginal('', 0, 1);
+    assert.strictEqual(r1.start, 0); assert.strictEqual(r1.end, 0);
+    var r2 = m._mapNormalizedToOriginal('abc', -1, 1);
+    assert.strictEqual(r2.start, 0); assert.strictEqual(r2.end, 0);
+    var r3 = m._mapNormalizedToOriginal('abc', 0, 0);
+    assert.strictEqual(r3.start, 0); assert.strictEqual(r3.end, 0);
+  });
+
+  it('maps match at end of string correctly', function () {
+    const m = loadModule();
+    // Original: اَبْ  (alef, fatha, ba, sukun)
+    // Normalized: اب (indices 0,1)
+    var original = '\u0627\u064E\u0628\u0652';
+    var result = m._mapNormalizedToOriginal(original, 1, 1);
+    assert.strictEqual(result.start, 2); // index of ب
+    assert.strictEqual(result.end, 3);   // one past ب
+  });
+
+  // ─── Parity with server-side normalizeArabic ───────────────────────────────
+
+  it('matches server-side QuranData.js normalizeArabic output', function () {
+    const m = loadModule();
+
+    const SERVER_SRC = fs.readFileSync(
+      path.join(__dirname, '..', 'QuranData.js'),
+      'utf8'
+    );
+    const serverSandbox = { console, CacheService: null, UrlFetchApp: null };
+    vm.createContext(serverSandbox);
+    vm.runInContext(SERVER_SRC, serverSandbox);
+
+    var samples = [
+      '\u0628\u0650\u0633\u0652\u0645\u0650 \u0671\u0644\u0644\u064E\u0651\u0647\u0650',
+      '\u0622\u064A\u064E\u0629',
+      '\u0623\u064E\u0646\u0632\u064E\u0644\u0652\u0646\u064E\u0627',
+      '\u0625\u0650\u0646\u064E\u0651',
+      'plain text without Arabic',
+      ''
+    ];
+
+    samples.forEach(function (s) {
+      assert.strictEqual(
+        m.normalizeArabic(s),
+        serverSandbox.normalizeArabic(s),
+        'Mismatch for: ' + JSON.stringify(s)
+      );
+    });
+  });
+
+  // ─── Run all tests ─────────────────────────────────────────────────────────
+
+  let ran = 0;
+  let failed = 0;
+  const chain = tests.reduce(function (p, t) {
+    return p.then(function () {
+      return Promise.resolve(t.fn())
+        .then(function () {
+          console.log('  \u2713 ' + t.label);
+          ran++;
+        })
+        .catch(function (e) {
+          console.log('  \u2717 ' + t.label + '\n      \u2192 ' + (e && e.message ? e.message : e));
+          failed++;
+        });
+    });
+  }, Promise.resolve());
+
+  return chain.then(function () {
+    console.log('\nnormalizeArabic: ' + ran + ' passed, ' + failed + ' failed.');
+    if (failed > 0) process.exit(1);
+  });
+}
+
+runTests();

--- a/tests/normalizeArabic.test.js
+++ b/tests/normalizeArabic.test.js
@@ -165,6 +165,78 @@ function runTests() {
     assert.strictEqual(result.end, 3);   // one past ب
   });
 
+  // ─── searchImlaeiClient logic ───────────────────────────────────────────────
+  //
+  // searchImlaeiClient lives in sidebar-js.html's IIFE, so we test its core
+  // algorithm here: normalize query, indexOf against pre-normalized map.
+
+  it('finds matching verse by normalized query', function () {
+    const m = loadModule();
+    var raw = {
+      '1:1': { surah: 1, ayah: 1, text: '\u0628\u0650\u0633\u0652\u0645\u0650 \u0671\u0644\u0644\u064E\u0651\u0647\u0650' },
+      '1:2': { surah: 1, ayah: 2, text: '\u0627\u0644\u062D\u064E\u0645\u0652\u062F\u064F' }
+    };
+    var normalized = {};
+    for (var key in raw) {
+      normalized[key] = m.normalizeArabic(raw[key].text);
+    }
+
+    var query = '\u0628\u0633\u0645';
+    var normalizedQuery = m.normalizeArabic(query);
+    var results = [];
+    for (var k in normalized) {
+      if (normalized[k].indexOf(normalizedQuery) >= 0) {
+        results.push({ key: k, verse: raw[k] });
+      }
+    }
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].key, '1:1');
+  });
+
+  it('matches query with tashkeel against stripped corpus', function () {
+    const m = loadModule();
+    var raw = {
+      '2:255': { surah: 2, ayah: 255, text: '\u0627\u0644\u0644\u0647 \u0644\u0627 \u0625\u0644\u0647 \u0625\u0644\u0627 \u0647\u0648' }
+    };
+    var normalized = {};
+    for (var key in raw) {
+      normalized[key] = m.normalizeArabic(raw[key].text);
+    }
+
+    // Query with alef-hamza-below (U+0625) should match plain alef in normalized
+    var query = '\u0625\u0644\u0647';
+    var normalizedQuery = m.normalizeArabic(query);
+    assert.strictEqual(normalizedQuery, '\u0627\u0644\u0647');
+    assert.ok(normalized['2:255'].indexOf(normalizedQuery) >= 0);
+  });
+
+  it('returns no results when query does not match', function () {
+    const m = loadModule();
+    var normalized = { '1:1': m.normalizeArabic('\u0628\u0633\u0645') };
+    var normalizedQuery = m.normalizeArabic('\u0642\u0644');
+    var found = false;
+    for (var k in normalized) {
+      if (normalized[k].indexOf(normalizedQuery) >= 0) found = true;
+    }
+    assert.strictEqual(found, false);
+  });
+
+  it('respects result cap', function () {
+    const m = loadModule();
+    var normalized = {};
+    for (var i = 1; i <= 60; i++) {
+      normalized['1:' + i] = '\u0628\u0633\u0645';
+    }
+    var normalizedQuery = '\u0628\u0633\u0645';
+    var cap = 50;
+    var count = 0;
+    for (var k in normalized) {
+      if (count >= cap) break;
+      if (normalized[k].indexOf(normalizedQuery) >= 0) count++;
+    }
+    assert.strictEqual(count, 50);
+  });
+
   // ─── Parity with server-side normalizeArabic ───────────────────────────────
 
   it('matches server-side QuranData.js normalizeArabic output', function () {


### PR DESCRIPTION
Closes #41

## Summary
- Load `imlaei-simple.json` eagerly at sidebar startup using `makeClientCache`
- Build raw and pre-normalized maps in a single parse pass (`_parseImlaeiData`)
- Port `normalizeArabic` and helpers from `QuranData.js` into `client/normalizeArabic.html`
- Add `ensureImlaeiCache` to `init()` (pendingInit 4 -> 5) and `switchTab` for the exact-search tab
- 21 unit tests for normalization + server-side parity test

## Test plan
- [x] All 27 tests pass (`npm test`)
- [x] `clasp push` successful (30 files)

Made with [Cursor](https://cursor.com)