### PR TITLE
Use imlaei-script.json for primary client Quran Arabic text

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,8 +115,8 @@ All four are module-private `_*CacheApi` objects. Public access is only through 
 
 | Function | Cache | Used by |
 |---|---|---|
-| `ensureUthmaniCache(onReady, onError)` | Uthmani JSON | `initDirectInsertTab`, `switchTab`, `init` |
-| `lookupUthmaniAyah(surah, ayah)` | Uthmani JSON | `initDirectInsertTab`, `_buildResultsFromReferences`, `_buildAyahDataForInsert` |
+| `ensureUthmaniCache(onReady, onError)` | **imlaei-script** JSON (see CLAUDE.md naming note; legacy “Uthmani” names) | `initDirectInsertTab`, `switchTab`, `init` |
+| `lookupUthmaniAyah(surah, ayah)` | **imlaei-script** JSON (same) | `initDirectInsertTab`, `_buildResultsFromReferences`, `_buildAyahDataForInsert` |
 | `ensureTranslationCache(onReady, onError)` | Translation JSON | `switchTab`, `init` |
 | `loadTranslationEdition(url, onReady, onError)` | Translation JSON | (settings, future use) |
 | `lookupTranslation(surah, ayah)` | Translation JSON | `initDirectInsertTab`, `_buildResultsFromReferences`, `_buildAyahDataForInsert` |
@@ -173,7 +173,7 @@ onInsertClick(e)                             [render-helpers.html]
     │
     ├── reads data-surah, data-ayah (single) OR data-surah, data-ayah-start, data-ayah-end (range)
     ├── reads window.getFormatState() → fs  (font, size, bold, color)
-    ├── reads _settings.arabicStyle → 'uthmani' | 'simple'
+    ├── reads _settings.arabicStyle → 'uthmani' | 'simple' (`'uthmani'` = imlaei-script display; see CLAUDE.md)
     │
     ├── SINGLE:  _buildAyahDataForInsert(surah, ayah, style)
     │               └── google.script.run.insertAyah(ayahData, fs, _settings)
@@ -218,7 +218,7 @@ User types in search box
         → searchImlaeiClient(query)
             → normalizeArabic(query)
             → scans pre-normalized imlaei index (loaded once at startup)
-            → _mapNormalizedToOriginal() maps match position back to Uthmani offsets
+            → _mapNormalizedToOriginal() maps match position back to offsets in the imlaei-simple verse string (preview Arabic for exact search)
             → returns up to MAX_RESULTS results
         → pagReset() + pagRenderPage()  →  paginated cards
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,14 @@ A Google Docs sidebar add-on for Islamic scholars to search and insert Quranic a
 ### Quran data — client-only, loaded from GitHub Pages into browser memory
 All Quran text, metadata, and translations are fetched **client-side** via `makeClientCache` (browser `fetch()`). The server never loads or caches Quran data.
 
-**Canonical URL constants** live in `sidebar/sidebar-js.html`:
+**Canonical URL constants** live in `sidebar/js/quran-caches.html`:
 ```
-UTHMANI:      https://tarazis.github.io/tasneef-data/quran/uthmani.json
-SIMPLE:       https://tarazis.github.io/tasneef-data/quran/imlaei-simple.json
-SURAH META:   https://tarazis.github.io/tasneef-data/quran/quran-metadata-surah-name.json
-TRANSLATION:  https://tarazis.github.io/tasneef-data/quran/en-sahih-international-simple.json
+IMLAEI_SCRIPT: https://tarazis.github.io/tasneef-data/quran/imlaei-script.json
+SIMPLE:        https://tarazis.github.io/tasneef-data/quran/imlaei-simple.json
+SURAH META:    https://tarazis.github.io/tasneef-data/quran/quran-metadata-surah-name.json
+TRANSLATION:   https://tarazis.github.io/tasneef-data/quran/en-sahih-international-simple.json
 ```
+**Naming note:** The primary Arabic feed above is **imlaei-script**. Legacy identifiers in code still say “uthmani” (`UTHMANI_URL`, `ensureUthmaniCache`, `lookupUthmaniAyah`, settings `arabicStyle: 'uthmani'`, payload `textUthmani`) but they all refer to this imlaei-script source, not traditional Uthmani rasm.
 Font URLs live in `FontService.js`:
 ```
 QURAN FONTS:  https://tarazis.github.io/tasneef-data/quran/quran-fonts.json

--- a/sidebar/js/quran-caches.html
+++ b/sidebar/js/quran-caches.html
@@ -1,7 +1,7 @@
 <script>
 // ─── Cache URLs ──────────────────────────────────────────────────────────────
 
-var UTHMANI_URL     = 'https://tarazis.github.io/tasneef-data/quran/uthmani.json';
+var UTHMANI_URL     = 'https://tarazis.github.io/tasneef-data/quran/imlaei-script.json';
 var IMLAEI_URL      = 'https://tarazis.github.io/tasneef-data/quran/imlaei-simple.json';
 var SURAH_META_URL  = 'https://tarazis.github.io/tasneef-data/quran/quran-metadata-surah-name.json';
 var TRANSLATION_URL = 'https://tarazis.github.io/tasneef-data/quran/en-sahih-international-simple.json';
@@ -81,7 +81,7 @@ var _surahMetaCacheApi = makeClientCache({
 // ─── Public accessors ─────────────────────────────────────────────────────────
 
 /**
- * Ensures uthmani.json is fetched and cached. Fetches at most once; subsequent calls queue callbacks.
+ * Ensures imlaei-script.json (UTHMANI_URL) is fetched and cached. Fetches at most once; subsequent calls queue callbacks.
  * @param {Function} [onReady]
  * @param {Function} [onError]
  */


### PR DESCRIPTION
Closes #70

Primary client Quran Arabic text now loads from `imlaei-script.json`. `CLAUDE.md` and `ARCHITECTURE.md` note that legacy “uthmani” names in code still refer to this feed.