### PR TITLE
Per-card translation toggle on ayah result cards

### DIFF
--- a/sidebar/js/card-builder.html
+++ b/sidebar/js/card-builder.html
@@ -60,14 +60,15 @@ function buildRangeData(results) {
  * Build the innerHTML for a single .result-card element.
  * Handles both single-ayah and range cards via cardData.isRange.
  * Highlights matched substring via matchStart/matchEnd (single cards only).
- * No translation is ever rendered on a card; it remains in the data for insert-time use.
+ * When cardData.translationText is non-empty, renders a hidden .translation div
+ * and a .btn-toggle-translation link to show/hide it.
  *
- * Card structure (stable for future per-card translation toggle):
- *   .ref-arabic | .arabic[.range-block] | .ref-english | button.btn-insert-result
+ * Card structure:
+ *   .ref-arabic | .arabic[.range-block] | .ref-english | [a.btn-toggle-translation | .translation.hidden] | button.btn-insert-result
  *
  * @param {Object} cardData
- *   Single: { surah, ayah, surahNameArabic, surahNameEnglish, arabicText, matchStart?, matchEnd? }
- *   Range:  { surah, ayahStart, ayahEnd, surahNameArabic, surahNameEnglish, arabicText, isRange: true }
+ *   Single: { surah, ayah, surahNameArabic, surahNameEnglish, arabicText, translationText?, matchStart?, matchEnd? }
+ *   Range:  { surah, ayahStart, ayahEnd, surahNameArabic, surahNameEnglish, arabicText, translationText?, isRange: true }
  * @param {string|Object} fontOrFs - CSS family string, or formatState-like { fontName, fontVariant }
  * @return {string} innerHTML for the card
  */
@@ -79,6 +80,13 @@ function buildCardHtml(cardData, fontOrFs) {
   } else {
     var f = (typeof fontOrFs === 'string' && fontOrFs) ? fontOrFs : 'Amiri';
     arabicCss = "font-family:'" + String(f).replace(/['\\<>]/g, '') + "',serif;font-weight:400;font-style:normal";
+  }
+
+  var translationBlock = '';
+  if (cardData.translationText) {
+    translationBlock =
+      '<a class="btn-toggle-translation" role="button" tabindex="0">Show translation</a>' +
+      '<div class="translation hidden">' + escapeHtml(cardData.translationText) + '</div>';
   }
 
   if (cardData.isRange) {
@@ -94,6 +102,7 @@ function buildCardHtml(cardData, fontOrFs) {
     return '<div class="ref-arabic">' + arabicRef + '</div>' +
       '<div class="arabic range-block" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
       '<div class="ref-english">' + englishRef + '</div>' +
+      translationBlock +
       '<button type="button" class="btn-primary btn-insert-result" ' +
         'data-surah="' + cardData.surah + '" ' +
         'data-ayah-start="' + cardData.ayahStart + '" ' +
@@ -114,6 +123,7 @@ function buildCardHtml(cardData, fontOrFs) {
   return '<div class="ref-arabic">' + arabicRef + '</div>' +
     '<div class="arabic" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
     '<div class="ref-english">' + englishRef + '</div>' +
+    translationBlock +
     '<button type="button" class="btn-primary btn-insert-result" ' +
       'data-surah="' + cardData.surah + '" data-ayah="' + cardData.ayah + '">Insert</button>';
 }

--- a/sidebar/js/render-helpers.html
+++ b/sidebar/js/render-helpers.html
@@ -129,4 +129,27 @@ function onInsertClick(e) {
     })
     .insertAyah(ayahData, fs, _settings);
 }
+
+/**
+ * Delegated click handler for the per-card translation toggle.
+ * Toggles the .translation sibling's visibility and swaps the link text.
+ */
+function onToggleTranslationClick(e) {
+  var toggle = e.target;
+  if (!toggle.classList || !toggle.classList.contains('btn-toggle-translation')) return;
+
+  var card = toggle.closest('.result-card');
+  if (!card) return;
+
+  var translationDiv = card.querySelector('.translation');
+  if (!translationDiv) return;
+
+  if (translationDiv.classList.contains('hidden')) {
+    translationDiv.classList.remove('hidden');
+    toggle.textContent = 'Hide translation';
+  } else {
+    translationDiv.classList.add('hidden');
+    toggle.textContent = 'Show translation';
+  }
+}
 </script>

--- a/sidebar/js/search-utils.html
+++ b/sidebar/js/search-utils.html
@@ -7,7 +7,7 @@
  * Synchronous client-side search against the pre-normalized imlaei corpus.
  * Must be called after imlaei cache is loaded (ensure resolves synchronously post-load).
  * @param {string} query - Raw Arabic search text
- * @return {Array<{surah, ayah, surahNameArabic, surahNameEnglish, arabicText, matchStart, matchEnd}>}
+ * @return {Array<{surah, ayah, surahNameArabic, surahNameEnglish, arabicText, translationText, matchStart, matchEnd}>}
  */
 function searchImlaeiClient(query) {
   if (!query || typeof query !== 'string') return [];
@@ -39,6 +39,7 @@ function searchImlaeiClient(query) {
       surahNameArabic: surahMeta ? surahMeta.nameArabic : '',
       surahNameEnglish: surahMeta ? surahMeta.nameEnglish : '',
       arabicText: verse.text || '',
+      translationText: lookupTranslation(verse.surah, verse.ayah) || '',
       matchStart: mapped.start,
       matchEnd: mapped.end
     });

--- a/sidebar/js/tab-ai-search-js.html
+++ b/sidebar/js/tab-ai-search-js.html
@@ -1,5 +1,5 @@
 <script>
-// Depends on globals: makeSkeleton, renderPreview, onInsertClick (render-helpers.html),
+// Depends on globals: makeSkeleton, renderPreview, onInsertClick, onToggleTranslationClick (render-helpers.html),
 //   searchImlaeiClient, _buildResultsFromReferences (search-utils.html),
 //   isConsecutiveRange (card-builder.html),
 //   pagClear, pagReset, pagRenderPage (pagination.html),
@@ -138,6 +138,7 @@ function initAISearchTab() {
   window.setupTextarea(queryEl, doAISearch);
   if (btnSend) btnSend.addEventListener('click', doAISearch);
   if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
+  if (resultsEl) resultsEl.addEventListener('click', onToggleTranslationClick);
 }
 
 function clearAISearch() {

--- a/sidebar/js/tab-direct-insert-js.html
+++ b/sidebar/js/tab-direct-insert-js.html
@@ -1,7 +1,7 @@
 <script>
 // Depends on globals: _surahList, MAX_RESULTS (shared-state.html),
 //   ensureSurahMetaCache, lookupUthmaniAyah, lookupTranslation (quran-caches.html),
-//   renderPreview, onInsertClick (render-helpers.html)
+//   renderPreview, onInsertClick, onToggleTranslationClick (render-helpers.html)
 // Sets window._refreshDirectInsert (read by format-bar.html)
 
 function initDirectInsertTab() {
@@ -130,6 +130,7 @@ function initDirectInsertTab() {
   window._refreshDirectInsert = autoRenderPreview;
 
   if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
+  if (resultsEl) resultsEl.addEventListener('click', onToggleTranslationClick);
 }
 
 function clearDirectInsert() {

--- a/sidebar/js/tab-exact-search-js.html
+++ b/sidebar/js/tab-exact-search-js.html
@@ -2,7 +2,7 @@
 // Depends on globals: EXACT_MIN_CHARS, EXACT_DEBOUNCE_MS (shared-state.html),
 //   searchImlaeiClient (search-utils.html),
 //   pagClear, pagReset, pagRenderPage (pagination.html),
-//   onInsertClick (render-helpers.html)
+//   onInsertClick, onToggleTranslationClick (render-helpers.html)
 
 function initExactSearchTab() {
   var queryEl = document.getElementById('exact-search-query');
@@ -70,6 +70,7 @@ function initExactSearchTab() {
 
   if (btnSearch) btnSearch.addEventListener('click', doExactSearch);
   if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
+  if (resultsEl) resultsEl.addEventListener('click', onToggleTranslationClick);
 }
 
 function clearExactSearch() {

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -72,6 +72,8 @@
   .result-card .arabic.range-block { line-height: 2.2; white-space: normal; word-break: normal; }
   .result-card mark { background: #fff59d; padding: 0 2px; }
   .result-card .translation { font-size: 12px; color: #555; margin: 6px 0 0; line-height: 1.5; }
+  .result-card .btn-toggle-translation { display: inline-block; font-size: 11px; color: #2e7d32; cursor: pointer; margin-top: 4px; user-select: none; }
+  .result-card .btn-toggle-translation:hover { text-decoration: underline; }
   .result-card .btn-insert-result { margin-top: 8px; padding: 6px 12px; font-size: 12px; }
 
   /* Clarify message from Claude */

--- a/tests/buildResultCardHtml.test.js
+++ b/tests/buildResultCardHtml.test.js
@@ -95,6 +95,13 @@ function buildCardHtml(cardData, fontOrFs) {
     arabicCss = 'font-family:\'' + String(f).replace(/['\\<>]/g, '') + '\',serif;font-weight:400;font-style:normal';
   }
 
+  var translationBlock = '';
+  if (cardData.translationText) {
+    translationBlock =
+      '<a class="btn-toggle-translation" role="button" tabindex="0">Show translation</a>' +
+      '<div class="translation hidden">' + escapeHtml(cardData.translationText) + '</div>';
+  }
+
   if (cardData.isRange) {
     arabicRef = escapeHtml(cardData.surahNameArabic || '') +
                 ' ' + toArabicIndicClient(cardData.ayahStart) +
@@ -108,6 +115,7 @@ function buildCardHtml(cardData, fontOrFs) {
     return '<div class="ref-arabic">' + arabicRef + '</div>' +
       '<div class="arabic range-block" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
       '<div class="ref-english">' + englishRef + '</div>' +
+      translationBlock +
       '<button type="button" class="btn-primary btn-insert-result" ' +
         'data-surah="' + cardData.surah + '" ' +
         'data-ayah-start="' + cardData.ayahStart + '" ' +
@@ -128,6 +136,7 @@ function buildCardHtml(cardData, fontOrFs) {
   return '<div class="ref-arabic">' + arabicRef + '</div>' +
     '<div class="arabic" style="' + escapeHtml(arabicCss) + '">' + arabicHtml + '</div>' +
     '<div class="ref-english">' + englishRef + '</div>' +
+    translationBlock +
     '<button type="button" class="btn-primary btn-insert-result" ' +
       'data-surah="' + cardData.surah + '" data-ayah="' + cardData.ayah + '">Insert</button>';
 }
@@ -389,7 +398,7 @@ function runTests() {
     assert.strictEqual(html.indexOf('<mark>'), -1, 'no <mark> when matchEnd equals matchStart');
   });
 
-  it('single: never renders a translation row', function () {
+  it('single: renders translation toggle and hidden translation div when translationText provided', function () {
     var r = {
       surah: 1, ayah: 1,
       surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
@@ -397,8 +406,44 @@ function runTests() {
       translationText: 'In the name of Allah, the Most Gracious, the Most Merciful'
     };
     var html = buildCardHtml(r, 'Amiri');
-    assert.strictEqual(html.indexOf('translation'), -1, 'no translation class in output');
-    assert.strictEqual(html.indexOf('Most Gracious'), -1, 'translation text not rendered');
+    assert.ok(html.indexOf('btn-toggle-translation') >= 0, 'toggle link present');
+    assert.ok(html.indexOf('Show translation') >= 0, 'toggle text is "Show translation"');
+    assert.ok(html.indexOf('translation hidden') >= 0, 'translation div has hidden class by default');
+    assert.ok(html.indexOf('Most Gracious') >= 0, 'translation text present in hidden div');
+  });
+
+  it('single: no translation toggle when translationText is empty', function () {
+    var r = {
+      surah: 1, ayah: 1,
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
+      arabicText: 'بسم الله', translationText: ''
+    };
+    var html = buildCardHtml(r, 'Amiri');
+    assert.strictEqual(html.indexOf('btn-toggle-translation'), -1, 'no toggle when translation empty');
+    assert.strictEqual(html.indexOf('class="translation'), -1, 'no translation div when empty');
+  });
+
+  it('single: no translation toggle when translationText is undefined', function () {
+    var r = {
+      surah: 1, ayah: 1,
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
+      arabicText: 'بسم الله'
+    };
+    var html = buildCardHtml(r, 'Amiri');
+    assert.strictEqual(html.indexOf('btn-toggle-translation'), -1, 'no toggle when translation undefined');
+    assert.strictEqual(html.indexOf('class="translation'), -1, 'no translation div when undefined');
+  });
+
+  it('single: translation text is HTML-escaped', function () {
+    var r = {
+      surah: 1, ayah: 1,
+      surahNameArabic: 'الفاتحة', surahNameEnglish: 'Al-Fatihah',
+      arabicText: 'بسم الله',
+      translationText: '<script>alert("xss")</script>'
+    };
+    var html = buildCardHtml(r, 'Amiri');
+    assert.strictEqual(html.indexOf('<script>alert'), -1, 'script tag escaped in translation');
+    assert.ok(html.indexOf('&lt;script&gt;') >= 0, 'escaped script present in translation div');
   });
 
   it('single: includes Arabic reference with Arabic-Indic ayah number', function () {
@@ -496,11 +541,20 @@ function runTests() {
     assert.strictEqual(html.indexOf('data-ayah="'), -1, 'no data-ayah on range card');
   });
 
-  it('range: never renders a translation row', function () {
+  it('range: renders translation toggle and hidden translation div when translationText provided', function () {
     var data = { isRange: true, surah: 2, ayahStart: 255, ayahEnd: 256, surahNameArabic: 'البقرة', surahNameEnglish: 'Al-Baqarah', arabicText: 'text', translationText: 'Allah - there is no deity' };
     var html = buildCardHtml(data, 'Amiri');
-    assert.strictEqual(html.indexOf('translation'), -1, 'no translation class in range card');
-    assert.strictEqual(html.indexOf('Allah - there is no deity'), -1, 'translation text not rendered');
+    assert.ok(html.indexOf('btn-toggle-translation') >= 0, 'toggle link present on range card');
+    assert.ok(html.indexOf('Show translation') >= 0, 'toggle text is "Show translation"');
+    assert.ok(html.indexOf('translation hidden') >= 0, 'translation div has hidden class');
+    assert.ok(html.indexOf('Allah - there is no deity') >= 0, 'translation text present');
+  });
+
+  it('range: no translation toggle when translationText is empty', function () {
+    var data = { isRange: true, surah: 2, ayahStart: 1, ayahEnd: 2, surahNameArabic: '', surahNameEnglish: '', arabicText: 'text', translationText: '' };
+    var html = buildCardHtml(data, 'Amiri');
+    assert.strictEqual(html.indexOf('btn-toggle-translation'), -1, 'no toggle on range when translation empty');
+    assert.strictEqual(html.indexOf('class="translation'), -1, 'no translation div on range when empty');
   });
 
   it('range: does not have <mark> even if match params somehow present', function () {


### PR DESCRIPTION
Closes #68

## Summary

- Add a "Show translation" / "Hide translation" toggle link to every ayah result card
- Translation text (Sahih International) appears below the Arabic text when toggled on, hidden by default
- Works across Insert, Search, and AI tabs — both single-ayah and range cards
- Cards with no translation text show no toggle

## Test plan

- [ ] `npm test` passes (90 tests: 46 card, 25 normalize, 9 client cache, 10 font)
- [ ] Insert tab: pick an ayah, verify toggle appears, click to show/hide translation
- [ ] Search tab: search Arabic text, verify toggle appears on all result cards
- [ ] AI tab: send a query, verify toggle appears on results
- [ ] Range cards show joined translation text

Made with [Cursor](https://cursor.com)