### PR TITLE
Unify card rendering, pagination, and insert behavior across all sidebar tabs

### DIFF
--- a/sidebar/sidebar-js.html
+++ b/sidebar/sidebar-js.html
@@ -10,7 +10,6 @@
   };
 
   var _settings = {};
-  var _currentRange = null;
   var saveDebounceTimer = null;
   var SAVE_DEBOUNCE_MS = 500;
 
@@ -158,8 +157,8 @@
 
   // ─── Client-side exact search against imlaei cache ──
 
-  var SEARCH_RESULT_CAP = 50;
-  var EXACT_PAGE_SIZE = 20;
+  var MAX_RESULTS = 50;
+  var PAGE_SIZE = 10;
   var EXACT_DEBOUNCE_MS = 200;
   var EXACT_MIN_CHARS = 2;
 
@@ -186,7 +185,7 @@
     var normalized = data.normalized;
 
     for (var key in normalized) {
-      if (results.length >= SEARCH_RESULT_CAP) break;
+      if (results.length >= MAX_RESULTS) break;
       var matchIdx = normalized[key].indexOf(normalizedQuery);
       if (matchIdx < 0) continue;
 
@@ -507,7 +506,7 @@
    * using in-memory caches (uthmani, imlaei, translation, surah metadata).
    * Acts as a hallucination guard — skips references that don't exist in cached data.
    * @param {Array<{surah: number, ayah: number}>} references
-   * @return {Array<Object>} Result objects matching renderResults() shape
+   * @return {Array<Object>} Result objects suitable for renderPreview() or pagReset()
    */
   function _buildResultsFromReferences(references) {
     var style = _settings.arabicStyle || 'uthmani';
@@ -577,22 +576,94 @@
     };
   }
 
+  // ─── Shared Range Utilities ──────────────────────────────────────────────────
+
+  /**
+   * Returns true if results form a consecutive ayah range within one surah.
+   * Requires length > 1, all same surah, and ayahs form an unbroken +1 sequence.
+   * @param {Array<{surah: number, ayah: number}>} results
+   * @return {boolean}
+   */
+  function isConsecutiveRange(results) {
+    if (!results || results.length < 2) return false;
+    var first = results[0];
+    for (var i = 1; i < results.length; i++) {
+      if (results[i].surah !== first.surah) return false;
+      if (results[i].ayah !== first.ayah + i) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Builds a range data object from an array of consecutive result objects.
+   * Concatenates Arabic text with per-ayah markers for display and insert.
+   * @param {Array<Object>} results - Ordered ayah result objects
+   * @return {Object} Range data: { surah, ayahStart, ayahEnd, surahNameArabic, surahNameEnglish, arabicText, translationText }
+   */
+  function buildRangeData(results) {
+    var first = results[0];
+    var last  = results[results.length - 1];
+    var concatenated = results.map(function(r) {
+      return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
+    }).join(' ');
+    return {
+      surah:            first.surah,
+      ayahStart:        first.ayah,
+      ayahEnd:          last.ayah,
+      surahNameArabic:  first.surahNameArabic  || '',
+      surahNameEnglish: first.surahNameEnglish || '',
+      arabicText:       concatenated,
+      translationText:  results.map(function(r) { return r.translationText || ''; }).join(' ')
+    };
+  }
+
+  // ─── Shared Card Builder ─────────────────────────────────────────────────────
+
   /**
    * Build the innerHTML for a single .result-card element.
-   * Highlights matched substring when matchStart/matchEnd are present.
-   * @param {{surah, ayah, surahNameArabic, surahNameEnglish, arabicText, matchStart?, matchEnd?}} r
+   * Handles both single-ayah and range cards via cardData.isRange.
+   * Highlights matched substring via matchStart/matchEnd (single cards only).
+   * No translation is ever rendered on a card; it remains in the data for insert-time use.
+   *
+   * Card structure (stable for future per-card translation toggle):
+   *   .ref-arabic | .arabic[.range-block] | .ref-english | button.btn-insert-result
+   *
+   * @param {Object} cardData
+   *   Single: { surah, ayah, surahNameArabic, surahNameEnglish, arabicText, matchStart?, matchEnd? }
+   *   Range:  { surah, ayahStart, ayahEnd, surahNameArabic, surahNameEnglish, arabicText, isRange: true }
    * @param {string} font - CSS font-family name
    * @return {string} innerHTML for the card
    */
-  function _buildResultCardHtml(r, font) {
-    var arabicRef = escapeHtml(r.surahNameArabic || '') + ' ' + toArabicIndicClient(r.ayah);
-    var englishRef = escapeHtml((r.surahNameEnglish || 'Surah') + ' ' + r.surah + ':' + r.ayah);
-    var arabicHtml = escapeHtml(r.arabicText);
+  function buildCardHtml(cardData, font) {
+    var arabicRef, englishRef, arabicHtml;
 
-    if (r.matchStart != null && r.matchEnd != null && r.matchEnd > r.matchStart) {
-      var before = escapeHtml(r.arabicText.substring(0, r.matchStart));
-      var match  = escapeHtml(r.arabicText.substring(r.matchStart, r.matchEnd));
-      var after  = escapeHtml(r.arabicText.substring(r.matchEnd));
+    if (cardData.isRange) {
+      arabicRef = escapeHtml(cardData.surahNameArabic || '') +
+                  ' ' + toArabicIndicClient(cardData.ayahStart) +
+                  ' - ' + toArabicIndicClient(cardData.ayahEnd);
+      englishRef = escapeHtml(
+        (cardData.surahNameEnglish || 'Surah') + ' ' +
+        cardData.surah + ':' + cardData.ayahStart + '-' + cardData.ayahEnd
+      );
+      arabicHtml = escapeHtml(cardData.arabicText);
+
+      return '<div class="ref-arabic">' + arabicRef + '</div>' +
+        '<div class="arabic range-block" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
+        '<div class="ref-english">' + englishRef + '</div>' +
+        '<button type="button" class="btn-primary btn-insert-result" ' +
+          'data-surah="' + cardData.surah + '" ' +
+          'data-ayah-start="' + cardData.ayahStart + '" ' +
+          'data-ayah-end="' + cardData.ayahEnd + '">Insert</button>';
+    }
+
+    arabicRef = escapeHtml(cardData.surahNameArabic || '') + ' ' + toArabicIndicClient(cardData.ayah);
+    englishRef = escapeHtml((cardData.surahNameEnglish || 'Surah') + ' ' + cardData.surah + ':' + cardData.ayah);
+    arabicHtml = escapeHtml(cardData.arabicText);
+
+    if (cardData.matchStart != null && cardData.matchEnd != null && cardData.matchEnd > cardData.matchStart) {
+      var before = escapeHtml(cardData.arabicText.substring(0, cardData.matchStart));
+      var match  = escapeHtml(cardData.arabicText.substring(cardData.matchStart, cardData.matchEnd));
+      var after  = escapeHtml(cardData.arabicText.substring(cardData.matchEnd));
       arabicHtml = before + '<mark>' + match + '</mark>' + after;
     }
 
@@ -600,105 +671,185 @@
       '<div class="arabic" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
       '<div class="ref-english">' + englishRef + '</div>' +
       '<button type="button" class="btn-primary btn-insert-result" ' +
-        'data-surah="' + r.surah + '" data-ayah="' + r.ayah + '">Insert</button>';
+        'data-surah="' + cardData.surah + '" data-ayah="' + cardData.ayah + '">Insert</button>';
   }
 
-  function renderResults(containerEl, results, type) {
-    containerEl.innerHTML = '';
+  // ─── Rendering Modes ─────────────────────────────────────────────────────────
 
-    if (type === 'range' && results.length > 1) {
-      renderRangeBlock(containerEl, results);
-      return;
-    }
+  /**
+   * Preview mode: renders exactly one card into containerEl.
+   * Single ayah → one card. Multiple ayahs → one combined range card.
+   * Used by Insert tab always, and by AI Search for consecutive references.
+   * @param {Element} containerEl
+   * @param {Array<Object>} results
+   */
+  function renderPreview(containerEl, results) {
+    containerEl.innerHTML = '';
+    if (!results || results.length === 0) return;
 
     var font = formatState.fontName || 'Amiri';
-
-    results.forEach(function(r) {
-      var card = document.createElement('div');
-      card.className = 'result-card';
-      card.innerHTML = _buildResultCardHtml(r, font);
-      containerEl.appendChild(card);
-    });
-  }
-
-  function renderRangeBlock(containerEl, results) {
-    var font  = formatState.fontName || 'Amiri';
-    var first = results[0];
-    var last  = results[results.length - 1];
-    var showTrans = _settings.showTranslation !== false;
-
-    var concatenated = results.map(function(r) {
-      return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
-    }).join(' ');
-
-    _currentRange = {
-      surah:            first.surah,
-      ayahStart:        first.ayah,
-      ayahEnd:          last.ayah,
-      arabicText:       concatenated,
-      translationText:  results.map(function(r) { return r.translationText || ''; }).join(' '),
-      surahNameArabic:  first.surahNameArabic  || '',
-      surahNameEnglish: first.surahNameEnglish || ''
-    };
-
-    var arabicRef = escapeHtml(first.surahNameArabic || '') +
-                    ' ' + toArabicIndicClient(first.ayah) +
-                    ' - ' + toArabicIndicClient(last.ayah);
-    var englishRef = escapeHtml(
-      (first.surahNameEnglish || 'Surah') + ' ' +
-      first.surah + ':' + first.ayah + '-' + last.ayah
-    );
-
-    var html =
-      '<div class="ref-arabic">' + arabicRef + '</div>' +
-      '<div class="arabic range-block" style="font-family:' + escapeHtml(font) + ',serif">' +
-        escapeHtml(concatenated) +
-      '</div>' +
-      '<div class="ref-english">' + englishRef + '</div>';
-
-    if (showTrans) {
-      var translationConcatenated = results.map(function(r) {
-        return escapeHtml(r.translationText || '');
-      }).join(' ');
-
-      if (translationConcatenated.trim()) {
-        html += '<div class="translation">' + translationConcatenated + '</div>';
-      }
-    }
-
-    html += '<button type="button" class="btn-primary btn-insert-result btn-insert-range">Insert</button>';
-
     var card = document.createElement('div');
     card.className = 'result-card';
-    card.innerHTML = html;
+
+    if (results.length === 1) {
+      card.innerHTML = buildCardHtml(results[0], font);
+    } else {
+      var rangeData = buildRangeData(results);
+      rangeData.isRange = true;
+      card.innerHTML = buildCardHtml(rangeData, font);
+    }
+
     containerEl.appendChild(card);
   }
 
+  // ─── Shared Pagination Module ─────────────────────────────────────────────────
+
+  var _pagState = {};
+
+  /**
+   * Initialize or reset pagination state for a tab with a new results array.
+   * @param {string} tabId
+   * @param {Array<Object>} results
+   */
+  function pagReset(tabId, results) {
+    _pagState[tabId] = { results: results || [], page: 0 };
+  }
+
+  /**
+   * Render the next page of results for a tab.
+   * Clears the container on page 0. Appends a "Show more" button if more results remain.
+   * Tab switching does NOT reset state; only pagClear or pagReset do.
+   * @param {string} tabId
+   * @param {Element} containerEl
+   * @param {Element} emptyEl
+   * @param {string} emptyMsg - Message shown when results array is empty
+   */
+  function pagRenderPage(tabId, containerEl, emptyEl, emptyMsg) {
+    var state = _pagState[tabId];
+    if (!state) { state = { results: [], page: 0 }; _pagState[tabId] = state; }
+
+    if (state.page === 0) {
+      containerEl.innerHTML = '';
+    }
+
+    if (state.results.length === 0 && state.page === 0) {
+      emptyEl.textContent = emptyMsg;
+      emptyEl.classList.remove('hidden');
+      return;
+    }
+    emptyEl.classList.add('hidden');
+
+    var oldBtn = containerEl.querySelector('.btn-show-more');
+    if (oldBtn) oldBtn.remove();
+
+    var start = state.page * PAGE_SIZE;
+    var end = Math.min(start + PAGE_SIZE, state.results.length);
+    var font = formatState.fontName || 'Amiri';
+
+    for (var i = start; i < end; i++) {
+      var card = document.createElement('div');
+      card.className = 'result-card';
+      card.innerHTML = buildCardHtml(state.results[i], font);
+      containerEl.appendChild(card);
+    }
+
+    state.page++;
+
+    if (end < state.results.length) {
+      var remaining = state.results.length - end;
+      var showMore = document.createElement('button');
+      showMore.type = 'button';
+      showMore.className = 'btn-show-more';
+      showMore.textContent = 'Show more (' + remaining + ' remaining)';
+      (function(tid, cEl, eEl, msg) {
+        showMore.addEventListener('click', function() {
+          pagRenderPage(tid, cEl, eEl, msg);
+        });
+      }(tabId, containerEl, emptyEl, emptyMsg));
+      containerEl.appendChild(showMore);
+    }
+  }
+
+  /**
+   * Clear pagination state for a tab. Called on new search or explicit clear actions.
+   * @param {string} tabId
+   */
+  function pagClear(tabId) {
+    _pagState[tabId] = { results: [], page: 0 };
+  }
+
+  /**
+   * Shared insert handler for all tabs and all card types.
+   * Detects range cards by the presence of data-ayah-start; rebuilds range data from
+   * client caches at click time so no global state is needed and arabic-style is respected.
+   */
   function onInsertClick(e) {
     var btn = e.target;
     if (btn.tagName !== 'BUTTON' || !btn.classList.contains('btn-insert-result')) return;
 
-    if (btn.classList.contains('btn-insert-range')) {
-      handleRangeInsertClick(btn);
+    btn.disabled = true;
+    btn.classList.add('btn-loading');
+
+    var fs = window.getFormatState ? window.getFormatState() : {};
+
+    if (btn.getAttribute('data-ayah-start')) {
+      var surah     = parseInt(btn.getAttribute('data-surah'), 10);
+      var ayahStart = parseInt(btn.getAttribute('data-ayah-start'), 10);
+      var ayahEnd   = parseInt(btn.getAttribute('data-ayah-end'), 10);
+      if (!surah || !ayahStart || !ayahEnd) {
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
+        return;
+      }
+
+      var style = _settings.arabicStyle || 'uthmani';
+      var rangeItems = [];
+      for (var i = ayahStart; i <= ayahEnd; i++) {
+        var d = _buildAyahDataForInsert(surah, i, style);
+        if (d) rangeItems.push(d);
+      }
+
+      if (!rangeItems.length) {
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
+        return;
+      }
+
+      var rangeData = buildRangeData(rangeItems);
+
+      google.script.run
+        .withSuccessHandler(function(result) {
+          btn.disabled = false;
+          btn.classList.remove('btn-loading');
+          if (result && !result.success) {
+            console.warn('Range insert warning:', result.message);
+          }
+        })
+        .withFailureHandler(function(err) {
+          btn.disabled = false;
+          btn.classList.remove('btn-loading');
+          console.error('Range insert failed:', err);
+        })
+        .insertAyahRange(rangeData, fs, _settings);
       return;
     }
 
-    var surah = parseInt(btn.getAttribute('data-surah'), 10);
-    var ayah = parseInt(btn.getAttribute('data-ayah'), 10);
-    if (!surah || !ayah) return;
+    var surahNum = parseInt(btn.getAttribute('data-surah'), 10);
+    var ayahNum  = parseInt(btn.getAttribute('data-ayah'), 10);
+    if (!surahNum || !ayahNum) {
+      btn.disabled = false;
+      btn.classList.remove('btn-loading');
+      return;
+    }
 
-    btn.disabled = true;
-    btn.classList.add('btn-loading');
-    var style = _settings.arabicStyle || 'uthmani';
-
-    var ayahData = _buildAyahDataForInsert(surah, ayah, style);
+    var insertStyle = _settings.arabicStyle || 'uthmani';
+    var ayahData = _buildAyahDataForInsert(surahNum, ayahNum, insertStyle);
     if (!ayahData) {
       btn.disabled = false;
       btn.classList.remove('btn-loading');
       return;
     }
 
-    var fs = window.getFormatState ? window.getFormatState() : {};
     google.script.run
       .withSuccessHandler(function(result) {
         btn.disabled = false;
@@ -713,30 +864,6 @@
         console.error('Insert failed:', err);
       })
       .insertAyah(ayahData, fs, _settings);
-  }
-
-  function handleRangeInsertClick(btn) {
-    if (!_currentRange) return;
-
-    btn.disabled = true;
-    btn.classList.add('btn-loading');
-
-    var fs = window.getFormatState ? window.getFormatState() : {};
-
-    google.script.run
-      .withSuccessHandler(function(result) {
-        btn.disabled = false;
-        btn.classList.remove('btn-loading');
-        if (result && !result.success) {
-          console.warn('Range insert warning:', result.message);
-        }
-      })
-      .withFailureHandler(function(err) {
-        btn.disabled = false;
-        btn.classList.remove('btn-loading');
-        console.error('Range insert failed:', err);
-      })
-      .insertAyahRange(_currentRange, fs, _settings);
   }
 
   function setupTextarea(el, onSubmit) {
@@ -817,8 +944,8 @@
       var end = endNum || startNum;
       var rangeSize = end - startNum + 1;
 
-      if (rangeSize > 30) {
-        emptyEl.textContent = 'Range too large. Maximum is 30 ayahs.';
+      if (rangeSize > MAX_RESULTS) {
+        emptyEl.textContent = 'Range too large. Maximum is ' + MAX_RESULTS + ' ayahs.';
         emptyEl.classList.remove('hidden');
         return;
       }
@@ -845,7 +972,7 @@
         });
       }
 
-      renderResults(resultsEl, results, results.length > 1 ? 'range' : 'single');
+      renderPreview(resultsEl, results);
     }
 
     surahSelect.addEventListener('change', function() {
@@ -896,13 +1023,9 @@
     if (ayahEnd) { ayahEnd.innerHTML = '<option value="">To</option>'; ayahEnd.disabled = true; }
     if (resultsEl) resultsEl.innerHTML = '';
     if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
-    _currentRange = null;
   }
 
   // ─── Exact Search Tab ────────────────────────────────────────────────────────
-
-  var _exactSearchAllResults = [];
-  var _exactSearchPage = 0;
 
   function initExactSearchTab() {
     var queryEl = document.getElementById('exact-search-query');
@@ -916,15 +1039,13 @@
 
       var query = queryEl ? queryEl.value.trim() : '';
       if (!query) {
-        _exactSearchAllResults = [];
-        _exactSearchPage = 0;
+        pagClear('exact-search');
         if (resultsEl) resultsEl.innerHTML = '';
         if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
         return;
       }
       if (query.length < EXACT_MIN_CHARS) {
-        _exactSearchAllResults = [];
-        _exactSearchPage = 0;
+        pagClear('exact-search');
         if (resultsEl) resultsEl.innerHTML = '';
         if (emptyEl) {
           emptyEl.textContent = 'Type at least ' + EXACT_MIN_CHARS + ' characters\u2026';
@@ -933,51 +1054,8 @@
         return;
       }
 
-      _exactSearchAllResults = searchImlaeiClient(query);
-      _exactSearchPage = 0;
-      renderExactPage(resultsEl, emptyEl);
-    }
-
-    function renderExactPage(container, emptyState) {
-      if (_exactSearchPage === 0) {
-        container.innerHTML = '';
-      }
-
-      if (_exactSearchAllResults.length === 0 && _exactSearchPage === 0) {
-        emptyState.textContent = 'No exact matches found.';
-        emptyState.classList.remove('hidden');
-        return;
-      }
-      emptyState.classList.add('hidden');
-
-      var oldBtn = container.querySelector('.btn-show-more');
-      if (oldBtn) oldBtn.remove();
-
-      var start = _exactSearchPage * EXACT_PAGE_SIZE;
-      var end = Math.min(start + EXACT_PAGE_SIZE, _exactSearchAllResults.length);
-      var font = formatState.fontName || 'Amiri';
-
-      for (var i = start; i < end; i++) {
-        var r = _exactSearchAllResults[i];
-        var card = document.createElement('div');
-        card.className = 'result-card';
-        card.innerHTML = _buildResultCardHtml(r, font);
-        container.appendChild(card);
-      }
-
-      _exactSearchPage++;
-
-      if (end < _exactSearchAllResults.length) {
-        var remaining = _exactSearchAllResults.length - end;
-        var showMore = document.createElement('button');
-        showMore.type = 'button';
-        showMore.className = 'btn-show-more';
-        showMore.textContent = 'Show more (' + remaining + ' remaining)';
-        showMore.addEventListener('click', function() {
-          renderExactPage(container, emptyState);
-        });
-        container.appendChild(showMore);
-      }
+      pagReset('exact-search', searchImlaeiClient(query));
+      pagRenderPage('exact-search', resultsEl, emptyEl, 'No exact matches found.');
     }
 
     queryEl.addEventListener('input', function() {
@@ -987,16 +1065,14 @@
       var val = queryEl.value;
       if (!val || !val.trim()) {
         if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
-        _exactSearchAllResults = [];
-        _exactSearchPage = 0;
+        pagClear('exact-search');
         if (resultsEl) resultsEl.innerHTML = '';
         if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
         return;
       }
       if (val.trim().length < EXACT_MIN_CHARS) {
         if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
-        _exactSearchAllResults = [];
-        _exactSearchPage = 0;
+        pagClear('exact-search');
         if (resultsEl) resultsEl.innerHTML = '';
         if (emptyEl) {
           emptyEl.textContent = 'Type at least ' + EXACT_MIN_CHARS + ' characters\u2026';
@@ -1020,8 +1096,7 @@
   }
 
   function clearExactSearch() {
-    _exactSearchAllResults = [];
-    _exactSearchPage = 0;
+    pagClear('exact-search');
     var queryEl = document.getElementById('exact-search-query');
     var resultsEl = document.getElementById('exact-search-results');
     var emptyEl = document.getElementById('exact-search-empty');
@@ -1048,6 +1123,7 @@
     }
 
     function clearAIResults() {
+      pagClear('ai-search');
       resultsEl.innerHTML = '';
       clarifyEl.classList.add('hidden');
       clarifyEl.textContent = '';
@@ -1124,7 +1200,7 @@
       // Non-clarify response breaks the conversation chain
       _conversationMessages = [];
 
-      // Arabic corpus search: run client-side against imlaei cache
+      // Arabic corpus search: run client-side against imlaei cache, show paginated results
       if (response.type === 'arabic_search') {
         var searchResults = searchImlaeiClient(response.query);
         if (!searchResults.length) {
@@ -1132,11 +1208,14 @@
           emptyEl.classList.remove('hidden');
           return;
         }
-        renderResults(resultsEl, searchResults, 'search');
+        pagReset('ai-search', searchResults);
+        pagRenderPage('ai-search', resultsEl, emptyEl, 'No exact matches found for that text.');
         return;
       }
 
       // References type: resolve against client-side caches
+      // Consecutive range in one surah → preview mode (one card)
+      // Non-consecutive or multi-surah → paginated search results mode
       if (response.type === 'references') {
         var refs = response.references || [];
         var resolved = _buildResultsFromReferences(refs);
@@ -1145,11 +1224,12 @@
           emptyEl.classList.remove('hidden');
           return;
         }
-        var isConsecutiveRange = refs.length > 1
-          && refs[0].surah === refs[refs.length - 1].surah
-          && refs[refs.length - 1].ayah - refs[0].ayah === refs.length - 1;
-        var renderType = isConsecutiveRange ? 'range' : 'search';
-        renderResults(resultsEl, resolved, renderType);
+        if (isConsecutiveRange(resolved)) {
+          renderPreview(resultsEl, resolved);
+        } else {
+          pagReset('ai-search', resolved);
+          pagRenderPage('ai-search', resultsEl, emptyEl, 'No verified results found. Try a different query.');
+        }
         return;
       }
 
@@ -1164,6 +1244,7 @@
 
   function clearAISearch() {
     _conversationMessages = [];
+    pagClear('ai-search');
     var queryEl = document.getElementById('ai-search-query');
     var resultsEl = document.getElementById('ai-search-results');
     var clarifyEl = document.getElementById('ai-search-clarify');

--- a/tests/buildResultCardHtml.test.js
+++ b/tests/buildResultCardHtml.test.js
@@ -1,12 +1,18 @@
 'use strict';
 
 /**
- * Node tests for _buildResultCardHtml (sidebar result-card builder).
- * Tests the shared helper that both exact search and AI search tabs use.
+ * Node tests for the shared sidebar card-building and pagination utilities:
+ *   buildCardHtml, isConsecutiveRange, buildRangeData, pagReset/pagRenderPage/pagClear.
+ *
+ * These functions live inside the IIFE in sidebar/sidebar-js.html. This file
+ * duplicates their implementations so they can be tested in Node without a DOM.
+ *
  * Run: npm run test:card
  */
 
 const assert = require('assert');
+
+// ─── Helpers duplicated from sidebar-js.html ────────────────────────────────
 
 var _ARABIC_INDIC = ['٠','١','٢','٣','٤','٥','٦','٧','٨','٩'];
 
@@ -25,15 +31,69 @@ function escapeHtml(s) {
     .replace(/"/g, '&quot;');
 }
 
-function _buildResultCardHtml(r, font) {
-  var arabicRef = escapeHtml(r.surahNameArabic || '') + ' ' + toArabicIndicClient(r.ayah);
-  var englishRef = escapeHtml((r.surahNameEnglish || 'Surah') + ' ' + r.surah + ':' + r.ayah);
-  var arabicHtml = escapeHtml(r.arabicText);
+// ─── isConsecutiveRange ───────────────────────────────────────────────────────
 
-  if (r.matchStart != null && r.matchEnd != null && r.matchEnd > r.matchStart) {
-    var before = escapeHtml(r.arabicText.substring(0, r.matchStart));
-    var match  = escapeHtml(r.arabicText.substring(r.matchStart, r.matchEnd));
-    var after  = escapeHtml(r.arabicText.substring(r.matchEnd));
+function isConsecutiveRange(results) {
+  if (!results || results.length < 2) return false;
+  var first = results[0];
+  for (var i = 1; i < results.length; i++) {
+    if (results[i].surah !== first.surah) return false;
+    if (results[i].ayah !== first.ayah + i) return false;
+  }
+  return true;
+}
+
+// ─── buildRangeData ───────────────────────────────────────────────────────────
+
+function buildRangeData(results) {
+  var first = results[0];
+  var last  = results[results.length - 1];
+  var concatenated = results.map(function(r) {
+    return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
+  }).join(' ');
+  return {
+    surah:            first.surah,
+    ayahStart:        first.ayah,
+    ayahEnd:          last.ayah,
+    surahNameArabic:  first.surahNameArabic  || '',
+    surahNameEnglish: first.surahNameEnglish || '',
+    arabicText:       concatenated,
+    translationText:  results.map(function(r) { return r.translationText || ''; }).join(' ')
+  };
+}
+
+// ─── buildCardHtml ────────────────────────────────────────────────────────────
+
+function buildCardHtml(cardData, font) {
+  var arabicRef, englishRef, arabicHtml;
+
+  if (cardData.isRange) {
+    arabicRef = escapeHtml(cardData.surahNameArabic || '') +
+                ' ' + toArabicIndicClient(cardData.ayahStart) +
+                ' - ' + toArabicIndicClient(cardData.ayahEnd);
+    englishRef = escapeHtml(
+      (cardData.surahNameEnglish || 'Surah') + ' ' +
+      cardData.surah + ':' + cardData.ayahStart + '-' + cardData.ayahEnd
+    );
+    arabicHtml = escapeHtml(cardData.arabicText);
+
+    return '<div class="ref-arabic">' + arabicRef + '</div>' +
+      '<div class="arabic range-block" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
+      '<div class="ref-english">' + englishRef + '</div>' +
+      '<button type="button" class="btn-primary btn-insert-result" ' +
+        'data-surah="' + cardData.surah + '" ' +
+        'data-ayah-start="' + cardData.ayahStart + '" ' +
+        'data-ayah-end="' + cardData.ayahEnd + '">Insert</button>';
+  }
+
+  arabicRef = escapeHtml(cardData.surahNameArabic || '') + ' ' + toArabicIndicClient(cardData.ayah);
+  englishRef = escapeHtml((cardData.surahNameEnglish || 'Surah') + ' ' + cardData.surah + ':' + cardData.ayah);
+  arabicHtml = escapeHtml(cardData.arabicText);
+
+  if (cardData.matchStart != null && cardData.matchEnd != null && cardData.matchEnd > cardData.matchStart) {
+    var before = escapeHtml(cardData.arabicText.substring(0, cardData.matchStart));
+    var match  = escapeHtml(cardData.arabicText.substring(cardData.matchStart, cardData.matchEnd));
+    var after  = escapeHtml(cardData.arabicText.substring(cardData.matchEnd));
     arabicHtml = before + '<mark>' + match + '</mark>' + after;
   }
 
@@ -41,207 +101,514 @@ function _buildResultCardHtml(r, font) {
     '<div class="arabic" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
     '<div class="ref-english">' + englishRef + '</div>' +
     '<button type="button" class="btn-primary btn-insert-result" ' +
-      'data-surah="' + r.surah + '" data-ayah="' + r.ayah + '">Insert</button>';
+      'data-surah="' + cardData.surah + '" data-ayah="' + cardData.ayah + '">Insert</button>';
 }
+
+// ─── Minimal DOM stub for pagination tests ────────────────────────────────────
+
+function makeEl(tag) {
+  var children = [];
+  var text = '';
+  var classSet = new Set();
+  return {
+    tagName: tag,
+    get textContent() { return text; },
+    set textContent(v) { text = v; },
+    get innerHTML() { return children.map(function(c) { return c._raw || ''; }).join(''); },
+    set innerHTML(v) {
+      // Clear in-place to preserve the `children` reference used by _children
+      children.length = 0;
+      if (v) children.push({ _raw: v });
+    },
+    classList: {
+      add: function(c) { classSet.add(c); },
+      remove: function(c) { classSet.delete(c); },
+      contains: function(c) { return classSet.has(c); }
+    },
+    appendChild: function(child) { children.push(child); },
+    querySelector: function(sel) {
+      // only handles '.classname' lookups for these tests
+      var cls = sel.replace('.', '');
+      for (var i = 0; i < children.length; i++) {
+        if (children[i] && children[i]._className === cls) return children[i];
+      }
+      return null;
+    },
+    // _children always reflects the live children array
+    get _children() { return children; }
+  };
+}
+
+function makeBtn(cls, text) {
+  return { _className: cls, type: 'button', textContent: text, _events: {}, addEventListener: function(ev, fn) { this._events[ev] = fn; }, remove: function() {} };
+}
+
+// ─── Pagination stub ──────────────────────────────────────────────────────────
+
+var PAGE_SIZE = 10;
+var _pagState = {};
+
+function pagReset(tabId, results) {
+  _pagState[tabId] = { results: results || [], page: 0 };
+}
+
+function pagClear(tabId) {
+  _pagState[tabId] = { results: [], page: 0 };
+}
+
+function pagRenderPage(tabId, containerEl, emptyEl, emptyMsg) {
+  var state = _pagState[tabId];
+  if (!state) { state = { results: [], page: 0 }; _pagState[tabId] = state; }
+
+  if (state.page === 0) {
+    containerEl.innerHTML = '';
+  }
+
+  if (state.results.length === 0 && state.page === 0) {
+    emptyEl.textContent = emptyMsg;
+    emptyEl.classList.remove('hidden');
+    return;
+  }
+  emptyEl.classList.add('hidden');
+
+  var oldBtn = containerEl.querySelector('.btn-show-more');
+  if (oldBtn) oldBtn.remove();
+
+  var start = state.page * PAGE_SIZE;
+  var end = Math.min(start + PAGE_SIZE, state.results.length);
+
+  for (var i = start; i < end; i++) {
+    var card = { _raw: '<card>' + i + '</card>', _className: 'result-card' };
+    containerEl.appendChild(card);
+  }
+
+  state.page++;
+
+  if (end < state.results.length) {
+    var remaining = state.results.length - end;
+    var showMore = makeBtn('btn-show-more', 'Show more (' + remaining + ' remaining)');
+    (function(tid, cEl, eEl, msg) {
+      showMore.addEventListener('click', function() {
+        pagRenderPage(tid, cEl, eEl, msg);
+      });
+    }(tabId, containerEl, emptyEl, emptyMsg));
+    containerEl.appendChild(showMore);
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
 
 function runTests() {
   var tests = [];
+  function it(label, fn) { tests.push({ label: label, fn: fn }); }
 
-  function it(label, fn) {
-    tests.push({ label: label, fn: fn });
-  }
+  // ─── isConsecutiveRange ──────────────────────────────────────────────────
 
-  // ─── Highlighting ──────────────────────────────────────────────────────────
+  it('returns false for empty array', function () {
+    assert.strictEqual(isConsecutiveRange([]), false);
+  });
 
-  it('wraps matched substring in <mark> when matchStart/matchEnd present', function () {
+  it('returns false for single-element array', function () {
+    assert.strictEqual(isConsecutiveRange([{ surah: 2, ayah: 255 }]), false);
+  });
+
+  it('returns true for two consecutive ayahs in same surah', function () {
+    assert.strictEqual(isConsecutiveRange([
+      { surah: 2, ayah: 255 },
+      { surah: 2, ayah: 256 }
+    ]), true);
+  });
+
+  it('returns true for three consecutive ayahs', function () {
+    assert.strictEqual(isConsecutiveRange([
+      { surah: 2, ayah: 255 },
+      { surah: 2, ayah: 256 },
+      { surah: 2, ayah: 257 }
+    ]), true);
+  });
+
+  it('returns false when ayahs skip a number', function () {
+    assert.strictEqual(isConsecutiveRange([
+      { surah: 2, ayah: 255 },
+      { surah: 2, ayah: 257 }
+    ]), false);
+  });
+
+  it('returns false when surahs differ', function () {
+    assert.strictEqual(isConsecutiveRange([
+      { surah: 2, ayah: 255 },
+      { surah: 3, ayah: 256 }
+    ]), false);
+  });
+
+  it('returns false for mixed-surah range even if ayah numbers are consecutive', function () {
+    assert.strictEqual(isConsecutiveRange([
+      { surah: 2, ayah: 1 },
+      { surah: 3, ayah: 2 }
+    ]), false);
+  });
+
+  // ─── buildRangeData ──────────────────────────────────────────────────────
+
+  it('sets surah, ayahStart, ayahEnd from first/last items', function () {
+    var results = [
+      { surah: 2, ayah: 255, arabicText: 'آية ٢٥٥', surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', translationText: 'Allah - there is no deity' },
+      { surah: 2, ayah: 256, arabicText: 'آية ٢٥٦', surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', translationText: 'There shall be no compulsion' }
+    ];
+    var data = buildRangeData(results);
+    assert.strictEqual(data.surah, 2);
+    assert.strictEqual(data.ayahStart, 255);
+    assert.strictEqual(data.ayahEnd, 256);
+    assert.strictEqual(data.surahNameArabic, 'البقرة');
+    assert.strictEqual(data.surahNameEnglish, 'Al-Baqarah');
+  });
+
+  it('concatenates arabicText with ayah markers', function () {
+    var results = [
+      { surah: 1, ayah: 1, arabicText: 'بسم الله', surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah', translationText: '' },
+      { surah: 1, ayah: 2, arabicText: 'الحمد لله', surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah', translationText: '' }
+    ];
+    var data = buildRangeData(results);
+    assert.ok(data.arabicText.indexOf('بسم الله') >= 0, 'first ayah text present');
+    assert.ok(data.arabicText.indexOf('الحمد لله') >= 0, 'second ayah text present');
+    assert.ok(data.arabicText.indexOf(toArabicIndicClient(1)) >= 0, 'ayah 1 marker present');
+    assert.ok(data.arabicText.indexOf(toArabicIndicClient(2)) >= 0, 'ayah 2 marker present');
+  });
+
+  it('joins translationText for all ayahs', function () {
+    var results = [
+      { surah: 2, ayah: 255, arabicText: 'text', surahNameArabic: '', surahNameEnglish: '', translationText: 'First translation' },
+      { surah: 2, ayah: 256, arabicText: 'text', surahNameArabic: '', surahNameEnglish: '', translationText: 'Second translation' }
+    ];
+    var data = buildRangeData(results);
+    assert.ok(data.translationText.indexOf('First translation') >= 0);
+    assert.ok(data.translationText.indexOf('Second translation') >= 0);
+  });
+
+  it('handles missing translationText gracefully', function () {
+    var results = [
+      { surah: 1, ayah: 1, arabicText: 'text', surahNameArabic: '', surahNameEnglish: '' }
+    ];
+    var data = buildRangeData([results[0], results[0]]);
+    assert.strictEqual(typeof data.translationText, 'string');
+  });
+
+  // ─── buildCardHtml — single card ─────────────────────────────────────────
+
+  it('single: wraps matched substring in <mark>', function () {
     var r = {
       surah: 1, ayah: 1,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
       arabicText: 'بسم الله الرحمن الرحيم',
       matchStart: 0, matchEnd: 3
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
-    assert.ok(html.indexOf('<mark>بسم</mark>') >= 0, 'matched text should be wrapped in <mark>');
-    assert.ok(html.indexOf(' الله الرحمن الرحيم') >= 0, 'rest of text should follow');
+    var html = buildCardHtml(r, 'Amiri');
+    assert.ok(html.indexOf('<mark>بسم</mark>') >= 0, 'matched text wrapped in <mark>');
+    assert.ok(html.indexOf(' الله الرحمن الرحيم') >= 0, 'rest of text follows');
   });
 
-  it('highlights match in the middle of the text', function () {
+  it('single: highlights match in the middle of text', function () {
     var r = {
       surah: 2, ayah: 255,
-      surahNameArabic: 'البقرة',
-      surahNameEnglish: 'Al-Baqarah',
+      surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah',
       arabicText: 'الله لا اله الا هو',
       matchStart: 5, matchEnd: 7
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
-    assert.ok(html.indexOf('<mark>لا</mark>') >= 0, 'middle match should be highlighted');
+    var html = buildCardHtml(r, 'Amiri');
+    assert.ok(html.indexOf('<mark>لا</mark>') >= 0, 'middle match highlighted');
   });
 
-  it('highlights match at end of text', function () {
+  it('single: highlights match at end of text', function () {
     var r = {
       surah: 1, ayah: 1,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
       arabicText: 'بسم الله',
       matchStart: 4, matchEnd: 8
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
-    assert.ok(html.indexOf('<mark>الله</mark>') >= 0, 'match at end should be highlighted');
+    var html = buildCardHtml(r, 'Amiri');
+    assert.ok(html.indexOf('<mark>الله</mark>') >= 0, 'end match highlighted');
   });
 
-  // ─── No highlighting ──────────────────────────────────────────────────────
-
-  it('does not produce <mark> when matchStart/matchEnd are absent', function () {
+  it('single: no <mark> when matchStart/matchEnd absent', function () {
     var r = {
       surah: 1, ayah: 2,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
       arabicText: 'الحمد لله رب العالمين'
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.strictEqual(html.indexOf('<mark>'), -1, 'no <mark> without match data');
   });
 
-  it('does not produce <mark> when matchStart/matchEnd are null', function () {
+  it('single: no <mark> when matchStart/matchEnd are null', function () {
     var r = {
       surah: 1, ayah: 2,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
       arabicText: 'الحمد لله رب العالمين',
       matchStart: null, matchEnd: null
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.strictEqual(html.indexOf('<mark>'), -1, 'no <mark> with null match data');
   });
 
-  it('does not produce <mark> when matchEnd <= matchStart', function () {
+  it('single: no <mark> when matchEnd <= matchStart', function () {
     var r = {
       surah: 1, ayah: 1,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
       arabicText: 'بسم الله',
       matchStart: 3, matchEnd: 3
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.strictEqual(html.indexOf('<mark>'), -1, 'no <mark> when matchEnd equals matchStart');
   });
 
-  // ─── No translation ───────────────────────────────────────────────────────
-
-  it('never renders a translation row even when translationText is present', function () {
+  it('single: never renders a translation row', function () {
     var r = {
       surah: 1, ayah: 1,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
       arabicText: 'بسم الله الرحمن الرحيم',
       translationText: 'In the name of Allah, the Most Gracious, the Most Merciful'
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.strictEqual(html.indexOf('translation'), -1, 'no translation class in output');
     assert.strictEqual(html.indexOf('Most Gracious'), -1, 'translation text not rendered');
   });
 
-  // ─── Card structure ────────────────────────────────────────────────────────
-
-  it('includes Arabic reference with Arabic-Indic ayah number', function () {
+  it('single: includes Arabic reference with Arabic-Indic ayah number', function () {
     var r = {
       surah: 2, ayah: 255,
-      surahNameArabic: 'البقرة',
-      surahNameEnglish: 'Al-Baqarah',
+      surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah',
       arabicText: 'الله لا اله الا هو'
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.ok(html.indexOf('البقرة ٢٥٥') >= 0, 'Arabic ref with Indic digits');
   });
 
-  it('includes English reference with Western numerals', function () {
+  it('single: includes English reference with Western numerals', function () {
     var r = {
       surah: 2, ayah: 255,
-      surahNameArabic: 'البقرة',
-      surahNameEnglish: 'Al-Baqarah',
+      surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah',
       arabicText: 'الله لا اله الا هو'
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.ok(html.indexOf('Al-Baqarah 2:255') >= 0, 'English ref present');
   });
 
-  it('includes insert button with correct data attributes', function () {
+  it('single: insert button has data-surah and data-ayah', function () {
     var r = {
       surah: 3, ayah: 18,
-      surahNameArabic: 'آل عمران',
-      surahNameEnglish: 'Ali Imran',
+      surahNameArabic: 'آل عمران', surahNameEnglish: 'Ali Imran',
       arabicText: 'شهد الله'
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.ok(html.indexOf('data-surah="3"') >= 0, 'data-surah present');
     assert.ok(html.indexOf('data-ayah="18"') >= 0, 'data-ayah present');
     assert.ok(html.indexOf('btn-insert-result') >= 0, 'insert button class present');
+    assert.strictEqual(html.indexOf('data-ayah-start'), -1, 'no data-ayah-start on single card');
   });
 
-  it('applies the specified font family', function () {
+  it('single: applies specified font family', function () {
     var r = {
       surah: 1, ayah: 1,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
       arabicText: 'بسم الله'
     };
-    var html = _buildResultCardHtml(r, 'Scheherazade New');
+    var html = buildCardHtml(r, 'Scheherazade New');
     assert.ok(html.indexOf('font-family:Scheherazade New,serif') >= 0, 'custom font applied');
   });
 
-  // ─── XSS safety ────────────────────────────────────────────────────────────
-
-  it('escapes HTML in arabicText', function () {
+  it('single: falls back to "Surah" when surahNameEnglish is empty', function () {
     var r = {
       surah: 1, ayah: 1,
-      surahNameArabic: 'الفاتحة',
-      surahNameEnglish: 'Al-Fatihah',
-      arabicText: '<script>alert("xss")</script>'
-    };
-    var html = _buildResultCardHtml(r, 'Amiri');
-    assert.strictEqual(html.indexOf('<script>'), -1, 'script tag should be escaped');
-    assert.ok(html.indexOf('&lt;script&gt;') >= 0, 'escaped script tag present');
-  });
-
-  it('escapes HTML in surahNameArabic and surahNameEnglish', function () {
-    var r = {
-      surah: 1, ayah: 1,
-      surahNameArabic: '<b>bold</b>',
-      surahNameEnglish: '<i>italic</i>',
-      arabicText: 'text'
-    };
-    var html = _buildResultCardHtml(r, 'Amiri');
-    assert.strictEqual(html.indexOf('<b>bold</b>'), -1, 'bold tag escaped in Arabic ref');
-    assert.strictEqual(html.indexOf('<i>italic</i>'), -1, 'italic tag escaped in English ref');
-  });
-
-  it('escapes HTML in matched substring', function () {
-    var r = {
-      surah: 1, ayah: 1,
-      surahNameArabic: 'test',
-      surahNameEnglish: 'Test',
-      arabicText: 'ab<img>cd',
-      matchStart: 2, matchEnd: 7
-    };
-    var html = _buildResultCardHtml(r, 'Amiri');
-    assert.ok(html.indexOf('<mark>&lt;img&gt;</mark>') >= 0, 'HTML in match is escaped inside mark');
-  });
-
-  // ─── Edge cases ────────────────────────────────────────────────────────────
-
-  it('falls back to "Surah" when surahNameEnglish is empty', function () {
-    var r = {
-      surah: 1, ayah: 1,
-      surahNameArabic: '',
-      surahNameEnglish: '',
+      surahNameArabic: '', surahNameEnglish: '',
       arabicText: 'بسم الله'
     };
-    var html = _buildResultCardHtml(r, 'Amiri');
+    var html = buildCardHtml(r, 'Amiri');
     assert.ok(html.indexOf('Surah 1:1') >= 0, 'falls back to "Surah"');
   });
 
-  // ─── Run all tests ─────────────────────────────────────────────────────────
+  it('single: does not have range-block class', function () {
+    var r = {
+      surah: 1, ayah: 1,
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
+      arabicText: 'بسم الله'
+    };
+    var html = buildCardHtml(r, 'Amiri');
+    assert.strictEqual(html.indexOf('range-block'), -1, 'no range-block class on single card');
+  });
+
+  // ─── buildCardHtml — range card ──────────────────────────────────────────
+
+  it('range: includes range-block class on arabic element', function () {
+    var data = { isRange: true, surah: 2, ayahStart: 255, ayahEnd: 257, surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', arabicText: 'text' };
+    var html = buildCardHtml(data, 'Amiri');
+    assert.ok(html.indexOf('range-block') >= 0, 'range-block class present');
+  });
+
+  it('range: shows Arabic ref as start - end range', function () {
+    var data = { isRange: true, surah: 2, ayahStart: 255, ayahEnd: 257, surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', arabicText: 'text' };
+    var html = buildCardHtml(data, 'Amiri');
+    var startIndic = toArabicIndicClient(255);
+    var endIndic   = toArabicIndicClient(257);
+    assert.ok(html.indexOf(startIndic) >= 0, 'start ayah in Arabic ref');
+    assert.ok(html.indexOf(endIndic) >= 0, 'end ayah in Arabic ref');
+  });
+
+  it('range: shows English ref as surah:start-end', function () {
+    var data = { isRange: true, surah: 2, ayahStart: 255, ayahEnd: 257, surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', arabicText: 'text' };
+    var html = buildCardHtml(data, 'Amiri');
+    assert.ok(html.indexOf('Al-Baqarah 2:255-257') >= 0, 'English ref with range');
+  });
+
+  it('range: insert button has data-surah, data-ayah-start, data-ayah-end', function () {
+    var data = { isRange: true, surah: 2, ayahStart: 255, ayahEnd: 257, surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', arabicText: 'text' };
+    var html = buildCardHtml(data, 'Amiri');
+    assert.ok(html.indexOf('data-surah="2"') >= 0, 'data-surah present');
+    assert.ok(html.indexOf('data-ayah-start="255"') >= 0, 'data-ayah-start present');
+    assert.ok(html.indexOf('data-ayah-end="257"') >= 0, 'data-ayah-end present');
+    assert.strictEqual(html.indexOf('data-ayah="'), -1, 'no data-ayah on range card');
+  });
+
+  it('range: never renders a translation row', function () {
+    var data = { isRange: true, surah: 2, ayahStart: 255, ayahEnd: 256, surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', arabicText: 'text', translationText: 'Allah - there is no deity' };
+    var html = buildCardHtml(data, 'Amiri');
+    assert.strictEqual(html.indexOf('translation'), -1, 'no translation class in range card');
+    assert.strictEqual(html.indexOf('Allah - there is no deity'), -1, 'translation text not rendered');
+  });
+
+  it('range: does not have <mark> even if match params somehow present', function () {
+    var data = { isRange: true, surah: 2, ayahStart: 1, ayahEnd: 2, surahNameArabic: '', surahNameEnglish: '', arabicText: 'text text', matchStart: 0, matchEnd: 4 };
+    var html = buildCardHtml(data, 'Amiri');
+    assert.strictEqual(html.indexOf('<mark>'), -1, 'no <mark> on range cards');
+  });
+
+  // ─── XSS safety ──────────────────────────────────────────────────────────
+
+  it('escapes HTML in arabicText (single)', function () {
+    var r = {
+      surah: 1, ayah: 1,
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
+      arabicText: '<script>alert("xss")</script>'
+    };
+    var html = buildCardHtml(r, 'Amiri');
+    assert.strictEqual(html.indexOf('<script>'), -1, 'script tag escaped');
+    assert.ok(html.indexOf('&lt;script&gt;') >= 0, 'escaped script tag present');
+  });
+
+  it('escapes HTML in surah names (single)', function () {
+    var r = {
+      surah: 1, ayah: 1,
+      surahNameArabic: '<b>bold</b>', surahNameEnglish: '<i>italic</i>',
+      arabicText: 'text'
+    };
+    var html = buildCardHtml(r, 'Amiri');
+    assert.strictEqual(html.indexOf('<b>bold</b>'), -1);
+    assert.strictEqual(html.indexOf('<i>italic</i>'), -1);
+  });
+
+  it('escapes HTML in matched substring (single)', function () {
+    var r = {
+      surah: 1, ayah: 1,
+      surahNameArabic: 'test', surahNameEnglish: 'Test',
+      arabicText: 'ab<img>cd',
+      matchStart: 2, matchEnd: 7
+    };
+    var html = buildCardHtml(r, 'Amiri');
+    assert.ok(html.indexOf('<mark>&lt;img&gt;</mark>') >= 0, 'HTML in match escaped inside mark');
+  });
+
+  it('escapes HTML in range arabicText', function () {
+    var data = { isRange: true, surah: 1, ayahStart: 1, ayahEnd: 2, surahNameArabic: '', surahNameEnglish: '', arabicText: '<script>xss</script>' };
+    var html = buildCardHtml(data, 'Amiri');
+    assert.strictEqual(html.indexOf('<script>'), -1);
+  });
+
+  // ─── Pagination module ────────────────────────────────────────────────────
+
+  it('pagReset initialises state with page 0', function () {
+    pagReset('test-tab', [{ id: 1 }, { id: 2 }]);
+    assert.strictEqual(_pagState['test-tab'].page, 0);
+    assert.strictEqual(_pagState['test-tab'].results.length, 2);
+  });
+
+  it('pagClear empties results and resets page', function () {
+    pagReset('test-tab', [{ id: 1 }]);
+    pagClear('test-tab');
+    assert.strictEqual(_pagState['test-tab'].results.length, 0);
+    assert.strictEqual(_pagState['test-tab'].page, 0);
+  });
+
+  it('pagRenderPage shows empty message when no results', function () {
+    var container = makeEl('div');
+    var emptyEl = makeEl('div');
+    pagReset('test-empty', []);
+    pagRenderPage('test-empty', container, emptyEl, 'Nothing found.');
+    assert.strictEqual(emptyEl.textContent, 'Nothing found.');
+    assert.ok(emptyEl.classList.contains('hidden') === false, 'emptyEl visible');
+  });
+
+  it('pagRenderPage renders at most PAGE_SIZE items on first page', function () {
+    var items = [];
+    for (var i = 0; i < 25; i++) items.push({ id: i });
+    var container = makeEl('div');
+    var emptyEl = makeEl('div');
+    pagReset('test-pag', items);
+    pagRenderPage('test-pag', container, emptyEl, 'Empty');
+    assert.strictEqual(_pagState['test-pag'].page, 1, 'page incremented to 1');
+    assert.ok(container._children.length <= PAGE_SIZE + 1, 'at most PAGE_SIZE cards + show-more btn');
+  });
+
+  it('pagRenderPage appends Show-more button when items remain', function () {
+    var items = [];
+    for (var i = 0; i < 15; i++) items.push({ id: i });
+    var container = makeEl('div');
+    var emptyEl = makeEl('div');
+    pagReset('test-showmore', items);
+    pagRenderPage('test-showmore', container, emptyEl, 'Empty');
+    var btn = container.querySelector('.btn-show-more');
+    assert.ok(btn, 'Show more button present');
+    assert.ok(btn.textContent.indexOf('5 remaining') >= 0, 'correct remaining count');
+  });
+
+  it('pagRenderPage does NOT append Show-more button when all items fit', function () {
+    var items = [];
+    for (var i = 0; i < 5; i++) items.push({ id: i });
+    var container = makeEl('div');
+    var emptyEl = makeEl('div');
+    pagReset('test-nomore', items);
+    pagRenderPage('test-nomore', container, emptyEl, 'Empty');
+    var btn = container.querySelector('.btn-show-more');
+    assert.strictEqual(btn, null, 'no Show more button when all items fit');
+  });
+
+  it('pagRenderPage appends more items on second call without clearing', function () {
+    var items = [];
+    for (var i = 0; i < 15; i++) items.push({ id: i });
+    var container = makeEl('div');
+    var emptyEl = makeEl('div');
+    pagReset('test-append', items);
+    pagRenderPage('test-append', container, emptyEl, 'Empty');
+    var countAfterFirst = container._children.length;
+    // Trigger second page
+    pagRenderPage('test-append', container, emptyEl, 'Empty');
+    assert.ok(container._children.length > countAfterFirst, 'more items appended on second call');
+  });
+
+  it('pagReset clears page back to 0 for a new search', function () {
+    var items = [];
+    for (var i = 0; i < 15; i++) items.push({ id: i });
+    var container = makeEl('div');
+    var emptyEl = makeEl('div');
+    pagReset('test-newq', items);
+    pagRenderPage('test-newq', container, emptyEl, 'Empty');
+    assert.strictEqual(_pagState['test-newq'].page, 1);
+
+    // new query resets
+    pagReset('test-newq', [{ id: 99 }]);
+    assert.strictEqual(_pagState['test-newq'].page, 0, 'page reset after pagReset');
+    assert.strictEqual(_pagState['test-newq'].results.length, 1, 'new results stored');
+  });
+
+  // ─── Run all tests ────────────────────────────────────────────────────────
 
   var ran = 0;
   var failed = 0;
@@ -256,7 +623,7 @@ function runTests() {
     }
   });
 
-  console.log('\n_buildResultCardHtml: ' + ran + ' passed, ' + failed + ' failed.');
+  console.log('\nCard/range/pagination utilities: ' + ran + ' passed, ' + failed + ' failed.');
   if (failed > 0) process.exit(1);
 }
 


### PR DESCRIPTION
Closes #53

## Summary
- Unified `buildCardHtml(cardData, font)` card builder used by all three tabs — no translation display on any card, stable 4-element structure ready for a future translation toggle
- Shared range utilities: `isConsecutiveRange()` and `buildRangeData()` replace duplicated logic across Insert and AI Search tabs
- Two rendering modes: `renderPreview()` (one card, no pagination) and search results mode via a shared pagination module (`pagReset`/`pagRenderPage`/`pagClear`)
- Consolidated `onInsertClick` handler eliminates `_currentRange` global; detects range cards via `data-ayah-start` and rebuilds range data from caches at click time
- Single source-of-truth constants: `MAX_RESULTS=50`, `PAGE_SIZE=10`, `EXACT_MIN_CHARS=2`, `EXACT_DEBOUNCE_MS=200`
- Test suite expanded from 14 to 42 tests in `test:card` (76 total across all suites)

## Test plan
- [ ] Run `npm test` — all 76 tests pass
- [ ] Insert tab: select single ayah → one card renders
- [ ] Insert tab: select range ≤50 → one range card renders
- [ ] Insert tab: select range >50 → error message shown
- [ ] Exact Search: type query → first 10 results shown, "Show more" button present
- [ ] Exact Search: click "Show more" → next 10 appended, results from first page preserved
- [ ] Exact Search: switch to another tab and back → results still displayed
- [ ] AI Search arabic_search → paginated results (10 at a time)
- [ ] AI Search consecutive references → one range card via preview mode
- [ ] AI Search non-consecutive references → paginated list
- [ ] Insert button works on all card types (single + range) across all tabs

Made with [Cursor](https://cursor.com)