### PR TITLE
Use Google Fonts API as single source for Arabic font list

### DIFF
--- a/FontService.js
+++ b/FontService.js
@@ -1,38 +1,29 @@
 /**
  * FontService.gs
- * Fetches Arabic-capable fonts from tasneef-data (GitHub Pages).
- * No API key required. Caches result for 24 hours in ScriptCache.
+ * Fetches Arabic-capable fonts from the Google Fonts API (subset=arabic).
+ * API key from User Properties (SettingsService); fallback key if unset.
+ * Cached for 24 hours in ScriptCache.
  */
 
 var FALLBACK_FONT = 'Amiri';
 
-var FONTS_JSON_URL = 'https://tarazis.github.io/tasneef-data/fonts.json';
+var GOOGLE_FONTS_API_BASE = 'https://www.googleapis.com/webfonts/v1/webfonts?subset=arabic&key=';
 var CACHE_KEY_FONTS = 'arabic_fonts';
 var CACHE_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 
-var BAD_FONTS = [
-  'Blaka', 'Blaka Hollow', 'Blaka Ink', 'Aref Ruqaa Ink',
-  'El Messiri', 'Alexandria', 'Lalezar', 'Playpen Sans Arabic', 'Mada',
-  'Rubik', 'Cairo', 'Almarai', 'Cairo Play', 'Readex Pro', 'Changa',
-  'Baloo Bhaijaan 2', 'Lemonada', 'Markazi Text', 'Kufam',
-  'Badeen Display', 'Marhey', 'Handjet', 'Oi', 'Reem Kufi Fun',
-  'Vibes', 'Qahiri'
+/** Hardcoded fallback when no key is stored in User Properties. */
+var GOOGLE_FONTS_API_KEY_FALLBACK = 'AIzaSyAx8SG23WQKR38AZeBq0iiVXAIneckwmP8';
+
+/**
+ * Curated list used when fetch fails.
+ */
+var FALLBACK_FONT_LIST = [
+  'Amiri', 'IBM Plex Sans Arabic', 'Lateef', 'Noto Kufi Arabic',
+  'Noto Naskh Arabic', 'Noto Sans Arabic', 'Scheherazade New', 'Tajawal'
 ];
 
 /**
- * Curated list used when fetch fails. Excludes BAD_FONTS.
- */
-var FALLBACK_FONT_LIST = (function () {
-  var list = [
-    'Amiri', 'IBM Plex Sans Arabic', 'Lateef', 'Noto Kufi Arabic',
-    'Noto Naskh Arabic', 'Noto Sans Arabic', 'Scheherazade New', 'Tajawal'
-  ];
-  return list.filter(function (f) { return BAD_FONTS.indexOf(f) < 0; });
-})();
-
-/**
- * Fetches Arabic fonts from tasneef-data URL. No API key required.
- * Filters out BAD_FONTS, returns family names sorted alphabetically.
+ * Fetches Arabic fonts from Google Fonts API. Returns family names sorted alphabetically.
  * Cached for 24 hours. Falls back to FALLBACK_FONT_LIST on error.
  * @return {Array<string>} Sorted list of font family names.
  */
@@ -46,7 +37,9 @@ function getArabicFonts() {
   var fonts = [];
 
   try {
-    var response = UrlFetchApp.fetch(FONTS_JSON_URL);
+    var apiKey = getGoogleFontsApiKey() || GOOGLE_FONTS_API_KEY_FALLBACK;
+    var url = GOOGLE_FONTS_API_BASE + encodeURIComponent(apiKey);
+    var response = UrlFetchApp.fetch(url);
     var json = JSON.parse(response.getContentText());
 
     // Support both array of strings and { items: [{ family: "..." }] }
@@ -59,14 +52,9 @@ function getArabicFonts() {
       items = json.fonts.map(function (f) { return typeof f === 'string' ? { family: f } : f; });
     }
 
-    var badSet = {};
-    for (var b = 0; b < BAD_FONTS.length; b++) {
-      badSet[BAD_FONTS[b]] = true;
-    }
-
     for (var i = 0; i < items.length; i++) {
       var family = items[i].family || (typeof items[i] === 'string' ? items[i] : null);
-      if (family && !badSet[family]) {
+      if (family) {
         fonts.push(family);
       }
     }

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -25,7 +25,12 @@ function applyFormatStateToUI() {
   var boldBtn = document.getElementById('btn-bold');
   var colorPicker = document.getElementById('color-picker');
   var colorTrigger = document.getElementById('color-trigger');
-  if (fontSelect) fontSelect.value = formatState.fontName;
+  if (fontSelect) {
+    fontSelect.value = formatState.fontName;
+    if (formatState.fontName) {
+      fontSelect.style.fontFamily = formatState.fontName + ', serif';
+    }
+  }
   if (sizeSelect) {
     var sizeVal = String(formatState.fontSize);
     if (sizeSelect.querySelector('option[value="' + sizeVal + '"]')) {
@@ -49,6 +54,7 @@ function initFormatBar() {
   if (fontSelect) {
     fontSelect.addEventListener('change', function() {
       formatState.fontName = fontSelect.value;
+      fontSelect.style.fontFamily = fontSelect.value + ', serif';
       debouncedSave();
       if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) window._refreshDirectInsert();
     });

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -124,6 +124,7 @@ function onFontsLoaded(fonts) {
     var opt = document.createElement('option');
     opt.value = f;
     opt.textContent = f;
+    opt.style.fontFamily = f + ', serif';
     if (f === formatState.fontName) opt.selected = true;
     fontSelect.appendChild(opt);
   });
@@ -131,8 +132,10 @@ function onFontsLoaded(fonts) {
     var fallback = document.createElement('option');
     fallback.value = formatState.fontName;
     fallback.textContent = formatState.fontName;
+    fallback.style.fontFamily = formatState.fontName + ', serif';
     fallback.selected = true;
     fontSelect.insertBefore(fallback, fontSelect.firstChild);
   }
+  fontSelect.style.fontFamily = formatState.fontName + ', serif';
 }
 </script>

--- a/sidebar/js/sidebar-js.html
+++ b/sidebar/js/sidebar-js.html
@@ -70,6 +70,17 @@
   }
   window.setupTextarea = setupTextarea;
 
+  function loadGoogleFontsCss(fonts) {
+    if (!fonts || !fonts.length) return;
+    var families = fonts.map(function(f) {
+      return 'family=' + encodeURIComponent(f);
+    }).join('&');
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?' + families + '&display=swap';
+    document.head.appendChild(link);
+  }
+
   // ─── Init ────────────────────────────────────────────────────────────────────
 
   function init() {
@@ -87,7 +98,7 @@
       .getSettings();
 
     google.script.run
-      .withSuccessHandler(function(f) { onFontsLoaded(f); onInitDone(); })
+      .withSuccessHandler(function(f) { onFontsLoaded(f); loadGoogleFontsCss(f); onInitDone(); })
       .withFailureHandler(function() { onInitDone(); })
       .getArabicFonts();
 

--- a/tests/FontService.test.gs
+++ b/tests/FontService.test.gs
@@ -4,7 +4,7 @@
  * Run from Apps Script editor: select runFontServiceTests, click Run.
  * View results in View → Logs.
  *
- * Fetches from tasneef-data/fonts.json (no API key). Falls back to curated list on error.
+ * Fetches from Google Fonts API (subset=arabic). Falls back to curated list on error.
  * No require/Node APIs.
  */
 
@@ -57,14 +57,9 @@ function runFontServiceTests() {
     expect(fonts).toContain('Amiri');
   });
 
-  it('excludes all BAD_FONTS from the list', function () {
+  it('returns more than 50 fonts from Google Fonts API', function () {
     var fonts = getArabicFonts();
-    var bad = ['Blaka', 'Cairo', 'Rubik', 'Markazi Text', 'Reem Kufi Fun'];
-    for (var i = 0; i < bad.length; i++) {
-      if (fonts.indexOf(bad[i]) >= 0) {
-        throw new Error('BAD_FONT ' + bad[i] + ' should not be in list');
-      }
-    }
+    expect(fonts.length).toBeGreaterThan(50);
   });
 
   it('returns list sorted alphabetically', function () {


### PR DESCRIPTION
Closes #61

Switches Arabic font discovery to the Google Fonts API (`subset=arabic`), keeps server-side fetch with ScriptCache, and loads faces via the Google Fonts CSS2 CDN in the sidebar. Removes the previous `fonts.json` source and `BAD_FONTS` blocklist. Per-option and select styling uses the chosen font family for the dropdown.