### PR TITLE
TEMP: Font audit — insert Al-Baqara 2:1-2 per font

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -4,6 +4,7 @@ task-*.md
 tasneef-*.md
 node_modules/**
 .git/**
+.claude/**
 README.md
 .clasp.json
 sidebar/assets/**

--- a/FontAuditService.js
+++ b/FontAuditService.js
@@ -20,12 +20,12 @@ function insertFontAudit(ayahData) {
     return { success: false, fontsInserted: 0, message: 'Invalid ayah data.' };
   }
 
-  var fontsResult = getAllArabicFontsFromApi();
+  var fontsResult = getCuratedFontCatalog();
   if (!fontsResult.ok) {
     return { success: false, fontsInserted: 0, message: fontsResult.error || 'Failed to fetch fonts.' };
   }
 
-  var fonts = fontsResult.fonts;
+  var fonts = fontsResult.catalog;
   if (!fonts.length) {
     return { success: false, fontsInserted: 0, message: 'No fonts returned from Google Fonts API.' };
   }

--- a/FontAuditService.js
+++ b/FontAuditService.js
@@ -1,7 +1,7 @@
 /**
  * FontAuditService.gs
- * TEMP dev tool — inserts the first two ayahs of Al-Baqara (2:1, 2:2) once per
- * Arabic font available in the Google Fonts API, each preceded by a label paragraph.
+ * TEMP dev tool — inserts As-Sajdah 32:15 once per Arabic font available in
+ * the Google Fonts API, each preceded by a label paragraph.
  * This file is NOT for merge; the branch will be discarded after font curation.
  */
 
@@ -9,16 +9,14 @@
  * Inserts a font audit block into the active document.
  * For each Arabic font in the Google Fonts API, appends:
  *   1. A label paragraph: "── Family Name ──" (Normal, LTR, no Arabic font)
- *   2. Ayah 2:1 paragraph (RTL, CENTER, 18pt, that font)
- *   3. Ayah 2:2 paragraph (RTL, CENTER, 18pt, that font)
+ *   2. Ayah 32:15 paragraph (RTL, CENTER, 18pt, that font)
  * Finishes with a cleanup paragraph.
  *
- * @param {Object} ayah1Data - { textUthmani, surahNameArabic, surahNameEnglish, surah, ayah }
- * @param {Object} ayah2Data - { textUthmani, surahNameArabic, surahNameEnglish, surah, ayah }
+ * @param {Object} ayahData - { textUthmani, surahNameArabic, surahNameEnglish, surah, ayah }
  * @return {{ success: boolean, fontsInserted: number, message: string }}
  */
-function insertFontAudit(ayah1Data, ayah2Data) {
-  if (!ayah1Data || !ayah1Data.textUthmani || !ayah2Data || !ayah2Data.textUthmani) {
+function insertFontAudit(ayahData) {
+  if (!ayahData || !ayahData.textUthmani) {
     return { success: false, fontsInserted: 0, message: 'Invalid ayah data.' };
   }
 
@@ -35,8 +33,7 @@ function insertFontAudit(ayah1Data, ayah2Data) {
   var doc = DocumentApp.getActiveDocument();
   var body = doc.getBody();
 
-  var text1 = '\uFD3F ' + ayah1Data.textUthmani + ' \uFD3E';
-  var text2 = '\uFD3F ' + ayah2Data.textUthmani + ' \uFD3E';
+  var text = '\uFD3F ' + ayahData.textUthmani + ' \uFD3E';
 
   for (var i = 0; i < fonts.length; i++) {
     var family = fonts[i].family;
@@ -49,17 +46,11 @@ function insertFontAudit(ayah1Data, ayah2Data) {
     label.setHeading(DocumentApp.ParagraphHeading.NORMAL);
     label.setLeftToRight(true);
 
-    // Ayah 2:1
-    var p1 = body.appendParagraph(text1);
-    p1.setAlignment(DocumentApp.HorizontalAlignment.CENTER);
-    p1.setLeftToRight(false);
-    applyFormat(p1.editAsText(), fs);
-
-    // Ayah 2:2
-    var p2 = body.appendParagraph(text2);
-    p2.setAlignment(DocumentApp.HorizontalAlignment.CENTER);
-    p2.setLeftToRight(false);
-    applyFormat(p2.editAsText(), fs);
+    // Ayah 32:15
+    var p = body.appendParagraph(text);
+    p.setAlignment(DocumentApp.HorizontalAlignment.CENTER);
+    p.setLeftToRight(false);
+    applyFormat(p.editAsText(), fs);
   }
 
   // Cleanup paragraph

--- a/FontAuditService.js
+++ b/FontAuditService.js
@@ -1,0 +1,77 @@
+/**
+ * FontAuditService.gs
+ * TEMP dev tool — inserts the first two ayahs of Al-Baqara (2:1, 2:2) once per
+ * Arabic font available in the Google Fonts API, each preceded by a label paragraph.
+ * This file is NOT for merge; the branch will be discarded after font curation.
+ */
+
+/**
+ * Inserts a font audit block into the active document.
+ * For each Arabic font in the Google Fonts API, appends:
+ *   1. A label paragraph: "── Family Name ──" (Normal, LTR, no Arabic font)
+ *   2. Ayah 2:1 paragraph (RTL, CENTER, 18pt, that font)
+ *   3. Ayah 2:2 paragraph (RTL, CENTER, 18pt, that font)
+ * Finishes with a cleanup paragraph.
+ *
+ * @param {Object} ayah1Data - { textUthmani, surahNameArabic, surahNameEnglish, surah, ayah }
+ * @param {Object} ayah2Data - { textUthmani, surahNameArabic, surahNameEnglish, surah, ayah }
+ * @return {{ success: boolean, fontsInserted: number, message: string }}
+ */
+function insertFontAudit(ayah1Data, ayah2Data) {
+  if (!ayah1Data || !ayah1Data.textUthmani || !ayah2Data || !ayah2Data.textUthmani) {
+    return { success: false, fontsInserted: 0, message: 'Invalid ayah data.' };
+  }
+
+  var fontsResult = getAllArabicFontsFromApi();
+  if (!fontsResult.ok) {
+    return { success: false, fontsInserted: 0, message: fontsResult.error || 'Failed to fetch fonts.' };
+  }
+
+  var fonts = fontsResult.fonts;
+  if (!fonts.length) {
+    return { success: false, fontsInserted: 0, message: 'No fonts returned from Google Fonts API.' };
+  }
+
+  var doc = DocumentApp.getActiveDocument();
+  var body = doc.getBody();
+
+  var text1 = '\uFD3F ' + ayah1Data.textUthmani + ' \uFD3E';
+  var text2 = '\uFD3F ' + ayah2Data.textUthmani + ' \uFD3E';
+
+  for (var i = 0; i < fonts.length; i++) {
+    var family = fonts[i].family;
+    var variant = pickRegularVariant_(fonts[i].variants);
+    var fs = { fontName: family, fontVariant: variant, fontSize: 18, bold: false, textColor: '#000000' };
+
+    // Label paragraph — intentionally no Arabic font so it stays legible
+    var label = body.appendParagraph('\u2500\u2500 ' + family + ' \u2500\u2500');
+    label.setAlignment(DocumentApp.HorizontalAlignment.LEFT);
+    label.setHeading(DocumentApp.ParagraphHeading.NORMAL);
+    label.setLeftToRight(true);
+
+    // Ayah 2:1
+    var p1 = body.appendParagraph(text1);
+    p1.setAlignment(DocumentApp.HorizontalAlignment.CENTER);
+    p1.setLeftToRight(false);
+    applyFormat(p1.editAsText(), fs);
+
+    // Ayah 2:2
+    var p2 = body.appendParagraph(text2);
+    p2.setAlignment(DocumentApp.HorizontalAlignment.CENTER);
+    p2.setLeftToRight(false);
+    applyFormat(p2.editAsText(), fs);
+  }
+
+  // Cleanup paragraph
+  var cleanup = body.appendParagraph('');
+  cleanup.setHeading(DocumentApp.ParagraphHeading.NORMAL);
+  cleanup.setLeftToRight(true);
+
+  try {
+    doc.setCursor(doc.newPosition(cleanup, 0));
+  } catch (e) {
+    // Non-UI context; ignore
+  }
+
+  return { success: true, fontsInserted: fonts.length, message: 'Inserted ' + fonts.length + ' fonts.' };
+}

--- a/FontService.js
+++ b/FontService.js
@@ -106,6 +106,58 @@ function getArabicFonts() {
 }
 
 /**
+ * Selects the regular (weight 400, non-italic) variant from a list, or the
+ * lightest non-italic weight if 'regular' is not present.
+ * @param {Array<string>} variants
+ * @return {string}
+ */
+function pickRegularVariant_(variants) {
+  if (!variants || !variants.length) return 'regular';
+  if (variants.indexOf('regular') !== -1) return 'regular';
+  var best = null;
+  var bestWeight = Infinity;
+  for (var i = 0; i < variants.length; i++) {
+    var parsed = parseGoogleFontVariant(variants[i]);
+    if (!parsed.italic && parsed.weight < bestWeight) {
+      bestWeight = parsed.weight;
+      best = variants[i];
+    }
+  }
+  return best || variants[0];
+}
+
+/**
+ * Fetches ALL Arabic-subset fonts from Google Fonts API without approved-list filtering.
+ * Requires Script Properties google_fonts_api_key via getGoogleFontsApiKey().
+ * @return {{ ok: boolean, error: string|null, fonts: Array<{family: string, variants: string[]}> }}
+ */
+function getAllArabicFontsFromApi() {
+  var empty = { ok: false, error: null, fonts: [] };
+  var apiKey = getGoogleFontsApiKey();
+  if (!apiKey || String(apiKey).trim().length === 0) {
+    empty.error = 'NO_GOOGLE_FONTS_API_KEY';
+    return empty;
+  }
+  try {
+    var url = GOOGLE_WEBFONTS_API +
+      '?key=' + encodeURIComponent(String(apiKey).trim()) +
+      '&subset=arabic&sort=alpha';
+    var r = UrlFetchApp.fetch(url);
+    var data = JSON.parse(r.getContentText());
+    var fonts = (data.items || []).map(function(item) {
+      return {
+        family: item.family,
+        variants: sortFontVariantTokens_(item.variants ? item.variants.slice() : [])
+      };
+    });
+    return { ok: true, error: null, fonts: fonts };
+  } catch (e) {
+    empty.error = String(e.message || e);
+    return empty;
+  }
+}
+
+/**
  * Fetches Google Fonts metadata (arabic subset) intersected with quran-fonts approved_fonts.
  * Requires Script Properties google_fonts_api_key via getGoogleFontsApiKey().
  * @return {{ ok: boolean, error: string|null, catalog: Array<{family: string, variants: string[]}> }}

--- a/sidebar/components/settings-panel.html
+++ b/sidebar/components/settings-panel.html
@@ -22,4 +22,10 @@
     <button type="button" class="btn-primary" id="btn-save-settings">Save</button>
     <p id="settings-saved-msg" class="settings-saved-msg hidden"></p>
   </div>
+
+  <div class="settings-section">
+    <label>Developer tools</label>
+    <button type="button" class="btn-secondary" id="btn-font-audit">Insert Font Audit (Al-Baqara 2:1–2)</button>
+    <p id="font-audit-msg" class="settings-saved-msg hidden"></p>
+  </div>
 </div>

--- a/sidebar/components/settings-panel.html
+++ b/sidebar/components/settings-panel.html
@@ -25,7 +25,7 @@
 
   <div class="settings-section">
     <label>Developer tools</label>
-    <button type="button" class="btn-secondary" id="btn-font-audit">Insert Font Audit (Al-Baqara 2:1–2)</button>
+    <button type="button" class="btn-secondary" id="btn-font-audit">Insert Font Audit (As-Sajdah 32:15)</button>
     <p id="font-audit-msg" class="settings-saved-msg hidden"></p>
   </div>
 </div>

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -127,26 +127,19 @@ function initFontAuditButton() {
 
     ensureUthmaniCache(function() {
       ensureSurahMetaCache(function(surahList) {
-        var meta = (surahList || []).find(function(s) { return s.number === 2; }) || {};
-        var u1 = lookupUthmaniAyah(2, 1);
-        var u2 = lookupUthmaniAyah(2, 2);
+        var meta = (surahList || []).find(function(s) { return s.number === 32; }) || {};
+        var u = lookupUthmaniAyah(32, 15);
 
-        if (!u1 || !u2) {
+        if (!u) {
           btn.disabled = false;
-          btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+          btn.textContent = 'Insert Font Audit (As-Sajdah 32:15)';
           showMsg('Failed to load ayah data.', true);
           return;
         }
 
-        var ayah1Data = {
-          surah: 2, ayah: 1,
-          textUthmani: u1.text,
-          surahNameArabic: meta.nameArabic || '',
-          surahNameEnglish: meta.nameEnglish || ''
-        };
-        var ayah2Data = {
-          surah: 2, ayah: 2,
-          textUthmani: u2.text,
+        var ayahData = {
+          surah: 32, ayah: 15,
+          textUthmani: u.text,
           surahNameArabic: meta.nameArabic || '',
           surahNameEnglish: meta.nameEnglish || ''
         };
@@ -154,23 +147,23 @@ function initFontAuditButton() {
         google.script.run
           .withSuccessHandler(function(result) {
             btn.disabled = false;
-            btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+            btn.textContent = 'Insert Font Audit (As-Sajdah 32:15)';
             showMsg(result.message || 'Done.', !result.success);
           })
           .withFailureHandler(function(err) {
             btn.disabled = false;
-            btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+            btn.textContent = 'Insert Font Audit (As-Sajdah 32:15)';
             showMsg('Error: ' + (err.message || String(err)), true);
           })
-          .insertFontAudit(ayah1Data, ayah2Data);
+          .insertFontAudit(ayahData);
       }, function() {
         btn.disabled = false;
-        btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+        btn.textContent = 'Insert Font Audit (As-Sajdah 32:15)';
         showMsg('Failed to load surah data.', true);
       });
     }, function() {
       btn.disabled = false;
-      btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+      btn.textContent = 'Insert Font Audit (As-Sajdah 32:15)';
       showMsg('Failed to load Quran text.', true);
     });
   });

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -34,6 +34,7 @@ function initSettings() {
       }
     });
   }
+  initFontAuditButton();
 }
 
 function refreshSettings() {
@@ -105,6 +106,74 @@ function initSettingsPanelHandlers() {
         .saveSettings({ showTranslation: showTranslation });
     });
   }
+}
+
+function initFontAuditButton() {
+  var btn = document.getElementById('btn-font-audit');
+  var msg = document.getElementById('font-audit-msg');
+  if (!btn) return;
+
+  function showMsg(text, isError) {
+    if (!msg) return;
+    msg.textContent = text;
+    msg.className = 'settings-saved-msg ' + (isError ? 'error' : 'success');
+    msg.classList.remove('hidden');
+    setTimeout(function() { msg.classList.add('hidden'); }, 4000);
+  }
+
+  btn.addEventListener('click', function() {
+    btn.disabled = true;
+    btn.textContent = 'Inserting\u2026';
+
+    ensureUthmaniCache(function() {
+      ensureSurahMetaCache(function(surahList) {
+        var meta = (surahList || []).find(function(s) { return s.number === 2; }) || {};
+        var u1 = lookupUthmaniAyah(2, 1);
+        var u2 = lookupUthmaniAyah(2, 2);
+
+        if (!u1 || !u2) {
+          btn.disabled = false;
+          btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+          showMsg('Failed to load ayah data.', true);
+          return;
+        }
+
+        var ayah1Data = {
+          surah: 2, ayah: 1,
+          textUthmani: u1.text,
+          surahNameArabic: meta.nameArabic || '',
+          surahNameEnglish: meta.nameEnglish || ''
+        };
+        var ayah2Data = {
+          surah: 2, ayah: 2,
+          textUthmani: u2.text,
+          surahNameArabic: meta.nameArabic || '',
+          surahNameEnglish: meta.nameEnglish || ''
+        };
+
+        google.script.run
+          .withSuccessHandler(function(result) {
+            btn.disabled = false;
+            btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+            showMsg(result.message || 'Done.', !result.success);
+          })
+          .withFailureHandler(function(err) {
+            btn.disabled = false;
+            btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+            showMsg('Error: ' + (err.message || String(err)), true);
+          })
+          .insertFontAudit(ayah1Data, ayah2Data);
+      }, function() {
+        btn.disabled = false;
+        btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+        showMsg('Failed to load surah data.', true);
+      });
+    }, function() {
+      btn.disabled = false;
+      btn.textContent = 'Insert Font Audit (Al-Baqara 2:1\u20132)';
+      showMsg('Failed to load Quran text.', true);
+    });
+  });
 }
 
 function onSettingsLoaded(settings) {

--- a/tests/fontAudit.test.gs
+++ b/tests/fontAudit.test.gs
@@ -1,0 +1,152 @@
+/**
+ * GAS-native tests for FontAuditService.gs and the font audit helpers in FontService.gs.
+ *
+ * Run from Apps Script editor: select runFontAuditTests, click Run.
+ * View results in View → Logs.
+ *
+ * getAllArabicFontsFromApi() requires a valid google_fonts_api_key in Script Properties.
+ * pickRegularVariant_() and insertFontAudit() validation tests require no external calls.
+ */
+
+function runFontAuditTests() {
+  var passed = 0;
+  var failed = 0;
+  var results = [];
+
+  function it(label, fn) {
+    try {
+      fn();
+      results.push('  \u2713 ' + label);
+      passed++;
+    } catch (e) {
+      results.push('  \u2717 ' + label + '\n      \u2192 ' + (e.message || e));
+      failed++;
+    }
+  }
+
+  function expect(actual) {
+    return {
+      toBe: function(expected) {
+        if (actual !== expected) {
+          throw new Error('Expected ' + JSON.stringify(expected) + ' but got ' + JSON.stringify(actual));
+        }
+      },
+      toBeTrue: function() {
+        if (actual !== true) throw new Error('Expected true but got ' + JSON.stringify(actual));
+      },
+      toBeFalse: function() {
+        if (actual !== false) throw new Error('Expected false but got ' + JSON.stringify(actual));
+      }
+    };
+  }
+
+  // ─── pickRegularVariant_() ─────────────────────────────────────────────────
+
+  results.push('\npickRegularVariant_()');
+
+  it('returns "regular" when present', function() {
+    expect(pickRegularVariant_(['700', 'regular', '700italic'])).toBe('regular');
+  });
+
+  it('returns lightest non-italic when "regular" is absent', function() {
+    var v = pickRegularVariant_(['700', '500', '700italic', '500italic']);
+    expect(v).toBe('500');
+  });
+
+  it('returns first variant for italic-only font', function() {
+    var v = pickRegularVariant_(['italic', '700italic']);
+    // italic is weight 400 italic — still lighter than 700italic
+    // implementation picks lightest non-italic; if none exist, falls back to first
+    if (typeof v !== 'string' || v.length === 0) throw new Error('Expected non-empty string, got ' + JSON.stringify(v));
+  });
+
+  it('returns "regular" for empty array', function() {
+    expect(pickRegularVariant_([])).toBe('regular');
+  });
+
+  it('returns "regular" for null', function() {
+    expect(pickRegularVariant_(null)).toBe('regular');
+  });
+
+  // ─── insertFontAudit() input validation ───────────────────────────────────
+
+  results.push('\ninsertFontAudit() validation');
+
+  it('returns failure for null ayah1Data', function() {
+    var r = insertFontAudit(null, { textUthmani: 'test' });
+    expect(r.success).toBeFalse();
+  });
+
+  it('returns failure for null ayah2Data', function() {
+    var r = insertFontAudit({ textUthmani: 'test' }, null);
+    expect(r.success).toBeFalse();
+  });
+
+  it('returns failure when textUthmani is missing from ayah1Data', function() {
+    var r = insertFontAudit({ surah: 2, ayah: 1 }, { textUthmani: 'test' });
+    expect(r.success).toBeFalse();
+  });
+
+  it('returns failure when textUthmani is missing from ayah2Data', function() {
+    var r = insertFontAudit({ textUthmani: 'test' }, { surah: 2, ayah: 2 });
+    expect(r.success).toBeFalse();
+  });
+
+  // ─── getAllArabicFontsFromApi() (requires live API key) ────────────────────
+
+  results.push('\ngetAllArabicFontsFromApi() [requires google_fonts_api_key]');
+
+  it('returns ok:true with a non-empty fonts array', function() {
+    var r = getAllArabicFontsFromApi();
+    if (!r.ok) {
+      // Skip gracefully if key is not set
+      if (r.error === 'NO_GOOGLE_FONTS_API_KEY') {
+        results[results.length - 1] += ' (SKIPPED — no API key)';
+        return;
+      }
+      throw new Error('Expected ok:true but got error: ' + r.error);
+    }
+    if (!(r.fonts instanceof Array) || r.fonts.length === 0) {
+      throw new Error('Expected non-empty fonts array');
+    }
+  });
+
+  it('each font entry has family string and variants array', function() {
+    var r = getAllArabicFontsFromApi();
+    if (!r.ok) {
+      results[results.length - 1] += ' (SKIPPED — no API key or fetch failed)';
+      return;
+    }
+    for (var i = 0; i < Math.min(r.fonts.length, 5); i++) {
+      var f = r.fonts[i];
+      if (typeof f.family !== 'string' || !f.family) {
+        throw new Error('fonts[' + i + '].family is not a non-empty string');
+      }
+      if (!(f.variants instanceof Array)) {
+        throw new Error('fonts[' + i + '].variants is not an array');
+      }
+    }
+  });
+
+  it('returns more fonts than the approved list (50+)', function() {
+    var r = getAllArabicFontsFromApi();
+    if (!r.ok) {
+      results[results.length - 1] += ' (SKIPPED — no API key or fetch failed)';
+      return;
+    }
+    if (r.fonts.length < 11) {
+      throw new Error('Expected >11 fonts but got ' + r.fonts.length);
+    }
+  });
+
+  // ─── Summary ──────────────────────────────────────────────────────────────
+
+  results.push('\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500');
+  results.push('Results: ' + passed + ' passed, ' + failed + ' failed');
+
+  Logger.log(results.join('\n'));
+
+  if (failed > 0) {
+    throw new Error(failed + ' test(s) failed \u2014 see Logs for details');
+  }
+}


### PR DESCRIPTION
Closes #63

Temporary dev tool: single-click button in Settings to insert Al-Baqara 2:1 and 2:2 for every Arabic font in the Google Fonts API (~50+ fonts), each labeled with the font family name.

**Not for merge** — branch will be discarded after font curation.