### PR TITLE
Load Arabic font list from curated quran-fonts.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ TRANSLATION:  https://tarazis.github.io/tasneef-data/quran/en-sahih-internationa
 ```
 Font URLs live in `FontService.js`:
 ```
-FONTS:        https://tarazis.github.io/tasneef-data/fonts.json
+QURAN FONTS:  https://tarazis.github.io/tasneef-data/quran/quran-fonts.json
 ```
 - INSPECT the actual JSON structure before writing code against it
 - Translation JSON is a flat object keyed by `"surah:ayah"` with `{t: "text"}` values

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -21,7 +21,7 @@
  * @param {Body} body - The document body
  * @param {Document} doc - The active document
  * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl? }
- * @param {Object} formatState - { fontName, fontSize, bold, textColor }
+ * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @return {Object} { fontWarning: string|null }
  */
 function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState) {
@@ -105,7 +105,7 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
  * Inserts an ayah into the document at the cursor position.
  * If no cursor, inserts after the last non-empty paragraph.
  * @param {Object} ayahData - { surah, ayah, surahNameArabic, surahNameEnglish, textUthmani, textSimple, translationText }
- * @param {Object} formatState - { fontName, fontSize, bold, textColor }
+ * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @param {Object} settings - { showTranslation, arabicStyle }
  * @return {Object} { success: boolean, message?: string }
  */
@@ -156,7 +156,7 @@ function insertAyah(ayahData, formatState, settings) {
  * Inserts a pre-assembled ayah range into the document.
  * If no cursor is set, inserts after the last non-empty paragraph.
  * @param {Object} rangeData - { surah, ayahStart, ayahEnd, arabicText, translationText, surahNameArabic, surahNameEnglish }
- * @param {Object} formatState - { fontName, fontSize, bold, textColor }
+ * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @param {Object} settings - { showTranslation }
  * @return {Object} { success: boolean, message?: string }
  */

--- a/FontService.js
+++ b/FontService.js
@@ -1,14 +1,16 @@
 /**
  * FontService.gs
  * Fetches the curated Arabic font list from tasneef-data (GitHub Pages).
- * No API key required. Caches result for 24 hours in ScriptCache.
+ * No API key required.
+ *
+ * The list is not stored in ScriptCache: a previous 24h cache caused the
+ * sidebar to lag behind updates to quran-fonts.json. Each getArabicFonts()
+ * call performs one UrlFetch (small payload).
  */
 
 var FALLBACK_FONT = 'Amiri';
 
 var QURAN_FONTS_JSON_URL = 'https://tarazis.github.io/tasneef-data/quran/quran-fonts.json';
-var CACHE_KEY_FONTS = 'arabic_fonts_quran_curated';
-var CACHE_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 
 /**
  * Mirror of hosted approved_fonts; used when fetch or parse fails.
@@ -16,7 +18,6 @@ var CACHE_TTL_SECONDS = 24 * 60 * 60; // 24 hours
  */
 var FALLBACK_APPROVED_FONTS = [
   'Amiri',
-  'Amiri Quran',
   'Harmattan',
   'IBM Plex Sans Arabic',
   'Lateef',
@@ -24,32 +25,36 @@ var FALLBACK_APPROVED_FONTS = [
   'Noto Kufi Arabic',
   'Noto Naskh Arabic',
   'Noto Sans Arabic',
-  'Scheherazade New'
+  'Reem Kufi Ink',
+  'Scheherazade New',
+  'Tajawal'
 ];
 
 /**
- * Fetches approved_fonts from quran-fonts.json, sorted alphabetically.
- * Cached for 24 hours. Falls back to FALLBACK_APPROVED_FONTS on error.
- * @return {Array<string>} Sorted list of font family names.
+ * @return {Array<string>} Sorted unique font names, or empty if invalid.
  */
-function getArabicFonts() {
-  var cache = CacheService.getScriptCache();
-  var cached = cache.get(CACHE_KEY_FONTS);
-  if (cached) {
-    return JSON.parse(cached);
+function buildSortedFontsFromJson(json) {
+  var raw = json && json.approved_fonts;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return [];
   }
-
-  var fonts = loadApprovedFontsFromUrl();
-  fonts.sort(function (a, b) { return a.localeCompare(b, 'en'); });
-
-  cache.put(CACHE_KEY_FONTS, JSON.stringify(fonts), CACHE_TTL_SECONDS);
-  return fonts;
+  var seen = {};
+  var out = [];
+  for (var i = 0; i < raw.length; i++) {
+    var name = typeof raw[i] === 'string' ? raw[i].trim() : '';
+    if (name && !seen[name]) {
+      seen[name] = true;
+      out.push(name);
+    }
+  }
+  out.sort(function (a, b) { return a.localeCompare(b, 'en'); });
+  return out;
 }
 
 /**
- * @return {Array<string>} Non-empty sorted unique families.
+ * @return {Array<string>} Sorted list of font family names.
  */
-function loadApprovedFontsFromUrl() {
+function getArabicFonts() {
   var fallback = FALLBACK_APPROVED_FONTS.slice().sort(function (a, b) {
     return a.localeCompare(b, 'en');
   });
@@ -57,26 +62,8 @@ function loadApprovedFontsFromUrl() {
   try {
     var response = UrlFetchApp.fetch(QURAN_FONTS_JSON_URL);
     var json = JSON.parse(response.getContentText());
-    var raw = json && json.approved_fonts;
-    if (!Array.isArray(raw) || raw.length === 0) {
-      return fallback;
-    }
-
-    var seen = {};
-    var out = [];
-    for (var i = 0; i < raw.length; i++) {
-      var name = typeof raw[i] === 'string' ? raw[i].trim() : '';
-      if (name && !seen[name]) {
-        seen[name] = true;
-        out.push(name);
-      }
-    }
-
-    if (out.length === 0) {
-      return fallback;
-    }
-
-    return out;
+    var list = buildSortedFontsFromJson(json);
+    return list.length > 0 ? list : fallback;
   } catch (e) {
     return fallback;
   }

--- a/FontService.js
+++ b/FontService.js
@@ -1,20 +1,15 @@
 /**
  * FontService.gs
- * Fetches the curated Arabic font list from tasneef-data (GitHub Pages).
- * No API key required.
- *
- * The list is not stored in ScriptCache: a previous 24h cache caused the
- * sidebar to lag behind updates to quran-fonts.json. Each getArabicFonts()
- * call performs one UrlFetch (small payload).
+ * Curated list from quran-fonts.json; full variant metadata via Google Fonts API.
  */
 
 var FALLBACK_FONT = 'Amiri';
 
 var QURAN_FONTS_JSON_URL = 'https://tarazis.github.io/tasneef-data/quran/quran-fonts.json';
+var GOOGLE_WEBFONTS_API = 'https://www.googleapis.com/webfonts/v1/webfonts';
 
 /**
  * Mirror of hosted approved_fonts; used when fetch or parse fails.
- * Keep in sync with tasneef-data/quran/quran-fonts.json.
  */
 var FALLBACK_APPROVED_FONTS = [
   'Amiri',
@@ -29,6 +24,47 @@ var FALLBACK_APPROVED_FONTS = [
   'Scheherazade New',
   'Tajawal'
 ];
+
+/**
+ * Parses a Google Fonts API variant token (e.g. regular, italic, 500, 700italic).
+ * Regular = weight 400 (Docs / CSS convention).
+ * @param {string} token
+ * @return {{ weight: number, italic: boolean }}
+ */
+function parseGoogleFontVariant(token) {
+  if (token == null || typeof token !== 'string') {
+    return { weight: 400, italic: false };
+  }
+  var t = token.replace(/\s/g, '');
+  if (t === '') return { weight: 400, italic: false };
+  if (t === 'regular') return { weight: 400, italic: false };
+  if (t === 'italic') return { weight: 400, italic: true };
+  var italic = /italic$/i.test(t);
+  if (italic) {
+    t = t.replace(/italic$/i, '');
+  }
+  var w = parseInt(t, 10);
+  if (!isNaN(w)) {
+    return { weight: w, italic: italic };
+  }
+  return { weight: 400, italic: false };
+}
+
+/**
+ * Sort variant tokens for stable UI order (by weight, then italic).
+ * @param {Array<string>} variants
+ * @return {Array<string>}
+ */
+function sortFontVariantTokens_(variants) {
+  var arr = variants.slice();
+  arr.sort(function (a, b) {
+    var pa = parseGoogleFontVariant(a);
+    var pb = parseGoogleFontVariant(b);
+    if (pa.weight !== pb.weight) return pa.weight - pb.weight;
+    return (pa.italic ? 1 : 0) - (pb.italic ? 1 : 0);
+  });
+  return arr;
+}
 
 /**
  * @return {Array<string>} Sorted unique font names, or empty if invalid.
@@ -52,7 +88,7 @@ function buildSortedFontsFromJson(json) {
 }
 
 /**
- * @return {Array<string>} Sorted list of font family names.
+ * @return {Array<string>} Sorted list of font family names (approved only).
  */
 function getArabicFonts() {
   var fallback = FALLBACK_APPROVED_FONTS.slice().sort(function (a, b) {
@@ -66,5 +102,61 @@ function getArabicFonts() {
     return list.length > 0 ? list : fallback;
   } catch (e) {
     return fallback;
+  }
+}
+
+/**
+ * Fetches Google Fonts metadata (arabic subset) intersected with quran-fonts approved_fonts.
+ * Requires User Properties google_fonts_api_key via getGoogleFontsApiKey().
+ * @return {{ ok: boolean, error: string|null, catalog: Array<{family: string, variants: string[]}> }}
+ */
+function getCuratedFontCatalog() {
+  var empty = { ok: false, error: null, catalog: [] };
+  var apiKey = getGoogleFontsApiKey();
+  if (!apiKey || String(apiKey).trim().length === 0) {
+    empty.error = 'NO_GOOGLE_FONTS_API_KEY';
+    return empty;
+  }
+
+  var approved = [];
+  try {
+    var rQ = UrlFetchApp.fetch(QURAN_FONTS_JSON_URL);
+    approved = buildSortedFontsFromJson(JSON.parse(rQ.getContentText()));
+  } catch (e) {
+    approved = FALLBACK_APPROVED_FONTS.slice().sort(function (a, b) {
+      return a.localeCompare(b, 'en');
+    });
+  }
+
+  var approvedSet = {};
+  for (var a = 0; a < approved.length; a++) {
+    approvedSet[approved[a]] = true;
+  }
+
+  try {
+    var url = GOOGLE_WEBFONTS_API +
+      '?key=' + encodeURIComponent(String(apiKey).trim()) +
+      '&subset=arabic&sort=alpha';
+    var rG = UrlFetchApp.fetch(url);
+    var data = JSON.parse(rG.getContentText());
+    var items = data.items || [];
+    var catalog = [];
+    for (var i = 0; i < items.length; i++) {
+      var fam = items[i].family;
+      if (!fam || !approvedSet[fam]) continue;
+      var v = items[i].variants;
+      if (!v || !v.length) continue;
+      catalog.push({
+        family: fam,
+        variants: sortFontVariantTokens_(v.slice())
+      });
+    }
+    catalog.sort(function (x, y) {
+      return x.family.localeCompare(y.family, 'en');
+    });
+    return { ok: true, error: null, catalog: catalog };
+  } catch (e) {
+    empty.error = String(e.message || e);
+    return empty;
   }
 }

--- a/FontService.js
+++ b/FontService.js
@@ -1,39 +1,35 @@
 /**
  * FontService.gs
- * Fetches Arabic-capable fonts from tasneef-data (GitHub Pages).
+ * Fetches the curated Arabic font list from tasneef-data (GitHub Pages).
  * No API key required. Caches result for 24 hours in ScriptCache.
  */
 
 var FALLBACK_FONT = 'Amiri';
 
-var FONTS_JSON_URL = 'https://tarazis.github.io/tasneef-data/fonts.json';
-var CACHE_KEY_FONTS = 'arabic_fonts';
+var QURAN_FONTS_JSON_URL = 'https://tarazis.github.io/tasneef-data/quran/quran-fonts.json';
+var CACHE_KEY_FONTS = 'arabic_fonts_quran_curated';
 var CACHE_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 
-var BAD_FONTS = [
-  'Blaka', 'Blaka Hollow', 'Blaka Ink', 'Aref Ruqaa Ink',
-  'El Messiri', 'Alexandria', 'Lalezar', 'Playpen Sans Arabic', 'Mada',
-  'Rubik', 'Cairo', 'Almarai', 'Cairo Play', 'Readex Pro', 'Changa',
-  'Baloo Bhaijaan 2', 'Lemonada', 'Markazi Text', 'Kufam',
-  'Badeen Display', 'Marhey', 'Handjet', 'Oi', 'Reem Kufi Fun',
-  'Vibes', 'Qahiri'
+/**
+ * Mirror of hosted approved_fonts; used when fetch or parse fails.
+ * Keep in sync with tasneef-data/quran/quran-fonts.json.
+ */
+var FALLBACK_APPROVED_FONTS = [
+  'Amiri',
+  'Amiri Quran',
+  'Harmattan',
+  'IBM Plex Sans Arabic',
+  'Lateef',
+  'Mada',
+  'Noto Kufi Arabic',
+  'Noto Naskh Arabic',
+  'Noto Sans Arabic',
+  'Scheherazade New'
 ];
 
 /**
- * Curated list used when fetch fails. Excludes BAD_FONTS.
- */
-var FALLBACK_FONT_LIST = (function () {
-  var list = [
-    'Amiri', 'IBM Plex Sans Arabic', 'Lateef', 'Noto Kufi Arabic',
-    'Noto Naskh Arabic', 'Noto Sans Arabic', 'Scheherazade New', 'Tajawal'
-  ];
-  return list.filter(function (f) { return BAD_FONTS.indexOf(f) < 0; });
-})();
-
-/**
- * Fetches Arabic fonts from tasneef-data URL. No API key required.
- * Filters out BAD_FONTS, returns family names sorted alphabetically.
- * Cached for 24 hours. Falls back to FALLBACK_FONT_LIST on error.
+ * Fetches approved_fonts from quran-fonts.json, sorted alphabetically.
+ * Cached for 24 hours. Falls back to FALLBACK_APPROVED_FONTS on error.
  * @return {Array<string>} Sorted list of font family names.
  */
 function getArabicFonts() {
@@ -43,44 +39,45 @@ function getArabicFonts() {
     return JSON.parse(cached);
   }
 
-  var fonts = [];
+  var fonts = loadApprovedFontsFromUrl();
+  fonts.sort(function (a, b) { return a.localeCompare(b, 'en'); });
+
+  cache.put(CACHE_KEY_FONTS, JSON.stringify(fonts), CACHE_TTL_SECONDS);
+  return fonts;
+}
+
+/**
+ * @return {Array<string>} Non-empty sorted unique families.
+ */
+function loadApprovedFontsFromUrl() {
+  var fallback = FALLBACK_APPROVED_FONTS.slice().sort(function (a, b) {
+    return a.localeCompare(b, 'en');
+  });
 
   try {
-    var response = UrlFetchApp.fetch(FONTS_JSON_URL);
+    var response = UrlFetchApp.fetch(QURAN_FONTS_JSON_URL);
     var json = JSON.parse(response.getContentText());
-
-    // Support both array of strings and { items: [{ family: "..." }] }
-    var items = [];
-    if (Array.isArray(json)) {
-      items = json.map(function (f) { return typeof f === 'string' ? { family: f } : f; });
-    } else if (json && json.items && Array.isArray(json.items)) {
-      items = json.items;
-    } else if (json && json.fonts && Array.isArray(json.fonts)) {
-      items = json.fonts.map(function (f) { return typeof f === 'string' ? { family: f } : f; });
+    var raw = json && json.approved_fonts;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      return fallback;
     }
 
-    var badSet = {};
-    for (var b = 0; b < BAD_FONTS.length; b++) {
-      badSet[BAD_FONTS[b]] = true;
-    }
-
-    for (var i = 0; i < items.length; i++) {
-      var family = items[i].family || (typeof items[i] === 'string' ? items[i] : null);
-      if (family && !badSet[family]) {
-        fonts.push(family);
+    var seen = {};
+    var out = [];
+    for (var i = 0; i < raw.length; i++) {
+      var name = typeof raw[i] === 'string' ? raw[i].trim() : '';
+      if (name && !seen[name]) {
+        seen[name] = true;
+        out.push(name);
       }
     }
 
-    fonts.sort(function (a, b) { return a.localeCompare(b, 'en'); });
-
-    if (fonts.length === 0) {
-      fonts = FALLBACK_FONT_LIST.slice();
+    if (out.length === 0) {
+      return fallback;
     }
 
-    cache.put(CACHE_KEY_FONTS, JSON.stringify(fonts), CACHE_TTL_SECONDS);
+    return out;
   } catch (e) {
-    fonts = FALLBACK_FONT_LIST.slice();
+    return fallback;
   }
-
-  return fonts;
 }

--- a/FontService.js
+++ b/FontService.js
@@ -107,7 +107,7 @@ function getArabicFonts() {
 
 /**
  * Fetches Google Fonts metadata (arabic subset) intersected with quran-fonts approved_fonts.
- * Requires User Properties google_fonts_api_key via getGoogleFontsApiKey().
+ * Requires Script Properties google_fonts_api_key via getGoogleFontsApiKey().
  * @return {{ ok: boolean, error: string|null, catalog: Array<{family: string, variants: string[]}> }}
  */
 function getCuratedFontCatalog() {

--- a/FormatService.js
+++ b/FormatService.js
@@ -2,15 +2,30 @@
  * FormatService.gs
  * Applies formatting to Google Docs text elements.
  * Font fallback to Amiri with toast on failure.
+ * Weighted Google Fonts use setFontFamily("Family;WEIGHT") with setItalic for italic tokens.
  */
 
 var ARABIC_INDIC = ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'];
 var FALLBACK_FONT = 'Amiri';
 
 /**
+ * Builds the font family string Google Docs accepts for weighted Google Fonts.
+ * @param {string} family
+ * @param {number} weight
+ * @return {string}
+ */
+function buildGoogleDocsWeightedFontFamily(family, weight) {
+  var f = family || FALLBACK_FONT;
+  if (weight == null || weight === 400) {
+    return f;
+  }
+  return f + ';' + weight;
+}
+
+/**
  * Converts a Western number to Arabic-Indic numerals.
- * @param {number} num - Western number (e.g., 255)
- * @return {string} Arabic-Indic string (e.g., "٢٥٥")
+ * @param {number} num - Western number (e.g. 255)
+ * @return {string} Arabic-Indic string (e.g. "٢٥٥")
  */
 function toArabicIndic(num) {
   if (num == null || isNaN(num)) return String(num);
@@ -27,27 +42,42 @@ function toArabicIndic(num) {
  * Applies format state to a Google Docs Text element.
  * Falls back to Amiri if font fails.
  * @param {GoogleAppsScript.Document.Text} textElement - The text element to format
- * @param {Object} formatState - { fontName, fontSize, bold, textColor }
+ * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @return {string|null} Warning message if font fallback occurred, null otherwise
  */
 function applyFormat(textElement, formatState) {
   if (!textElement || !formatState) return null;
 
   var fontWarning = null;
-  var fontName = formatState.fontName || FALLBACK_FONT;
+  var family = formatState.fontName || FALLBACK_FONT;
+  var parsed = parseGoogleFontVariant(formatState.fontVariant != null ? formatState.fontVariant : 'regular');
+  var fontSpec = buildGoogleDocsWeightedFontFamily(family, parsed.weight);
+
   try {
-    textElement.setFontFamily(fontName);
+    textElement.setFontFamily(fontSpec);
   } catch (e) {
     textElement.setFontFamily(FALLBACK_FONT);
-    fontWarning = 'Font "' + fontName + '" not available. Using Amiri.';
+    fontWarning = 'Font "' + family + '" not available. Using Amiri.';
+  }
+
+  try {
+    textElement.setItalic(parsed.italic);
+  } catch (ignore) {
+    // older containers may omit; ignore
   }
 
   if (formatState.fontSize != null) {
     textElement.setFontSize(formatState.fontSize);
   }
-  if (formatState.bold != null) {
-    textElement.setBold(formatState.bold);
+
+  var boldApply = formatState.bold === true;
+  if (boldApply && parsed.weight >= 700) {
+    boldApply = false;
   }
+  if (formatState.bold != null) {
+    textElement.setBold(boldApply);
+  }
+
   if (formatState.textColor) {
     textElement.setForegroundColor(formatState.textColor);
   }

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -106,21 +106,22 @@ function setClaudeApiKey(key) {
 }
 
 /**
- * Returns the stored Google Fonts API key, or null if not set.
+ * Returns the Google Fonts Developer API key from Script Properties (shared by all users).
+ * Set once in Project settings → Script properties as google_fonts_api_key.
  * @return {string|null}
  */
 function getGoogleFontsApiKey() {
-  return PropertiesService.getUserProperties()
+  return PropertiesService.getScriptProperties()
     .getProperty(PROPERTY_KEYS.GOOGLE_FONTS_API_KEY) || null;
 }
 
 /**
- * Persists the Google Fonts API key to User Properties.
+ * Persists the Google Fonts API key to Script Properties (optional; prefer Script editor UI).
  * @param {string} key - The API key to store.
  */
 function setGoogleFontsApiKey(key) {
-  PropertiesService.getUserProperties()
-    .setProperty(PROPERTY_KEYS.GOOGLE_FONTS_API_KEY, key);
+  PropertiesService.getScriptProperties()
+    .setProperty(PROPERTY_KEYS.GOOGLE_FONTS_API_KEY, String(key || '').trim());
 }
 
 /**

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -11,6 +11,7 @@ var SETTINGS_DEFAULTS = {
   insertArabic: true,
   arabicStyle: 'uthmani',     // "uthmani" | "simple"
   fontName: 'Amiri',
+  fontVariant: 'regular',    // Google Fonts API variant token
   fontSize: 18,
   bold: false,
   textColor: '#000000'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "tasneef-ai",
   "private": true,
   "scripts": {
-    "test": "npm run test:client && npm run test:normalize && npm run test:card",
+    "test": "npm run test:client && npm run test:normalize && npm run test:card && npm run test:font",
+    "test:font": "node tests/fontVariant.test.js",
     "test:client": "node tests/makeClientCache.test.js",
     "test:normalize": "node tests/normalizeArabic.test.js",
     "test:card": "node tests/buildResultCardHtml.test.js"

--- a/sidebar/components/format-bar.html
+++ b/sidebar/components/format-bar.html
@@ -1,7 +1,13 @@
 <div class="format-bar">
-  <select class="font-select" id="font-select" title="Font">
-    <option value="Amiri">Amiri</option>
-  </select>
+  <div class="font-picker" id="font-picker">
+    <button type="button" class="font-picker-trigger" id="font-picker-trigger" aria-haspopup="listbox" aria-expanded="false" title="Font">
+      <span class="font-picker-label" id="font-picker-label">Amiri · Normal</span>
+      <span class="font-picker-caret" aria-hidden="true">▾</span>
+    </button>
+    <div class="font-picker-dropdown hidden" id="font-picker-dropdown" role="listbox" aria-label="Fonts">
+      <ul class="font-picker-families" id="font-picker-families"></ul>
+    </div>
+  </div>
   <select class="size-select" id="size-select" title="Font size">
     <option value="12">12</option>
     <option value="14">14</option>

--- a/sidebar/js/card-builder.html
+++ b/sidebar/js/card-builder.html
@@ -68,11 +68,18 @@ function buildRangeData(results) {
  * @param {Object} cardData
  *   Single: { surah, ayah, surahNameArabic, surahNameEnglish, arabicText, matchStart?, matchEnd? }
  *   Range:  { surah, ayahStart, ayahEnd, surahNameArabic, surahNameEnglish, arabicText, isRange: true }
- * @param {string} font - CSS font-family name
+ * @param {string|Object} fontOrFs - CSS family string, or formatState-like { fontName, fontVariant }
  * @return {string} innerHTML for the card
  */
-function buildCardHtml(cardData, font) {
+function buildCardHtml(cardData, fontOrFs) {
   var arabicRef, englishRef, arabicHtml;
+  var arabicCss;
+  if (fontOrFs && typeof fontOrFs === 'object' && fontOrFs.fontName) {
+    arabicCss = arabicPreviewFontStyle(fontOrFs);
+  } else {
+    var f = (typeof fontOrFs === 'string' && fontOrFs) ? fontOrFs : 'Amiri';
+    arabicCss = "font-family:'" + String(f).replace(/['\\<>]/g, '') + "',serif;font-weight:400;font-style:normal";
+  }
 
   if (cardData.isRange) {
     arabicRef = escapeHtml(cardData.surahNameArabic || '') +
@@ -85,7 +92,7 @@ function buildCardHtml(cardData, font) {
     arabicHtml = escapeHtml(cardData.arabicText);
 
     return '<div class="ref-arabic">' + arabicRef + '</div>' +
-      '<div class="arabic range-block" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
+      '<div class="arabic range-block" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
       '<div class="ref-english">' + englishRef + '</div>' +
       '<button type="button" class="btn-primary btn-insert-result" ' +
         'data-surah="' + cardData.surah + '" ' +
@@ -105,7 +112,7 @@ function buildCardHtml(cardData, font) {
   }
 
   return '<div class="ref-arabic">' + arabicRef + '</div>' +
-    '<div class="arabic" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
+    '<div class="arabic" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
     '<div class="ref-english">' + englishRef + '</div>' +
     '<button type="button" class="btn-primary btn-insert-result" ' +
       'data-surah="' + cardData.surah + '" data-ayah="' + cardData.ayah + '">Insert</button>';

--- a/sidebar/js/font-variant-utils.html
+++ b/sidebar/js/font-variant-utils.html
@@ -1,0 +1,109 @@
+<script>
+/**
+ * Client-side font variant helpers (keep parse logic aligned with FontService.parseGoogleFontVariant).
+ */
+function parseGoogleFontVariantClient(token) {
+  if (token == null || typeof token !== 'string') {
+    return { weight: 400, italic: false };
+  }
+  var t = token.replace(/\s/g, '');
+  if (t === '') return { weight: 400, italic: false };
+  if (t === 'regular') return { weight: 400, italic: false };
+  if (t === 'italic') return { weight: 400, italic: true };
+  var italic = /italic$/i.test(t);
+  if (italic) t = t.replace(/italic$/i, '');
+  var w = parseInt(t, 10);
+  if (!isNaN(w)) return { weight: w, italic: italic };
+  return { weight: 400, italic: false };
+}
+
+var _WEIGHT_LABELS = {
+  100: 'Thin',
+  200: 'Extra Light',
+  300: 'Light',
+  400: 'Normal',
+  500: 'Medium',
+  600: 'Semi Bold',
+  700: 'Bold',
+  800: 'Extra Bold',
+  900: 'Black'
+};
+
+function googleFontVariantLabel(token) {
+  var p = parseGoogleFontVariantClient(token);
+  var base = _WEIGHT_LABELS[p.weight] || String(p.weight);
+  if (p.italic) {
+    return base === 'Normal' ? 'Italic' : base + ' Italic';
+  }
+  return base;
+}
+
+/**
+ * Builds Google Fonts CSS2 href for sidebar Arabic preview.
+ * @param {string} family
+ * @param {Array<string>} variantTokens
+ * @return {string}
+ */
+function buildGoogleFontsPreviewHref(family, variantTokens) {
+  var famEnc = family.replace(/ /g, '+');
+  var pairSet = {};
+  var hasItal = false;
+  var hasRom = false;
+  for (var i = 0; i < variantTokens.length; i++) {
+    var p = parseGoogleFontVariantClient(variantTokens[i]);
+    if (p.italic) hasItal = true;
+    else hasRom = true;
+    var pair = (p.italic ? 1 : 0) + ',' + p.weight;
+    pairSet[pair] = true;
+  }
+  var pairs = Object.keys(pairSet).sort(function (a, b) {
+    var aa = a.split(',');
+    var bb = b.split(',');
+    if (aa[0] !== bb[0]) return parseInt(aa[0], 10) - parseInt(bb[0], 10);
+    return parseInt(aa[1], 10) - parseInt(bb[1], 10);
+  });
+  if (!hasItal) {
+    var wOnly = [];
+    for (var j = 0; j < pairs.length; j++) {
+      wOnly.push(pairs[j].split(',')[1]);
+    }
+    return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':wght@' +
+      wOnly.join(';') + '&display=swap';
+  }
+  if (!hasRom) {
+    var italOnly = pairs.map(function (pr) { return '1,' + pr.split(',')[1]; });
+    return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' +
+      italOnly.join(';') + '&display=swap';
+  }
+  return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' +
+    pairs.join(';') + '&display=swap';
+}
+
+function ensureGoogleFontsPreviewStylesheet(family, variantTokens) {
+  if (!family || !variantTokens || !variantTokens.length) return;
+  var id = 'gf-preview-' + family.replace(/[^a-zA-Z0-9]+/g, '-');
+  var href = buildGoogleFontsPreviewHref(family, variantTokens);
+  var existing = document.getElementById(id);
+  if (existing && existing.getAttribute('data-href') === href) return;
+  if (existing) existing.remove();
+  var link = document.createElement('link');
+  link.id = id;
+  link.rel = 'stylesheet';
+  link.href = href;
+  link.setAttribute('data-href', href);
+  document.head.appendChild(link);
+}
+
+/**
+ * Inline style for Arabic preview (.arabic) from formatState.
+ * @param {Object} fs - formatState-like { fontName, fontVariant }
+ * @return {string}
+ */
+function arabicPreviewFontStyle(fs) {
+  var fam = (fs && fs.fontName) || 'Amiri';
+  var safeFam = String(fam).replace(/['\\<>]/g, '');
+  var p = parseGoogleFontVariantClient(fs && fs.fontVariant ? fs.fontVariant : 'regular');
+  return "font-family:'" + safeFam + "',serif;font-weight:" + p.weight +
+    ';font-style:' + (p.italic ? 'italic' : 'normal');
+}
+</script>

--- a/sidebar/js/font-variant-utils.html
+++ b/sidebar/js/font-variant-utils.html
@@ -39,6 +39,22 @@ function googleFontVariantLabel(token) {
 }
 
 /**
+ * Token to use when user picks a family without choosing a weight (e.g. click row).
+ * Prefers Google "regular"; else first 400 non-italic; else first listed.
+ * @param {Array<string>} variants
+ * @return {string}
+ */
+function pickDefaultRegularVariant(variants) {
+  if (!variants || !variants.length) return 'regular';
+  if (variants.indexOf('regular') >= 0) return 'regular';
+  for (var i = 0; i < variants.length; i++) {
+    var p = parseGoogleFontVariantClient(variants[i]);
+    if (p.weight === 400 && !p.italic) return variants[i];
+  }
+  return variants[0];
+}
+
+/**
  * Builds Google Fonts CSS2 href for sidebar Arabic preview.
  * @param {string} family
  * @param {Array<string>} variantTokens

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -29,11 +29,48 @@ function refreshArabicPreviewFontFace() {
   }
 }
 
+function resetFontPickerFlyoutPositions() {
+  var nodes = document.querySelectorAll('.font-picker-flyout');
+  for (var i = 0; i < nodes.length; i++) {
+    nodes[i].style.left = '';
+    nodes[i].style.top = '';
+  }
+}
+
+function positionFontPickerFlyout(li, fly) {
+  if (!li || !fly) return;
+  var r = li.getBoundingClientRect();
+  var gap = 4;
+  fly.style.left = r.right + gap + 'px';
+  fly.style.top = r.top + 'px';
+  var fr = fly.getBoundingClientRect();
+  if (fr.width > 0 && fr.right > window.innerWidth - 8) {
+    fly.style.left = Math.max(8, r.left - fr.width - gap) + 'px';
+  }
+}
+
+function repositionHoveredFontFlyout() {
+  var drop = document.getElementById('font-picker-dropdown');
+  if (!drop || drop.classList.contains('hidden')) return;
+  var items = drop.querySelectorAll('.font-picker-family-item');
+  for (var j = 0; j < items.length; j++) {
+    var item = items[j];
+    if (item.matches && item.matches(':hover')) {
+      var fl = item.querySelector('.font-picker-flyout');
+      if (fl) {
+        positionFontPickerFlyout(item, fl);
+        return;
+      }
+    }
+  }
+}
+
 function closeFontPicker() {
   var drop = document.getElementById('font-picker-dropdown');
   var trig = document.getElementById('font-picker-trigger');
   if (drop) drop.classList.add('hidden');
   if (trig) trig.setAttribute('aria-expanded', 'false');
+  resetFontPickerFlyoutPositions();
   document.removeEventListener('click', onFontPickerDocClick, true);
 }
 
@@ -111,6 +148,11 @@ function buildFontPickerDom() {
           })(variants[v]);
         }
         li.appendChild(fly);
+        li.addEventListener('mouseenter', function () {
+          requestAnimationFrame(function () {
+            positionFontPickerFlyout(li, fly);
+          });
+        });
         li.addEventListener('click', function (e) {
           if (e.target && e.target.closest && e.target.closest('.font-picker-flyout')) return;
           e.stopPropagation();
@@ -222,6 +264,15 @@ function initFormatBar() {
       e.stopPropagation();
       toggleFontPicker();
     });
+  }
+  var fontDrop = document.getElementById('font-picker-dropdown');
+  if (fontDrop && !fontDrop._fontFlyoutScrollBound) {
+    fontDrop._fontFlyoutScrollBound = true;
+    fontDrop.addEventListener('scroll', repositionHoveredFontFlyout);
+  }
+  if (typeof window !== 'undefined' && !window._fontFlyoutResizeBound) {
+    window._fontFlyoutResizeBound = true;
+    window.addEventListener('resize', repositionHoveredFontFlyout);
   }
   if (sizeSelect) {
     sizeSelect.addEventListener('change', function () {

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -1,16 +1,186 @@
 <script>
-// Depends on globals: formatState, SAVE_DEBOUNCE_MS (shared-state.html)
-// Reads window._activeTab and window._refreshDirectInsert (set by sidebar-js.html IIFE)
+// Depends on: formatState, SAVE_DEBOUNCE_MS (shared-state.html),
+//   parseGoogleFontVariantClient, googleFontVariantLabel, ensureGoogleFontsPreviewStylesheet,
+//   arabicPreviewFontStyle (font-variant-utils.html)
+// Reads window._activeTab, window._refreshDirectInsert (sidebar-js.html)
 
 var saveDebounceTimer = null;
+window._fontCatalog = null;
+
+function updateFontPickerLabel() {
+  var el = document.getElementById('font-picker-label');
+  if (!el) return;
+  var fam = formatState.fontName || 'Amiri';
+  var tok = formatState.fontVariant || 'regular';
+  el.textContent = fam + ' · ' + googleFontVariantLabel(tok);
+}
+
+function refreshArabicPreviewFontFace() {
+  if (!window._fontCatalog || !formatState.fontName) return;
+  var entry = null;
+  for (var i = 0; i < window._fontCatalog.length; i++) {
+    if (window._fontCatalog[i].family === formatState.fontName) {
+      entry = window._fontCatalog[i];
+      break;
+    }
+  }
+  if (entry && entry.variants && entry.variants.length) {
+    ensureGoogleFontsPreviewStylesheet(entry.family, entry.variants);
+  }
+}
+
+function closeFontPicker() {
+  var drop = document.getElementById('font-picker-dropdown');
+  var trig = document.getElementById('font-picker-trigger');
+  if (drop) drop.classList.add('hidden');
+  if (trig) trig.setAttribute('aria-expanded', 'false');
+  document.removeEventListener('click', onFontPickerDocClick, true);
+}
+
+function onFontPickerDocClick(e) {
+  var picker = document.getElementById('font-picker');
+  if (picker && !picker.contains(e.target)) closeFontPicker();
+}
+
+function openFontPicker() {
+  var drop = document.getElementById('font-picker-dropdown');
+  var trig = document.getElementById('font-picker-trigger');
+  if (!drop || !trig) return;
+  drop.classList.remove('hidden');
+  trig.setAttribute('aria-expanded', 'true');
+  setTimeout(function() {
+    document.addEventListener('click', onFontPickerDocClick, true);
+  }, 0);
+}
+
+function toggleFontPicker() {
+  var drop = document.getElementById('font-picker-dropdown');
+  if (!drop) return;
+  if (drop.classList.contains('hidden')) openFontPicker();
+  else closeFontPicker();
+}
+
+function selectFontAndVariant(family, variant, closeMenu) {
+  formatState.fontName = family;
+  formatState.fontVariant = variant || 'regular';
+  updateFontPickerLabel();
+  refreshArabicPreviewFontFace();
+  debouncedSave();
+  if (closeMenu) closeFontPicker();
+  if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) {
+    window._refreshDirectInsert();
+  }
+}
+
+function buildFontPickerDom() {
+  var ul = document.getElementById('font-picker-families');
+  if (!ul) return;
+  ul.innerHTML = '';
+  if (!window._fontCatalog || !window._fontCatalog.length) {
+    var li0 = document.createElement('li');
+    li0.className = 'font-picker-empty';
+    li0.textContent = 'No fonts loaded. Check Google Fonts API access.';
+    ul.appendChild(li0);
+    return;
+  }
+  for (var i = 0; i < window._fontCatalog.length; i++) {
+    (function (entry) {
+      var li = document.createElement('li');
+      li.className = 'font-picker-family-item';
+      var nameSpan = document.createElement('span');
+      nameSpan.className = 'font-picker-family-name';
+      nameSpan.textContent = entry.family;
+      li.appendChild(nameSpan);
+      var variants = entry.variants || [];
+      if (variants.length > 1) {
+        var chev = document.createElement('span');
+        chev.className = 'font-picker-chevron';
+        chev.textContent = '›';
+        li.appendChild(chev);
+        var fly = document.createElement('ul');
+        fly.className = 'font-picker-flyout';
+        for (var v = 0; v < variants.length; v++) {
+          (function (tok) {
+            var vli = document.createElement('li');
+            vli.textContent = googleFontVariantLabel(tok);
+            vli.addEventListener('click', function (e) {
+              e.stopPropagation();
+              selectFontAndVariant(entry.family, tok, true);
+            });
+            fly.appendChild(vli);
+          })(variants[v]);
+        }
+        li.appendChild(fly);
+        li.addEventListener('click', function (e) {
+          if (e.target && e.target.closest && e.target.closest('.font-picker-flyout')) return;
+          e.stopPropagation();
+        });
+      } else if (variants.length === 1) {
+        li.addEventListener('click', function () {
+          selectFontAndVariant(entry.family, variants[0], true);
+        });
+      }
+      ul.appendChild(li);
+    })(window._fontCatalog[i]);
+  }
+}
+
+/**
+ * If saved family/variant missing from catalog, reset to first entries.
+ */
+function reconcileFontCatalogState() {
+  if (!window._fontCatalog || !window._fontCatalog.length) {
+    updateFontPickerLabel();
+    return;
+  }
+  var cat = window._fontCatalog;
+  var entry = null;
+  for (var i = 0; i < cat.length; i++) {
+    if (cat[i].family === formatState.fontName) {
+      entry = cat[i];
+      break;
+    }
+  }
+  var changed = false;
+  if (!entry) {
+    entry = cat[0];
+    formatState.fontName = entry.family;
+    formatState.fontVariant = entry.variants[0];
+    changed = true;
+  } else if (entry.variants.indexOf(formatState.fontVariant) < 0) {
+    formatState.fontVariant = entry.variants[0];
+    changed = true;
+  }
+  updateFontPickerLabel();
+  refreshArabicPreviewFontFace();
+  if (changed) {
+    google.script.run
+      .withFailureHandler(function () {})
+      .saveSettings({ fontName: formatState.fontName, fontVariant: formatState.fontVariant });
+  }
+}
+
+function onFontCatalogLoaded(result) {
+  window._fontCatalog = (result && result.catalog) ? result.catalog : [];
+  if (!result || !result.ok) {
+    window._fontCatalog = [];
+    var err = (result && result.error) ? result.error : 'UNKNOWN';
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('Font catalog:', err);
+    }
+  }
+  buildFontPickerDom();
+  reconcileFontCatalogState();
+}
 
 function debouncedSave() {
   if (saveDebounceTimer) clearTimeout(saveDebounceTimer);
-  saveDebounceTimer = setTimeout(function() {
+  saveDebounceTimer = setTimeout(function () {
     google.script.run
-      .withFailureHandler(function(err) { console.error('Save settings failed:', err); })
+      .withFailureHandler(function (err) { console.error('Save settings failed:', err); })
       .saveSettings({
         fontName: formatState.fontName,
+        fontVariant: formatState.fontVariant,
         fontSize: formatState.fontSize,
         bold: formatState.bold,
         textColor: formatState.textColor
@@ -20,12 +190,11 @@ function debouncedSave() {
 }
 
 function applyFormatStateToUI() {
-  var fontSelect = document.getElementById('font-select');
   var sizeSelect = document.getElementById('size-select');
   var boldBtn = document.getElementById('btn-bold');
   var colorPicker = document.getElementById('color-picker');
   var colorTrigger = document.getElementById('color-trigger');
-  if (fontSelect) fontSelect.value = formatState.fontName;
+  updateFontPickerLabel();
   if (sizeSelect) {
     var sizeVal = String(formatState.fontSize);
     if (sizeSelect.querySelector('option[value="' + sizeVal + '"]')) {
@@ -39,42 +208,49 @@ function applyFormatStateToUI() {
   if (colorTrigger) colorTrigger.style.backgroundColor = formatState.textColor;
 }
 
+window.reconcileFontCatalogState = reconcileFontCatalogState;
+
 function initFormatBar() {
-  var fontSelect = document.getElementById('font-select');
   var sizeSelect = document.getElementById('size-select');
   var boldBtn = document.getElementById('btn-bold');
   var colorTrigger = document.getElementById('color-trigger');
   var colorPicker = document.getElementById('color-picker');
+  var trig = document.getElementById('font-picker-trigger');
 
-  if (fontSelect) {
-    fontSelect.addEventListener('change', function() {
-      formatState.fontName = fontSelect.value;
-      debouncedSave();
-      if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) window._refreshDirectInsert();
+  if (trig) {
+    trig.addEventListener('click', function (e) {
+      e.stopPropagation();
+      toggleFontPicker();
     });
   }
   if (sizeSelect) {
-    sizeSelect.addEventListener('change', function() {
+    sizeSelect.addEventListener('change', function () {
       formatState.fontSize = parseInt(sizeSelect.value, 10) || 18;
       debouncedSave();
-      if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) window._refreshDirectInsert();
+      if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) {
+        window._refreshDirectInsert();
+      }
     });
   }
   if (boldBtn) {
-    boldBtn.addEventListener('click', function() {
+    boldBtn.addEventListener('click', function () {
       formatState.bold = !formatState.bold;
       boldBtn.classList.toggle('active', formatState.bold);
       debouncedSave();
-      if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) window._refreshDirectInsert();
+      if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) {
+        window._refreshDirectInsert();
+      }
     });
   }
   if (colorTrigger && colorPicker) {
-    colorTrigger.addEventListener('click', function() { colorPicker.click(); });
+    colorTrigger.addEventListener('click', function () { colorPicker.click(); });
     function onColorChange() {
       formatState.textColor = colorPicker.value;
       colorTrigger.style.backgroundColor = colorPicker.value;
       debouncedSave();
-      if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) window._refreshDirectInsert();
+      if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) {
+        window._refreshDirectInsert();
+      }
     }
     colorPicker.addEventListener('input', onColorChange);
     colorPicker.addEventListener('change', onColorChange);

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -40,12 +40,12 @@ function resetFontPickerFlyoutPositions() {
 function positionFontPickerFlyout(li, fly) {
   if (!li || !fly) return;
   var r = li.getBoundingClientRect();
-  var gap = 4;
-  fly.style.left = r.right + gap + 'px';
+  var overlap = 1;
+  fly.style.left = r.right - overlap + 'px';
   fly.style.top = r.top + 'px';
   var fr = fly.getBoundingClientRect();
   if (fr.width > 0 && fr.right > window.innerWidth - 8) {
-    fly.style.left = Math.max(8, r.left - fr.width - gap) + 'px';
+    fly.style.left = Math.max(8, r.left - fr.width + overlap) + 'px';
   }
 }
 

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -83,6 +83,7 @@ function openFontPicker() {
   var drop = document.getElementById('font-picker-dropdown');
   var trig = document.getElementById('font-picker-trigger');
   if (!drop || !trig) return;
+  syncFontPickerSelectionClasses();
   drop.classList.remove('hidden');
   trig.setAttribute('aria-expanded', 'true');
   setTimeout(function() {
@@ -97,11 +98,33 @@ function toggleFontPicker() {
   else closeFontPicker();
 }
 
+function syncFontPickerSelectionClasses() {
+  var fam = formatState.fontName || '';
+  var tok = formatState.fontVariant || 'regular';
+  var items = document.querySelectorAll('.font-picker-family-item');
+  for (var i = 0; i < items.length; i++) {
+    var li = items[i];
+    var liFam = li.getAttribute('data-font-family') || '';
+    var familySelected = liFam === fam;
+    li.classList.toggle('is-selected', familySelected);
+    li.setAttribute('aria-selected', familySelected ? 'true' : 'false');
+    var flyLis = li.querySelectorAll('.font-picker-flyout li');
+    for (var j = 0; j < flyLis.length; j++) {
+      var vli = flyLis[j];
+      var vtok = vli.getAttribute('data-variant-token') || '';
+      var variantSelected = familySelected && vtok === tok;
+      vli.classList.toggle('is-selected', variantSelected);
+      vli.setAttribute('aria-selected', variantSelected ? 'true' : 'false');
+    }
+  }
+}
+
 function selectFontAndVariant(family, variant, closeMenu) {
   formatState.fontName = family;
   formatState.fontVariant = variant || 'regular';
   updateFontPickerLabel();
   refreshArabicPreviewFontFace();
+  syncFontPickerSelectionClasses();
   debouncedSave();
   if (closeMenu) closeFontPicker();
   if (window._activeTab === 'direct-insert' && window._refreshDirectInsert) {
@@ -124,6 +147,8 @@ function buildFontPickerDom() {
     (function (entry) {
       var li = document.createElement('li');
       li.className = 'font-picker-family-item';
+      li.setAttribute('data-font-family', entry.family);
+      li.setAttribute('role', 'option');
       var nameSpan = document.createElement('span');
       nameSpan.className = 'font-picker-family-name';
       nameSpan.textContent = entry.family;
@@ -139,6 +164,8 @@ function buildFontPickerDom() {
         for (var v = 0; v < variants.length; v++) {
           (function (tok) {
             var vli = document.createElement('li');
+            vli.setAttribute('data-variant-token', tok);
+            vli.setAttribute('role', 'option');
             vli.textContent = googleFontVariantLabel(tok);
             vli.addEventListener('click', function (e) {
               e.stopPropagation();
@@ -166,6 +193,7 @@ function buildFontPickerDom() {
       ul.appendChild(li);
     })(window._fontCatalog[i]);
   }
+  syncFontPickerSelectionClasses();
 }
 
 /**
@@ -196,6 +224,7 @@ function reconcileFontCatalogState() {
   }
   updateFontPickerLabel();
   refreshArabicPreviewFontFace();
+  syncFontPickerSelectionClasses();
   if (changed) {
     google.script.run
       .withFailureHandler(function () {})
@@ -238,6 +267,7 @@ function applyFormatStateToUI() {
   var colorPicker = document.getElementById('color-picker');
   var colorTrigger = document.getElementById('color-trigger');
   updateFontPickerLabel();
+  syncFontPickerSelectionClasses();
   if (sizeSelect) {
     var sizeVal = String(formatState.fontSize);
     if (sizeSelect.querySelector('option[value="' + sizeVal + '"]')) {

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -1,7 +1,7 @@
 <script>
 // Depends on: formatState, SAVE_DEBOUNCE_MS (shared-state.html),
-//   parseGoogleFontVariantClient, googleFontVariantLabel, ensureGoogleFontsPreviewStylesheet,
-//   arabicPreviewFontStyle (font-variant-utils.html)
+//   parseGoogleFontVariantClient, googleFontVariantLabel, pickDefaultRegularVariant,
+//   ensureGoogleFontsPreviewStylesheet, arabicPreviewFontStyle (font-variant-utils.html)
 // Reads window._activeTab, window._refreshDirectInsert (sidebar-js.html)
 
 var saveDebounceTimer = null;
@@ -156,6 +156,7 @@ function buildFontPickerDom() {
         li.addEventListener('click', function (e) {
           if (e.target && e.target.closest && e.target.closest('.font-picker-flyout')) return;
           e.stopPropagation();
+          selectFontAndVariant(entry.family, pickDefaultRegularVariant(variants), true);
         });
       } else if (variants.length === 1) {
         li.addEventListener('click', function () {

--- a/sidebar/js/pagination.html
+++ b/sidebar/js/pagination.html
@@ -46,12 +46,14 @@ function pagRenderPage(tabId, containerEl, emptyEl, emptyMsg) {
 
   var start = state.page * PAGE_SIZE;
   var end = Math.min(start + PAGE_SIZE, state.results.length);
-  var font = window.getFormatState ? window.getFormatState().fontName : 'Amiri';
+  var fs = window.getFormatState
+    ? window.getFormatState()
+    : { fontName: 'Amiri', fontVariant: 'regular' };
 
   for (var i = start; i < end; i++) {
     var card = document.createElement('div');
     card.className = 'result-card';
-    card.innerHTML = buildCardHtml(state.results[i], font);
+    card.innerHTML = buildCardHtml(state.results[i], fs);
     containerEl.appendChild(card);
   }
 

--- a/sidebar/js/render-helpers.html
+++ b/sidebar/js/render-helpers.html
@@ -27,16 +27,16 @@ function renderPreview(containerEl, results) {
   containerEl.innerHTML = '';
   if (!results || results.length === 0) return;
 
-  var font = formatState.fontName || 'Amiri';
+  var fs = window.getFormatState ? window.getFormatState() : formatState;
   var card = document.createElement('div');
   card.className = 'result-card';
 
   if (results.length === 1) {
-    card.innerHTML = buildCardHtml(results[0], font);
+    card.innerHTML = buildCardHtml(results[0], fs);
   } else {
     var rangeData = buildRangeData(results);
     rangeData.isRange = true;
-    card.innerHTML = buildCardHtml(rangeData, font);
+    card.innerHTML = buildCardHtml(rangeData, fs);
   }
 
   containerEl.appendChild(card);

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -110,29 +110,13 @@ function initSettingsPanelHandlers() {
 function onSettingsLoaded(settings) {
   _settings = settings;
   formatState.fontName = settings.fontName || 'Amiri';
+  formatState.fontVariant = settings.fontVariant || 'regular';
   formatState.fontSize = settings.fontSize || 18;
   formatState.bold = settings.bold || false;
   formatState.textColor = settings.textColor || '#000000';
   applyFormatStateToUI();
-}
-
-function onFontsLoaded(fonts) {
-  var fontSelect = document.getElementById('font-select');
-  if (!fontSelect || !fonts || !fonts.length) return;
-  fontSelect.innerHTML = '';
-  fonts.forEach(function(f) {
-    var opt = document.createElement('option');
-    opt.value = f;
-    opt.textContent = f;
-    if (f === formatState.fontName) opt.selected = true;
-    fontSelect.appendChild(opt);
-  });
-  if (formatState.fontName && !fonts.some(function(f){ return f === formatState.fontName; })) {
-    var fallback = document.createElement('option');
-    fallback.value = formatState.fontName;
-    fallback.textContent = formatState.fontName;
-    fallback.selected = true;
-    fontSelect.insertBefore(fallback, fontSelect.firstChild);
+  if (window._fontCatalog && window._fontCatalog.length && window.reconcileFontCatalogState) {
+    window.reconcileFontCatalogState();
   }
 }
 </script>

--- a/sidebar/js/shared-state.html
+++ b/sidebar/js/shared-state.html
@@ -1,6 +1,7 @@
 <script>
 var formatState = {
   fontName: 'Amiri',
+  fontVariant: 'regular',
   fontSize: 18,
   bold: false,
   textColor: '#000000'

--- a/sidebar/js/sidebar-js.html
+++ b/sidebar/js/sidebar-js.html
@@ -87,9 +87,9 @@
       .getSettings();
 
     google.script.run
-      .withSuccessHandler(function(f) { onFontsLoaded(f); onInitDone(); })
-      .withFailureHandler(function() { onInitDone(); })
-      .getArabicFonts();
+      .withSuccessHandler(function(res) { onFontCatalogLoaded(res); onInitDone(); })
+      .withFailureHandler(function() { onFontCatalogLoaded({ ok: false, error: 'RPC_FAIL', catalog: [] }); onInitDone(); })
+      .getCuratedFontCatalog();
 
     ensureUthmaniCache(onInitDone, onInitDone);
     ensureTranslationCache(onInitDone, onInitDone);

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -23,10 +23,10 @@
   .format-bar .font-picker-family-item { position: relative; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: space-between; gap: 6px; font-size: 12px; }
   .format-bar .font-picker-family-item:hover { background: #f0f0f0; }
   .format-bar .font-picker-chevron { flex-shrink: 0; color: #999; font-size: 12px; line-height: 1; }
-  .format-bar .font-picker-flyout { display: none; position: absolute; left: 0; right: 0; top: 100%; margin-top: 2px; min-width: 100%; box-sizing: border-box; max-height: 220px; overflow-y: auto; overflow-x: hidden; list-style: none; margin: 0; padding: 4px 0; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 301; box-shadow: 0 2px 10px rgba(0,0,0,0.12); scrollbar-width: none; -ms-overflow-style: none; }
+  .format-bar .font-picker-flyout { display: none; position: fixed; width: max-content; max-width: min(220px, calc(100vw - 24px)); min-width: 0; left: 0; top: 0; margin: 0; box-sizing: border-box; max-height: 220px; overflow-y: auto; overflow-x: hidden; list-style: none; padding: 4px 0; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 400; box-shadow: 0 2px 10px rgba(0,0,0,0.12); scrollbar-width: none; -ms-overflow-style: none; }
   .format-bar .font-picker-flyout::-webkit-scrollbar { display: none; }
   .format-bar .font-picker-family-item:hover .font-picker-flyout { display: block; }
-  .format-bar .font-picker-flyout li { padding: 6px 10px; font-size: 12px; cursor: pointer; white-space: nowrap; }
+  .format-bar .font-picker-flyout li { padding: 6px 8px; font-size: 12px; cursor: pointer; white-space: nowrap; }
   .format-bar .font-picker-flyout li:hover { background: #e8e8e8; }
   .format-bar .font-picker-empty { padding: 8px 10px; font-size: 11px; color: #888; list-style: none; }
   .format-bar .size-select { width: 52px; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -11,7 +11,21 @@
 
   .format-bar { display: flex; align-items: center; gap: 8px; padding: 10px 16px; border-bottom: 1px solid #e0e0e0; flex-wrap: wrap; flex-shrink: 0; }
   .format-bar select, .format-bar input[type="number"] { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 12px; min-width: 0; }
-  .format-bar .font-select { flex: 1; min-width: 80px; max-width: 140px; }
+  .format-bar .font-picker { position: relative; flex: 1; min-width: 80px; max-width: 200px; }
+  .format-bar .font-picker-trigger { width: 100%; text-align: left; display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 12px; background: #fff; cursor: pointer; }
+  .format-bar .font-picker-trigger:hover { border-color: #999; }
+  .format-bar .font-picker-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  .format-bar .font-picker-caret { flex-shrink: 0; color: #666; font-size: 10px; }
+  .format-bar .font-picker-dropdown { position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; max-width: 280px; max-height: 240px; overflow-y: auto; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 300; box-shadow: 0 2px 10px rgba(0,0,0,0.12); }
+  .format-bar .font-picker-families { list-style: none; margin: 0; padding: 4px 0; }
+  .format-bar .font-picker-family-item { position: relative; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: space-between; gap: 6px; font-size: 12px; }
+  .format-bar .font-picker-family-item:hover { background: #f0f0f0; }
+  .format-bar .font-picker-chevron { flex-shrink: 0; color: #999; font-size: 12px; line-height: 1; }
+  .format-bar .font-picker-flyout { display: none; position: absolute; left: 100%; top: 0; margin-left: 2px; min-width: 148px; max-height: 220px; overflow-y: auto; list-style: none; margin: 0; padding: 4px 0; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 301; box-shadow: 0 2px 10px rgba(0,0,0,0.12); }
+  .format-bar .font-picker-family-item:hover .font-picker-flyout { display: block; }
+  .format-bar .font-picker-flyout li { padding: 6px 10px; font-size: 12px; cursor: pointer; white-space: nowrap; }
+  .format-bar .font-picker-flyout li:hover { background: #e8e8e8; }
+  .format-bar .font-picker-empty { padding: 8px 10px; font-size: 11px; color: #888; list-style: none; }
   .format-bar .size-select { width: 52px; }
   .format-bar .btn-format { padding: 6px 10px; border: 1px solid #ccc; background: #fafafa; border-radius: 4px; font-size: 12px; font-weight: 700; cursor: pointer; }
   .format-bar .btn-format.active { background: #e8e8e8; border-color: #999; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -16,12 +16,15 @@
   .format-bar .font-picker-trigger:hover { border-color: #999; }
   .format-bar .font-picker-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
   .format-bar .font-picker-caret { flex-shrink: 0; color: #666; font-size: 10px; }
-  .format-bar .font-picker-dropdown { position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; max-width: 280px; max-height: 240px; overflow-y: auto; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 300; box-shadow: 0 2px 10px rgba(0,0,0,0.12); }
-  .format-bar .font-picker-families { list-style: none; margin: 0; padding: 4px 0; }
+  .format-bar .font-picker-dropdown { position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; width: max-content; max-width: min(318px, calc(100vw - 32px)); max-height: 240px; overflow-y: auto; overflow-x: hidden; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 300; box-shadow: 0 2px 10px rgba(0,0,0,0.12); scrollbar-width: none; -ms-overflow-style: none; }
+  .format-bar .font-picker-dropdown::-webkit-scrollbar { display: none; }
+  .format-bar .font-picker-families { list-style: none; margin: 0; padding: 4px 0; min-width: 100%; }
+  .format-bar .font-picker-family-name { white-space: nowrap; min-width: 0; }
   .format-bar .font-picker-family-item { position: relative; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: space-between; gap: 6px; font-size: 12px; }
   .format-bar .font-picker-family-item:hover { background: #f0f0f0; }
   .format-bar .font-picker-chevron { flex-shrink: 0; color: #999; font-size: 12px; line-height: 1; }
-  .format-bar .font-picker-flyout { display: none; position: absolute; left: 100%; top: 0; margin-left: 2px; min-width: 148px; max-height: 220px; overflow-y: auto; list-style: none; margin: 0; padding: 4px 0; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 301; box-shadow: 0 2px 10px rgba(0,0,0,0.12); }
+  .format-bar .font-picker-flyout { display: none; position: absolute; left: 0; right: 0; top: 100%; margin-top: 2px; min-width: 100%; box-sizing: border-box; max-height: 220px; overflow-y: auto; overflow-x: hidden; list-style: none; margin: 0; padding: 4px 0; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 301; box-shadow: 0 2px 10px rgba(0,0,0,0.12); scrollbar-width: none; -ms-overflow-style: none; }
+  .format-bar .font-picker-flyout::-webkit-scrollbar { display: none; }
   .format-bar .font-picker-family-item:hover .font-picker-flyout { display: block; }
   .format-bar .font-picker-flyout li { padding: 6px 10px; font-size: 12px; cursor: pointer; white-space: nowrap; }
   .format-bar .font-picker-flyout li:hover { background: #e8e8e8; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -22,12 +22,16 @@
   .format-bar .font-picker-family-name { white-space: nowrap; min-width: 0; }
   .format-bar .font-picker-family-item { position: relative; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; justify-content: space-between; gap: 6px; font-size: 12px; }
   .format-bar .font-picker-family-item:hover { background: #f0f0f0; }
+  .format-bar .font-picker-family-item.is-selected { background: #e8f5e9; box-shadow: inset 3px 0 0 #2e7d32; }
+  .format-bar .font-picker-family-item.is-selected:hover { background: #dcedc8; }
   .format-bar .font-picker-chevron { flex-shrink: 0; color: #999; font-size: 12px; line-height: 1; }
   .format-bar .font-picker-flyout { display: none; position: fixed; width: max-content; max-width: min(220px, calc(100vw - 24px)); min-width: 0; left: 0; top: 0; margin: 0; box-sizing: border-box; max-height: 220px; overflow-y: auto; overflow-x: hidden; list-style: none; padding: 4px 0; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 400; box-shadow: 0 2px 10px rgba(0,0,0,0.12); scrollbar-width: none; -ms-overflow-style: none; }
   .format-bar .font-picker-flyout::-webkit-scrollbar { display: none; }
   .format-bar .font-picker-family-item:hover .font-picker-flyout { display: block; }
   .format-bar .font-picker-flyout li { padding: 6px 8px; font-size: 12px; cursor: pointer; white-space: nowrap; }
   .format-bar .font-picker-flyout li:hover { background: #e8e8e8; }
+  .format-bar .font-picker-flyout li.is-selected { background: #e8f5e9; box-shadow: inset 3px 0 0 #2e7d32; font-weight: 500; color: #1b5e20; }
+  .format-bar .font-picker-flyout li.is-selected:hover { background: #dcedc8; }
   .format-bar .font-picker-empty { padding: 8px 10px; font-size: 11px; color: #888; list-style: none; }
   .format-bar .size-select { width: 52px; }
   .format-bar .btn-format { padding: 6px 10px; border: 1px solid #ccc; background: #fafafa; border-radius: 4px; font-size: 12px; font-weight: 700; cursor: pointer; }

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -47,6 +47,7 @@
   <?!= include('sidebar/js/quran-caches') ?>
   <?!= include('sidebar/js/search-utils') ?>
   <?!= include('sidebar/js/shared-state') ?>
+  <?!= include('sidebar/js/font-variant-utils') ?>
   <?!= include('sidebar/js/card-builder') ?>
   <?!= include('sidebar/js/pagination') ?>
   <?!= include('sidebar/js/render-helpers') ?>

--- a/tests/FontService.test.gs
+++ b/tests/FontService.test.gs
@@ -61,6 +61,26 @@ function runFontServiceTests() {
     }
   }
 
+  results.push('\nparseGoogleFontVariant()');
+
+  it('regular is weight 400 not italic', function () {
+    var p = parseGoogleFontVariant('regular');
+    if (p.weight !== 400 || p.italic !== false) throw new Error(JSON.stringify(p));
+  });
+
+  it('700italic is weight 700 italic', function () {
+    var p = parseGoogleFontVariant('700italic');
+    if (p.weight !== 700 || p.italic !== true) throw new Error(JSON.stringify(p));
+  });
+
+  results.push('\ngetCuratedFontCatalog()');
+
+  it('getCuratedFontCatalog returns ok boolean and catalog array', function () {
+    var cur = getCuratedFontCatalog();
+    if (typeof cur.ok !== 'boolean') throw new Error('missing ok');
+    if (!(cur.catalog instanceof Array)) throw new Error('catalog must be array');
+  });
+
   results.push('\ngetArabicFonts()');
 
   it('returns an array', function () {

--- a/tests/FontService.test.gs
+++ b/tests/FontService.test.gs
@@ -4,9 +4,24 @@
  * Run from Apps Script editor: select runFontServiceTests, click Run.
  * View results in View → Logs.
  *
- * Fetches from tasneef-data/fonts.json (no API key). Falls back to curated list on error.
+ * Fetches from tasneef-data/quran/quran-fonts.json (no API key).
+ * Update EXPECTED_APPROVED_FONTS_SORTED when hosted approved_fonts changes.
  * No require/Node APIs.
  */
+
+/** Sorted copy of tasneef-data/quran/quran-fonts.json approved_fonts */
+var EXPECTED_APPROVED_FONTS_SORTED = [
+  'Amiri',
+  'Amiri Quran',
+  'Harmattan',
+  'IBM Plex Sans Arabic',
+  'Lateef',
+  'Mada',
+  'Noto Kufi Arabic',
+  'Noto Naskh Arabic',
+  'Noto Sans Arabic',
+  'Scheherazade New'
+];
 
 function runFontServiceTests() {
   var passed = 0;
@@ -30,18 +45,19 @@ function runFontServiceTests() {
         if (actual !== expected) {
           throw new Error('Expected ' + JSON.stringify(expected) + ' but got ' + JSON.stringify(actual));
         }
-      },
-      toBeGreaterThan: function (n) {
-        if (typeof actual !== 'number' || actual <= n) {
-          throw new Error('Expected > ' + n + ' but got ' + JSON.stringify(actual));
-        }
-      },
-      toContain: function (item) {
-        if (actual.indexOf(item) < 0) {
-          throw new Error('Expected array to contain ' + JSON.stringify(item));
-        }
       }
     };
+  }
+
+  function expectArraysEqual(a, b) {
+    if (!a || !b || a.length !== b.length) {
+      throw new Error('Expected equal length arrays, got ' + JSON.stringify(a) + ' vs ' + JSON.stringify(b));
+    }
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        throw new Error('Mismatch at ' + i + ': ' + JSON.stringify(a[i]) + ' vs ' + JSON.stringify(b[i]));
+      }
+    }
   }
 
   results.push('\ngetArabicFonts()');
@@ -51,33 +67,20 @@ function runFontServiceTests() {
     if (!(fonts instanceof Array)) throw new Error('Expected array');
   });
 
-  it('returns at least one font (Amiri in list)', function () {
+  it('matches sorted curated list from quran-fonts.json', function () {
     var fonts = getArabicFonts();
-    expect(fonts.length).toBeGreaterThan(0);
-    expect(fonts).toContain('Amiri');
-  });
-
-  it('excludes all BAD_FONTS from the list', function () {
-    var fonts = getArabicFonts();
-    var bad = ['Blaka', 'Cairo', 'Rubik', 'Markazi Text', 'Reem Kufi Fun'];
-    for (var i = 0; i < bad.length; i++) {
-      if (fonts.indexOf(bad[i]) >= 0) {
-        throw new Error('BAD_FONT ' + bad[i] + ' should not be in list');
-      }
-    }
-  });
-
-  it('returns list sorted alphabetically', function () {
-    var fonts = getArabicFonts();
-    for (var j = 1; j < fonts.length; j++) {
-      if (fonts[j].localeCompare(fonts[j - 1], 'en') < 0) {
-        throw new Error('List not sorted: ' + fonts[j - 1] + ' before ' + fonts[j]);
-      }
-    }
+    expectArraysEqual(fonts, EXPECTED_APPROVED_FONTS_SORTED);
   });
 
   it('FALLBACK_FONT constant equals Amiri', function () {
     expect(FALLBACK_FONT).toBe('Amiri');
+  });
+
+  it('FALLBACK_APPROVED_FONTS matches expected curated set (unsorted ok)', function () {
+    var sorted = FALLBACK_APPROVED_FONTS.slice().sort(function (a, b) {
+      return a.localeCompare(b, 'en');
+    });
+    expectArraysEqual(sorted, EXPECTED_APPROVED_FONTS_SORTED);
   });
 
   results.push('\n─────────────────────────────────────────');

--- a/tests/FontService.test.gs
+++ b/tests/FontService.test.gs
@@ -4,7 +4,7 @@
  * Run from Apps Script editor: select runFontServiceTests, click Run.
  * View results in View → Logs.
  *
- * Fetches from tasneef-data/quran/quran-fonts.json (no API key).
+ * Fetches from tasneef-data/quran/quran-fonts.json (no API key, no ScriptCache).
  * Update EXPECTED_APPROVED_FONTS_SORTED when hosted approved_fonts changes.
  * No require/Node APIs.
  */
@@ -12,7 +12,6 @@
 /** Sorted copy of tasneef-data/quran/quran-fonts.json approved_fonts */
 var EXPECTED_APPROVED_FONTS_SORTED = [
   'Amiri',
-  'Amiri Quran',
   'Harmattan',
   'IBM Plex Sans Arabic',
   'Lateef',
@@ -20,7 +19,9 @@ var EXPECTED_APPROVED_FONTS_SORTED = [
   'Noto Kufi Arabic',
   'Noto Naskh Arabic',
   'Noto Sans Arabic',
-  'Scheherazade New'
+  'Reem Kufi Ink',
+  'Scheherazade New',
+  'Tajawal'
 ];
 
 function runFontServiceTests() {

--- a/tests/buildResultCardHtml.test.js
+++ b/tests/buildResultCardHtml.test.js
@@ -31,6 +31,27 @@ function escapeHtml(s) {
     .replace(/"/g, '&quot;');
 }
 
+function parseGoogleFontVariantClient(token) {
+  if (token == null || typeof token !== 'string') return { weight: 400, italic: false };
+  var t = token.replace(/\s/g, '');
+  if (t === '') return { weight: 400, italic: false };
+  if (t === 'regular') return { weight: 400, italic: false };
+  if (t === 'italic') return { weight: 400, italic: true };
+  var italic = /italic$/i.test(t);
+  if (italic) t = t.replace(/italic$/i, '');
+  var w = parseInt(t, 10);
+  if (!isNaN(w)) return { weight: w, italic: italic };
+  return { weight: 400, italic: false };
+}
+
+function arabicPreviewFontStyle(fs) {
+  var fam = (fs && fs.fontName) || 'Amiri';
+  var safeFam = String(fam).replace(/['\\<>]/g, '');
+  var p = parseGoogleFontVariantClient(fs && fs.fontVariant ? fs.fontVariant : 'regular');
+  return 'font-family:\'' + safeFam + '\',serif;font-weight:' + p.weight +
+    ';font-style:' + (p.italic ? 'italic' : 'normal');
+}
+
 // ─── isConsecutiveRange ───────────────────────────────────────────────────────
 
 function isConsecutiveRange(results) {
@@ -64,8 +85,15 @@ function buildRangeData(results) {
 
 // ─── buildCardHtml ────────────────────────────────────────────────────────────
 
-function buildCardHtml(cardData, font) {
+function buildCardHtml(cardData, fontOrFs) {
   var arabicRef, englishRef, arabicHtml;
+  var arabicCss;
+  if (fontOrFs && typeof fontOrFs === 'object' && fontOrFs.fontName) {
+    arabicCss = arabicPreviewFontStyle(fontOrFs);
+  } else {
+    var f = (typeof fontOrFs === 'string' && fontOrFs) ? fontOrFs : 'Amiri';
+    arabicCss = 'font-family:\'' + String(f).replace(/['\\<>]/g, '') + '\',serif;font-weight:400;font-style:normal';
+  }
 
   if (cardData.isRange) {
     arabicRef = escapeHtml(cardData.surahNameArabic || '') +
@@ -78,7 +106,7 @@ function buildCardHtml(cardData, font) {
     arabicHtml = escapeHtml(cardData.arabicText);
 
     return '<div class="ref-arabic">' + arabicRef + '</div>' +
-      '<div class="arabic range-block" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
+      '<div class="arabic range-block" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
       '<div class="ref-english">' + englishRef + '</div>' +
       '<button type="button" class="btn-primary btn-insert-result" ' +
         'data-surah="' + cardData.surah + '" ' +
@@ -98,7 +126,7 @@ function buildCardHtml(cardData, font) {
   }
 
   return '<div class="ref-arabic">' + arabicRef + '</div>' +
-    '<div class="arabic" style="font-family:' + escapeHtml(font) + ',serif">' + arabicHtml + '</div>' +
+    '<div class="arabic" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
     '<div class="ref-english">' + englishRef + '</div>' +
     '<button type="button" class="btn-primary btn-insert-result" ' +
       'data-surah="' + cardData.surah + '" data-ayah="' + cardData.ayah + '">Insert</button>';
@@ -413,7 +441,7 @@ function runTests() {
       arabicText: 'بسم الله'
     };
     var html = buildCardHtml(r, 'Scheherazade New');
-    assert.ok(html.indexOf('font-family:Scheherazade New,serif') >= 0, 'custom font applied');
+    assert.ok(html.indexOf("font-family:'Scheherazade New',serif") >= 0, 'custom font applied');
   });
 
   it('single: falls back to "Surah" when surahNameEnglish is empty', function () {

--- a/tests/fontVariant.test.js
+++ b/tests/fontVariant.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/**
+ * Node tests for Google Fonts variant token parsing (parity with FontService.parseGoogleFontVariant).
+ * Run: npm run test:font
+ */
+
+const assert = require('assert');
+
+function parseGoogleFontVariant(token) {
+  if (token == null || typeof token !== 'string') return { weight: 400, italic: false };
+  var t = token.replace(/\s/g, '');
+  if (t === '') return { weight: 400, italic: false };
+  if (t === 'regular') return { weight: 400, italic: false };
+  if (t === 'italic') return { weight: 400, italic: true };
+  var italic = /italic$/i.test(t);
+  if (italic) t = t.replace(/italic$/i, '');
+  var w = parseInt(t, 10);
+  if (!isNaN(w)) return { weight: w, italic: italic };
+  return { weight: 400, italic: false };
+}
+
+function buildGoogleFontsPreviewHref(family, variantTokens) {
+  var famEnc = family.replace(/ /g, '+');
+  var pairSet = {};
+  var hasItal = false;
+  var hasRom = false;
+  for (var i = 0; i < variantTokens.length; i++) {
+    var p = parseGoogleFontVariant(variantTokens[i]);
+    if (p.italic) hasItal = true;
+    else hasRom = true;
+    var pair = (p.italic ? 1 : 0) + ',' + p.weight;
+    pairSet[pair] = true;
+  }
+  var pairs = Object.keys(pairSet).sort(function (a, b) {
+    var aa = a.split(',');
+    var bb = b.split(',');
+    if (aa[0] !== bb[0]) return parseInt(aa[0], 10) - parseInt(bb[0], 10);
+    return parseInt(aa[1], 10) - parseInt(bb[1], 10);
+  });
+  if (!hasItal) {
+    var wOnly = [];
+    for (var j = 0; j < pairs.length; j++) {
+      wOnly.push(pairs[j].split(',')[1]);
+    }
+    return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':wght@' + wOnly.join(';') + '&display=swap';
+  }
+  if (!hasRom) {
+    var italOnly = pairs.map(function (pr) { return '1,' + pr.split(',')[1]; });
+    return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' + italOnly.join(';') + '&display=swap';
+  }
+  return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' + pairs.join(';') + '&display=swap';
+}
+
+var passed = 0;
+function it(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log('  ✓', name);
+  } catch (e) {
+    console.error('  ✗', name, e.message);
+    process.exitCode = 1;
+  }
+}
+
+console.log('fontVariant');
+it('regular → 400 roman', function () {
+  var p = parseGoogleFontVariant('regular');
+  assert.strictEqual(p.weight, 400);
+  assert.strictEqual(p.italic, false);
+});
+it('italic → 400 italic', function () {
+  var p = parseGoogleFontVariant('italic');
+  assert.strictEqual(p.weight, 400);
+  assert.strictEqual(p.italic, true);
+});
+it('700 → 700 roman', function () {
+  var p = parseGoogleFontVariant('700');
+  assert.strictEqual(p.weight, 700);
+  assert.strictEqual(p.italic, false);
+});
+it('700italic → 700 italic', function () {
+  var p = parseGoogleFontVariant('700italic');
+  assert.strictEqual(p.weight, 700);
+  assert.strictEqual(p.italic, true);
+});
+it('preview href roman weights only', function () {
+  var h = buildGoogleFontsPreviewHref('Amiri', ['regular', '700']);
+  assert.ok(h.indexOf('family=Amiri') > 0 && h.indexOf(':wght@') > 0, h);
+});
+it('preview href mixed roman and italic', function () {
+  var h = buildGoogleFontsPreviewHref('Amiri', ['regular', 'italic']);
+  assert.ok(h.indexOf('ital,wght@') > 0, h);
+});
+
+console.log('fontVariant:', passed, 'passed');

--- a/tests/fontVariant.test.js
+++ b/tests/fontVariant.test.js
@@ -20,6 +20,16 @@ function parseGoogleFontVariant(token) {
   return { weight: 400, italic: false };
 }
 
+function pickDefaultRegularVariant(variants) {
+  if (!variants || !variants.length) return 'regular';
+  if (variants.indexOf('regular') >= 0) return 'regular';
+  for (var i = 0; i < variants.length; i++) {
+    var p = parseGoogleFontVariant(variants[i]);
+    if (p.weight === 400 && !p.italic) return variants[i];
+  }
+  return variants[0];
+}
+
 function buildGoogleFontsPreviewHref(family, variantTokens) {
   var famEnc = family.replace(/ /g, '+');
   var pairSet = {};
@@ -92,6 +102,18 @@ it('preview href roman weights only', function () {
 it('preview href mixed roman and italic', function () {
   var h = buildGoogleFontsPreviewHref('Amiri', ['regular', 'italic']);
   assert.ok(h.indexOf('ital,wght@') > 0, h);
+});
+it('pickDefaultRegularVariant prefers regular token', function () {
+  assert.strictEqual(pickDefaultRegularVariant(['700', 'regular', 'italic']), 'regular');
+});
+it('pickDefaultRegularVariant uses first 400 roman when regular missing', function () {
+  assert.strictEqual(pickDefaultRegularVariant(['300', '400', '700']), '400');
+});
+it('pickDefaultRegularVariant falls back to first token', function () {
+  assert.strictEqual(pickDefaultRegularVariant(['700', '800']), '700');
+});
+it('pickDefaultRegularVariant empty → regular', function () {
+  assert.strictEqual(pickDefaultRegularVariant([]), 'regular');
 });
 
 console.log('fontVariant:', passed, 'passed');


### PR DESCRIPTION
Closes #64

- `getArabicFonts()` reads `approved_fonts` from `tasneef-data/quran/quran-fonts.json` only (no `fonts.json`, no `BAD_FONTS`).
- New script cache key `arabic_fonts_quran_curated` so existing caches refresh.
- GAS tests assert the sorted list matches the hosted curated set; update `EXPECTED_APPROVED_FONTS_SORTED` when the JSON changes.
- CLAUDE.md documents the new URL.

Made with [Cursor](https://cursor.com)