### PR TITLE
Post-insert cursor moves to Normal text line below ayah

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -4,6 +4,38 @@
  */
 
 /**
+ * Body child index where the trailing empty Normal paragraph should be inserted,
+ * immediately after a block that starts at insertIndex with insertedParagraphCount paragraphs.
+ * @param {number} insertIndex
+ * @param {number} insertedParagraphCount
+ * @return {number}
+ */
+function trailingNormalParagraphInsertIndex(insertIndex, insertedParagraphCount) {
+  return insertIndex + insertedParagraphCount;
+}
+
+/**
+ * Inserts an empty Normal-text paragraph below the ayah block and moves the cursor there.
+ * @param {GoogleAppsScript.Document.Body} body
+ * @param {number} insertIndex - body index of the first ayah paragraph inserted
+ * @param {number} insertedParagraphCount - number of ayah paragraphs just inserted
+ */
+function _finishInsertWithNormalLineBelow(body, insertIndex, insertedParagraphCount) {
+  var doc = DocumentApp.getActiveDocument();
+  var nextIdx = trailingNormalParagraphInsertIndex(insertIndex, insertedParagraphCount);
+  var p = body.insertParagraph(nextIdx, '');
+  p.setHeading(DocumentApp.ParagraphHeading.NORMAL);
+  p.setAlignment(DocumentApp.HorizontalAlignment.LEFT);
+  p.setLeftToRight(true);
+  try {
+    var t = p.editAsText();
+    doc.setCursor(doc.newPosition(t, 0));
+  } catch (e) {
+    // Cursor may fail in edge cases; ayah insert still succeeded.
+  }
+}
+
+/**
  * Inserts an ayah into the document at the cursor position.
  * @param {Object} ayahData - { surah, ayah, surahNameArabic, surahNameEnglish, textUthmani, textSimple, translationText }
  * @param {Object} formatState - { fontName, fontSize, bold, textColor }
@@ -67,6 +99,8 @@ function insertAyah(ayahData, formatState, settings) {
     if (paragraphsToInsert[i].rtl) p.setLeftToRight(false);
     fontWarning = applyFormat(p.editAsText(), formatState) || fontWarning;
   }
+
+  _finishInsertWithNormalLineBelow(body, insertIndex, paragraphsToInsert.length);
 
   var message = fontWarning ? 'Ayah inserted. ' + fontWarning : 'Ayah inserted.';
   return { success: true, message: message };
@@ -139,6 +173,8 @@ function insertAyahRange(rangeData, formatState, settings) {
     if (paragraphsToInsert[i].rtl) p.setLeftToRight(false);
     fontWarning = applyFormat(p.editAsText(), formatState) || fontWarning;
   }
+
+  _finishInsertWithNormalLineBelow(body, insertIndex, paragraphsToInsert.length);
 
   return { success: true, message: fontWarning ? 'Range inserted. ' + fontWarning : 'Range inserted.' };
 }

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -1,0 +1,57 @@
+/**
+ * GAS-native tests for DocumentService.gs
+ * Run from Apps Script editor: select runDocumentServiceTests, click Run.
+ *
+ * trailingNormalParagraphInsertIndex is unit-tested here.
+ * _finishInsertWithNormalLineBelow requires a real Document (manual check in a Doc).
+ */
+
+function runDocumentServiceTests() {
+  var passed = 0;
+  var failed = 0;
+  var results = [];
+
+  function it(label, fn) {
+    try {
+      fn();
+      results.push('  ✓ ' + label);
+      passed++;
+    } catch (e) {
+      results.push('  ✗ ' + label + '\n      → ' + (e.message || e));
+      failed++;
+    }
+  }
+
+  function expect(actual) {
+    return {
+      toBe: function (expected) {
+        if (actual !== expected) {
+          throw new Error('Expected ' + JSON.stringify(expected) + ' but got ' + JSON.stringify(actual));
+        }
+      }
+    };
+  }
+
+  results.push('\ntrailingNormalParagraphInsertIndex()');
+
+  it('returns index after one inserted paragraph', function () {
+    expect(trailingNormalParagraphInsertIndex(5, 1)).toBe(6);
+  });
+  it('returns index after two inserted paragraphs', function () {
+    expect(trailingNormalParagraphInsertIndex(3, 2)).toBe(5);
+  });
+  it('handles insertIndex 0', function () {
+    expect(trailingNormalParagraphInsertIndex(0, 1)).toBe(1);
+  });
+  it('handles zero inserted count (edge)', function () {
+    expect(trailingNormalParagraphInsertIndex(4, 0)).toBe(4);
+  });
+
+  results.push('\n─────────────────────────────────────────');
+  results.push('Results: ' + passed + ' passed, ' + failed + ' failed');
+  Logger.log(results.join('\n'));
+
+  if (failed > 0) {
+    throw new Error(failed + ' test(s) failed — see Logs for details');
+  }
+}


### PR DESCRIPTION
After each successful `insertAyah` / `insertAyahRange`, inserts an empty paragraph with Normal text style (left-aligned, LTR) and moves the document cursor there.

Closes #57