### PR TITLE
Remove quranapi dependency from AI Search — use client-side caches

### DIFF
--- a/ClaudeAPI.js
+++ b/ClaudeAPI.js
@@ -180,9 +180,7 @@ function performAISearch(messages) {
   var response;
   switch (classified.action) {
     case 'fetch_ayah':
-      var ayahStart = classified.ayahStart || classified.ayah;
-      var ayahEnd = classified.ayahEnd || classified.ayah || ayahStart;
-      response = insertDirectAyah(classified.surah, ayahStart, ayahEnd);
+      response = _handleFetchAyahAsReferences(classified);
       break;
     case 'search':
       response = _handleSearchRouting(classified);
@@ -225,13 +223,12 @@ function _handleSearchRouting(classified) {
 }
 
 /**
- * Handles English/semantic search: validates Claude's references against quranapi.
+ * Handles English/semantic search: returns Claude's validated references for
+ * client-side resolution against in-memory caches.
  * @param {Object} classified - { query, references: [{surah, ayah}] }
- * @return {Object} Unified result object
+ * @return {Object} { type: 'references', references: [{surah, ayah}] } or error
  */
 function _handleEnglishSearch(classified) {
-  var settings = getSettings();
-  var style = settings.arabicStyle || 'uthmani';
   var refs = classified.references;
 
   if (!refs || !Array.isArray(refs) || !refs.length) {
@@ -251,12 +248,35 @@ function _handleEnglishSearch(classified) {
     return { type: 'error', error: 'No valid results found. Try a different query.' };
   }
 
-  var validated = _validateAndFetchReferences(validRefs, style);
-  if (!validated.length) {
-    return { type: 'error', error: 'No verified results found. Try a different query.' };
+  return { type: 'references', references: validRefs };
+}
+
+/**
+ * Converts a fetch_ayah classification into raw references for client-side resolution.
+ * @param {Object} classified - { surah, ayah?, ayahStart?, ayahEnd? }
+ * @return {Object} { type: 'references', references: [{surah, ayah}] } or error
+ */
+function _handleFetchAyahAsReferences(classified) {
+  var ayahStart = parseInt(classified.ayahStart || classified.ayah, 10);
+  var ayahEnd = parseInt(classified.ayahEnd || classified.ayah || ayahStart, 10);
+  var s = parseInt(classified.surah, 10);
+
+  if (!s || s < 1 || s > 114) {
+    return { type: 'error', error: 'Invalid surah number. Must be 1\u2013114.' };
+  }
+  if (!ayahStart || ayahStart < 1) {
+    return { type: 'error', error: 'Invalid ayah number.' };
+  }
+  if (ayahEnd < ayahStart) ayahEnd = ayahStart;
+  if (ayahEnd - ayahStart + 1 > DIRECT_AYAH_RANGE_CAP) {
+    return { type: 'error', error: 'Range too large. Maximum ' + DIRECT_AYAH_RANGE_CAP + ' ayahs at once.' };
   }
 
-  return { type: 'search', results: validated };
+  var refs = [];
+  for (var i = ayahStart; i <= ayahEnd; i++) {
+    refs.push({ surah: s, ayah: i });
+  }
+  return { type: 'references', references: refs };
 }
 
 /**

--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -500,6 +500,83 @@
     });
   }
 
+  // ─── Build results from server-returned references using client caches ─────
+
+  /**
+   * Validates and assembles full result objects from raw {surah, ayah} references
+   * using in-memory caches (uthmani, imlaei, translation, surah metadata).
+   * Acts as a hallucination guard — skips references that don't exist in cached data.
+   * @param {Array<{surah: number, ayah: number}>} references
+   * @return {Array<Object>} Result objects matching renderResults() shape
+   */
+  function _buildResultsFromReferences(references) {
+    var style = _settings.arabicStyle || 'uthmani';
+    var imlaeiData = null;
+    if (style === 'simple') {
+      _imlaeiCacheApi.ensure(function(d) { imlaeiData = d; });
+    }
+    var results = [];
+    for (var i = 0; i < references.length; i++) {
+      var ref = references[i];
+      var surahMeta = _surahList.find(function(s) { return s.number === ref.surah; });
+      if (!surahMeta || ref.ayah > surahMeta.ayahCount) continue;
+
+      var uthmaniData = lookupUthmaniAyah(ref.surah, ref.ayah);
+      if (!uthmaniData) continue;
+
+      var arabicText = uthmaniData.text;
+      if (style === 'simple' && imlaeiData && imlaeiData.raw) {
+        var entry = imlaeiData.raw[ref.surah + ':' + ref.ayah];
+        if (entry && entry.text) arabicText = entry.text;
+      }
+
+      results.push({
+        surah:            ref.surah,
+        ayah:             ref.ayah,
+        surahNameArabic:  surahMeta.nameArabic,
+        surahNameEnglish: surahMeta.nameEnglish,
+        arabicText:       arabicText,
+        translationText:  lookupTranslation(ref.surah, ref.ayah) || ''
+      });
+    }
+    return results;
+  }
+
+  /**
+   * Builds a full ayah data object for insertion from client-side caches.
+   * Returns the same shape that insertAyah() expects.
+   * @param {number} surahNum
+   * @param {number} ayahNum
+   * @param {string} style - "uthmani" or "simple"
+   * @return {Object|null}
+   */
+  function _buildAyahDataForInsert(surahNum, ayahNum, style) {
+    var surahMeta = _surahList.find(function(s) { return s.number === surahNum; });
+    var uthmaniData = lookupUthmaniAyah(surahNum, ayahNum);
+    if (!uthmaniData) return null;
+
+    var simpleText = '';
+    var imlaeiData = null;
+    _imlaeiCacheApi.ensure(function(d) { imlaeiData = d; });
+    if (imlaeiData && imlaeiData.raw) {
+      var entry = imlaeiData.raw[surahNum + ':' + ayahNum];
+      if (entry) simpleText = entry.text || '';
+    }
+
+    var arabicText = (style === 'simple' && simpleText) ? simpleText : uthmaniData.text;
+
+    return {
+      surah: surahNum,
+      ayah: ayahNum,
+      surahNameArabic: surahMeta ? surahMeta.nameArabic : '',
+      surahNameEnglish: surahMeta ? surahMeta.nameEnglish : '',
+      arabicText: arabicText,
+      textUthmani: uthmaniData.text,
+      textSimple: simpleText,
+      translationText: lookupTranslation(surahNum, ayahNum) || ''
+    };
+  }
+
   function renderResults(containerEl, results, type) {
     containerEl.innerHTML = '';
 
@@ -613,34 +690,28 @@
     btn.classList.add('btn-loading');
     var style = _settings.arabicStyle || 'uthmani';
 
+    var ayahData = _buildAyahDataForInsert(surah, ayah, style);
+    if (!ayahData) {
+      btn.disabled = false;
+      btn.classList.remove('btn-loading');
+      return;
+    }
+
+    var fs = window.getFormatState ? window.getFormatState() : {};
     google.script.run
-      .withSuccessHandler(function(ayahData) {
-        if (!ayahData) {
-          btn.disabled = false;
-          btn.classList.remove('btn-loading');
-          return;
-        }
-        var fs = window.getFormatState ? window.getFormatState() : {};
-        google.script.run
-          .withSuccessHandler(function(result) {
-            btn.disabled = false;
-            btn.classList.remove('btn-loading');
-            if (result && !result.success) {
-              console.warn('Insert warning:', result.message);
-            }
-          })
-          .withFailureHandler(function(err) {
-            btn.disabled = false;
-            btn.classList.remove('btn-loading');
-            console.error('Insert failed:', err);
-          })
-          .insertAyah(ayahData, fs, _settings);
-      })
-      .withFailureHandler(function() {
+      .withSuccessHandler(function(result) {
         btn.disabled = false;
         btn.classList.remove('btn-loading');
+        if (result && !result.success) {
+          console.warn('Insert warning:', result.message);
+        }
       })
-      .getAyahForInsert(surah, ayah, style);
+      .withFailureHandler(function(err) {
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
+        console.error('Insert failed:', err);
+      })
+      .insertAyah(ayahData, fs, _settings);
   }
 
   function handleRangeInsertClick(btn) {
@@ -1061,6 +1132,23 @@
 
       // Non-clarify response breaks the conversation chain
       _conversationMessages = [];
+
+      // References type: resolve against client-side caches
+      if (response.type === 'references') {
+        var refs = response.references || [];
+        var resolved = _buildResultsFromReferences(refs);
+        if (!resolved.length) {
+          emptyEl.textContent = 'No verified results found. Try a different query.';
+          emptyEl.classList.remove('hidden');
+          return;
+        }
+        var isConsecutiveRange = refs.length > 1
+          && refs[0].surah === refs[refs.length - 1].surah
+          && refs[refs.length - 1].ayah - refs[0].ayah === refs.length - 1;
+        var renderType = isConsecutiveRange ? 'range' : 'search';
+        renderResults(resultsEl, resolved, renderType);
+        return;
+      }
 
       var results = response.results || [];
       if (response.message && results.length === 0) {

--- a/tests/ClaudeAPI.test.gs
+++ b/tests/ClaudeAPI.test.gs
@@ -244,36 +244,86 @@ function runClaudeAPITests() {
     expect(r.matchEnd != null).toBe(true);
   });
 
-  // ── _handleEnglishSearch (integration) ─────────────────────────────────────
+  // ── _handleEnglishSearch (unit — returns raw references) ──────────────────
 
   results.push('\n_handleEnglishSearch()');
 
-  it('validates good references for English search', function () {
+  it('returns references type with valid surah/ayah pairs', function () {
     var classified = {
       query: 'patience',
       language: 'english',
       references: [{ surah: 1, ayah: 1 }, { surah: 2, ayah: 255 }]
     };
     var result = _handleEnglishSearch(classified);
-    expect(result.type).toBe('search');
-    expect(result.results.length).toBe(2);
-    expect(result.results[0].arabicText).toBeTruthy();
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(2);
+    expect(result.references[0].surah).toBe(1);
+    expect(result.references[0].ayah).toBe(1);
+    expect(result.references[1].surah).toBe(2);
+    expect(result.references[1].ayah).toBe(255);
   });
 
-  it('discards hallucinated references', function () {
+  it('discards references with invalid surah (> 114)', function () {
     var classified = {
       query: 'test',
       language: 'english',
       references: [{ surah: 1, ayah: 1 }, { surah: 999, ayah: 1 }]
     };
     var result = _handleEnglishSearch(classified);
-    expect(result.type).toBe('search');
-    expect(result.results.length).toBe(1);
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(1);
+    expect(result.references[0].surah).toBe(1);
   });
 
   it('returns error when no references provided for English search', function () {
     var result = _handleEnglishSearch({ query: 'patience', language: 'english' });
     expect(result.type).toBe('error');
+  });
+
+  it('caps references at AI_MAX_REFERENCES', function () {
+    var refs = [];
+    for (var r = 0; r < 15; r++) { refs.push({ surah: 1, ayah: r + 1 }); }
+    var classified = { query: 'test', language: 'english', references: refs };
+    var result = _handleEnglishSearch(classified);
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(AI_MAX_REFERENCES);
+  });
+
+  // ── _handleFetchAyahAsReferences (unit) ───────────────────────────────────
+
+  results.push('\n_handleFetchAyahAsReferences()');
+
+  it('returns single reference for fetch_ayah', function () {
+    var result = _handleFetchAyahAsReferences({ surah: 2, ayah: 255 });
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(1);
+    expect(result.references[0].surah).toBe(2);
+    expect(result.references[0].ayah).toBe(255);
+  });
+
+  it('returns range of references for ayahStart/ayahEnd', function () {
+    var result = _handleFetchAyahAsReferences({ surah: 3, ayahStart: 190, ayahEnd: 194 });
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(5);
+    expect(result.references[0].ayah).toBe(190);
+    expect(result.references[4].ayah).toBe(194);
+  });
+
+  it('returns error for invalid surah (0)', function () {
+    var result = _handleFetchAyahAsReferences({ surah: 0, ayah: 1 });
+    expect(result.type).toBe('error');
+  });
+
+  it('returns error for range exceeding cap', function () {
+    var result = _handleFetchAyahAsReferences({ surah: 2, ayahStart: 1, ayahEnd: 50 });
+    expect(result.type).toBe('error');
+  });
+
+  it('defaults ayahEnd to ayahStart when not provided', function () {
+    var result = _handleFetchAyahAsReferences({ surah: 1, ayah: 5 });
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(1);
+    expect(result.references[0].ayah).toBe(5);
   });
 
   // ── performAISearch (integration) ──────────────────────────────────────────
@@ -326,18 +376,20 @@ function runClaudeAPITests() {
   // Full integration tests — only run if API key is present
   var apiKey = getClaudeApiKey();
   if (apiKey) {
-    it('performAISearch("show me ayat al kursi") returns results (live API)', function () {
+    it('performAISearch("show me ayat al kursi") returns references (live API)', function () {
       var result = performAISearch([{ role: 'user', content: 'show me ayat al kursi' }]);
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
-      expect(result.results.length).toBeGreaterThan(0);
-      expect(result.results[0].arabicText).toBeTruthy();
+      expect(result.type).toBe('references');
+      expect(result.references.length).toBeGreaterThan(0);
+      expect(result.references[0].surah).toBeGreaterThan(0);
       expect(result.rawResponse).toBeTruthy();
     });
 
-    it('performAISearch("verses about patience") returns search results (live API)', function () {
+    it('performAISearch("verses about patience") returns references (live API)', function () {
       var result = performAISearch([{ role: 'user', content: 'verses about patience' }]);
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
-      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.type).toBe('references');
+      expect(result.references.length).toBeGreaterThan(0);
     });
 
     it('handles conversation context for clarification (live API)', function () {
@@ -349,29 +401,33 @@ function runClaudeAPITests() {
       var result = performAISearch(messages);
       if (result.type === 'clarify') return; // acceptable if Claude still needs more info
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
-      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.type).toBe('references');
+      expect(result.references.length).toBeGreaterThan(0);
     });
 
-    it('performAISearch("show me Al-Imran 190 to 194") returns range results (live API)', function () {
+    it('performAISearch("show me Al-Imran 190 to 194") returns references (live API)', function () {
       var result = performAISearch([{ role: 'user', content: 'show me Al-Imran 190 to 194' }]);
       if (result.type === 'clarify') return; // acceptable
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
-      expect(result.results.length).toBeGreaterThan(0);
-      expect(result.results[0].surah).toBe(3);
+      expect(result.type).toBe('references');
+      expect(result.references.length).toBeGreaterThan(0);
+      expect(result.references[0].surah).toBe(3);
     });
 
-    it('performAISearch("give me the last 3 ayahs of surah Al-Baqarah") returns results (live API)', function () {
+    it('performAISearch("give me the last 3 ayahs of surah Al-Baqarah") returns references (live API)', function () {
       var result = performAISearch([{ role: 'user', content: 'give me the last 3 ayahs of surah Al-Baqarah' }]);
       if (result.type === 'clarify') return; // acceptable
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
-      expect(result.results.length).toBeGreaterThan(0);
-      expect(result.results[0].surah).toBe(2);
+      expect(result.type).toBe('references');
+      expect(result.references.length).toBeGreaterThan(0);
+      expect(result.references[0].surah).toBe(2);
     });
 
     it('processUnifiedQuery delegates to performAISearch (live API)', function () {
       var result = processUnifiedQuery([{ role: 'user', content: 'show me ayat al kursi' }]);
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
-      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.type).toBe('references');
+      expect(result.references.length).toBeGreaterThan(0);
       expect(result.rawResponse).toBeTruthy();
     });
   } else {


### PR DESCRIPTION
Closes #45

## Summary
- Server returns raw `{surah, ayah}` references from Claude instead of fetching text from quranapi.pages.dev
- Client validates references against in-memory surah list (hallucination guard) and assembles results from cached uthmani/imlaei/translation data
- Insert button uses client-side caches instead of re-fetching from quranapi
- Both `fetch_ayah` and `search` actions now return `type: 'references'` for uniform client-side resolution
- Supports `arabicStyle: 'simple'` by falling back to imlaei cache

## Test plan
- [ ] AI Search: "verses about patience" → results render with Arabic text + translation
- [ ] AI Search: "show me Ayat al-Kursi" → single result renders correctly
- [ ] AI Search: "Al-Imran 190-194" → range block renders
- [ ] Insert button works from all result types
- [ ] Arabic exact search still works (unaffected path)
- [ ] No requests to quranapi.pages.dev in Network tab during AI search
- [ ] Run GAS-native ClaudeAPI tests in Apps Script editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)