### PR TITLE
Load surah list from GitHub Pages on startup

### DIFF
--- a/sidebar/components/tab-direct-insert.html
+++ b/sidebar/components/tab-direct-insert.html
@@ -21,6 +21,7 @@
       </div>
     </div>
   </div>
+  <div id="surah-meta-cache-status" class="cache-status hidden"></div>
   <div id="uthmani-cache-status" class="cache-status hidden"></div>
   <div id="translation-cache-status" class="cache-status hidden"></div>
   <div id="direct-insert-results" class="results-list"></div>

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -18,6 +18,7 @@
 
   var UTHMANI_URL     = 'https://tarazis.github.io/tasneef-data/quran/uthmani.json';
   var IMLAEI_URL      = 'https://tarazis.github.io/tasneef-data/quran/imlaei-simple.json';
+  var SURAH_META_URL  = 'https://tarazis.github.io/tasneef-data/quran/quran-metadata-surah-name.json';
   var TRANSLATION_URL = 'https://quranapi.pages.dev/api/english.json';
 
   // ─── Client-side Quran / translation caches (makeClientCache from sidebar/client-cache) ──
@@ -127,6 +128,36 @@
    */
   function ensureImlaeiCache(onReady, onError) {
     _imlaeiCacheApi.ensure(onReady, onError);
+  }
+
+  // ─── Client-side surah metadata cache ────────────────────────────────────────
+
+  function _parseSurahMetaData(rawObj) {
+    var list = [];
+    for (var i = 1; i <= 114; i++) {
+      var s = rawObj[String(i)];
+      if (!s) continue;
+      list.push({
+        number: s.id,
+        nameArabic: s.name_arabic || '',
+        nameEnglish: s.name_simple || s.name || '',
+        ayahCount: s.verses_count || 0
+      });
+    }
+    return list;
+  }
+
+  var _surahMetaCacheApi = makeClientCache({
+    url: SURAH_META_URL,
+    statusElId: 'surah-meta-cache-status',
+    loadingMsg: 'Loading surah list\u2026',
+    errorMsg: 'Failed to load surah list.',
+    parseData: _parseSurahMetaData,
+    logLabel: 'Surah meta cache'
+  });
+
+  function ensureSurahMetaCache(onReady, onError) {
+    _surahMetaCacheApi.ensure(onReady, onError);
   }
 
   // ─── Client-side exact search against imlaei cache ──
@@ -661,26 +692,23 @@
     var resultsEl = document.getElementById('direct-insert-results');
     var emptyEl = document.getElementById('direct-insert-empty');
 
-    // Load surah list
-    google.script.run
-      .withSuccessHandler(function(list) {
-        _surahList = list || [];
-        surahSelect.innerHTML = '';
-        var placeholder = document.createElement('option');
-        placeholder.value = '';
-        placeholder.textContent = 'Select a Surah…';
-        surahSelect.appendChild(placeholder);
-        _surahList.forEach(function(s) {
-          var opt = document.createElement('option');
-          opt.value = s.number;
-          opt.textContent = s.number + '. ' + s.nameEnglish + ' - ' + s.nameArabic;
-          surahSelect.appendChild(opt);
-        });
-      })
-      .withFailureHandler(function() {
-        surahSelect.innerHTML = '<option value="">Failed to load</option>';
-      })
-      .getSurahListFromQuranApi();
+    // Load surah list from client-side cache (tarazis.github.io)
+    ensureSurahMetaCache(function(list) {
+      _surahList = list || [];
+      surahSelect.innerHTML = '';
+      var placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = 'Select a Surah\u2026';
+      surahSelect.appendChild(placeholder);
+      _surahList.forEach(function(s) {
+        var opt = document.createElement('option');
+        opt.value = s.number;
+        opt.textContent = s.number + '. ' + s.nameEnglish + ' - ' + s.nameArabic;
+        surahSelect.appendChild(opt);
+      });
+    }, function() {
+      surahSelect.innerHTML = '<option value="">Failed to load</option>';
+    });
 
     function populateAyahSelect(selectEl, from, to, placeholder) {
       selectEl.innerHTML = '';
@@ -1071,7 +1099,7 @@
   // ─── Init ────────────────────────────────────────────────────────────────────
 
   function init() {
-    var pendingInit = 5;
+    var pendingInit = 6;
     function onInitDone() {
       if (--pendingInit <= 0) {
         var overlay = document.getElementById('startup-overlay');
@@ -1092,6 +1120,7 @@
     ensureUthmaniCache(onInitDone, onInitDone);
     ensureTranslationCache(onInitDone, onInitDone);
     ensureImlaeiCache(onInitDone, onInitDone);
+    ensureSurahMetaCache(onInitDone, onInitDone);
 
     initFormatBar();
     initSettings();

--- a/tests/makeClientCache.test.js
+++ b/tests/makeClientCache.test.js
@@ -230,6 +230,92 @@ function runTests() {
     });
   });
 
+  it('parseSurahMetaData converts raw object to sorted surah array', function () {
+    const rawObj = {
+      '1':   { id: 1,   name_arabic: 'الفاتحة', name_simple: 'Al-Fatihah', verses_count: 7 },
+      '2':   { id: 2,   name_arabic: 'البقرة',  name_simple: 'Al-Baqarah', verses_count: 286 },
+      '114': { id: 114, name_arabic: 'الناس',   name_simple: 'An-Nas',     verses_count: 6 }
+    };
+    function parseSurahMetaData(obj) {
+      var list = [];
+      for (var i = 1; i <= 114; i++) {
+        var s = obj[String(i)];
+        if (!s) continue;
+        list.push({
+          number: s.id,
+          nameArabic: s.name_arabic || '',
+          nameEnglish: s.name_simple || s.name || '',
+          ayahCount: s.verses_count || 0
+        });
+      }
+      return list;
+    }
+    const result = parseSurahMetaData(rawObj);
+    assert.strictEqual(result.length, 3);
+    assert.deepStrictEqual(result[0], { number: 1, nameArabic: 'الفاتحة', nameEnglish: 'Al-Fatihah', ayahCount: 7 });
+    assert.deepStrictEqual(result[1], { number: 2, nameArabic: 'البقرة', nameEnglish: 'Al-Baqarah', ayahCount: 286 });
+    assert.deepStrictEqual(result[2], { number: 114, nameArabic: 'الناس', nameEnglish: 'An-Nas', ayahCount: 6 });
+  });
+
+  it('parseSurahMetaData falls back to name when name_simple is absent', function () {
+    const rawObj = { '5': { id: 5, name_arabic: 'المائدة', name: 'Al-Maidah', verses_count: 120 } };
+    function parseSurahMetaData(obj) {
+      var list = [];
+      for (var i = 1; i <= 114; i++) {
+        var s = obj[String(i)];
+        if (!s) continue;
+        list.push({ number: s.id, nameArabic: s.name_arabic || '', nameEnglish: s.name_simple || s.name || '', ayahCount: s.verses_count || 0 });
+      }
+      return list;
+    }
+    const result = parseSurahMetaData(rawObj);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].nameEnglish, 'Al-Maidah');
+  });
+
+  it('ensure with parseSurahMetaData stores array accessible via onReady callback', function () {
+    const rawObj = {
+      '1': { id: 1, name_arabic: 'الفاتحة', name_simple: 'Al-Fatihah', verses_count: 7 }
+    };
+    doc.fetch = function () {
+      return Promise.resolve({
+        ok: true,
+        json: function () { return Promise.resolve(rawObj); }
+      });
+    };
+    const makeClientCache = loadFactory(doc);
+    const cache = makeClientCache({
+      url: 'https://example.com/surah-meta.json',
+      statusElId: 'status-x',
+      loadingMsg: '…',
+      errorMsg: 'err',
+      parseData: function (obj) {
+        var list = [];
+        for (var i = 1; i <= 114; i++) {
+          var s = obj[String(i)];
+          if (!s) continue;
+          list.push({ number: s.id, nameArabic: s.name_arabic || '', nameEnglish: s.name_simple || '', ayahCount: s.verses_count || 0 });
+        }
+        return list;
+      },
+      logLabel: 'surah-meta-test'
+    });
+    return new Promise(function (resolve, reject) {
+      cache.ensure(function (list) {
+        try {
+          assert.ok(Array.isArray(list), 'parsed result should be an array');
+          assert.strictEqual(list.length, 1);
+          assert.strictEqual(list[0].number, 1);
+          assert.strictEqual(list[0].nameEnglish, 'Al-Fatihah');
+          assert.strictEqual(list[0].ayahCount, 7);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+
   it('lookup returns null while JSON pending then returns value', function () {
     let finishJson;
     doc.fetch = function () {


### PR DESCRIPTION
Closes #43

## Summary
- Replace `google.script.run.getSurahListFromQuranApi()` with a client-side `makeClientCache` fetch from `tarazis.github.io/tasneef-data/quran/quran-metadata-surah-name.json`
- Surah list now loads in parallel with uthmani, imlaei, and translation caches on startup
- Startup overlay waits for surah list to load (`pendingInit` = 6)
- Added `surah-meta-cache-status` DOM element for loading/error feedback with retry button
- Added 3 unit tests for `_parseSurahMetaData` logic in `makeClientCache.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)