### PR TITLE
Use Figtree font for inserted English translation

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -20,7 +20,7 @@
  *
  * @param {Body} body - The document body
  * @param {Document} doc - The active document
- * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl? }
+ * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, useEnglishTranslationFont? }
  * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @return {Object} { fontWarning: string|null }
  */
@@ -69,10 +69,14 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
 
   var fontWarning = null;
   for (var i = 0; i < paragraphsToInsert.length; i++) {
-    var p = body.insertParagraph(insertIndex + i, paragraphsToInsert[i].text);
-    p.setAlignment(paragraphsToInsert[i].align);
-    if (paragraphsToInsert[i].rtl) p.setLeftToRight(false);
-    fontWarning = applyFormat(p.editAsText(), formatState) || fontWarning;
+    var item = paragraphsToInsert[i];
+    var p = body.insertParagraph(insertIndex + i, item.text);
+    p.setAlignment(item.align);
+    if (item.rtl) p.setLeftToRight(false);
+    var fs = item.useEnglishTranslationFont
+      ? formatStateForEnglishTranslation(formatState)
+      : formatState;
+    fontWarning = applyFormat(p.editAsText(), fs) || fontWarning;
   }
 
   if (removeTarget) {
@@ -137,7 +141,8 @@ function insertAyah(ayahData, formatState, settings) {
     });
     paragraphsToInsert.push({
       text: '\u201C' + translationText + '\u201D (' + surahNameEn + ' ' + ayahData.surah + ':' + ayahData.ayah + ')',
-      align: DocumentApp.HorizontalAlignment.CENTER
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      useEnglishTranslationFont: true
     });
   } else {
     paragraphsToInsert.push({
@@ -187,7 +192,8 @@ function insertAyahRange(rangeData, formatState, settings) {
       text: '\u201C' + translationText + '\u201D (' +
             surahNameEn + ' ' + rangeData.surah + ':' +
             rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
-      align: DocumentApp.HorizontalAlignment.CENTER
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      useEnglishTranslationFont: true
     });
   } else {
     paragraphsToInsert.push({

--- a/FormatService.js
+++ b/FormatService.js
@@ -7,6 +7,27 @@
 
 var ARABIC_INDIC = ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'];
 var FALLBACK_FONT = 'Amiri';
+/** Google Docs font family for inserted English translation (Google Fonts name). */
+var ENGLISH_TRANSLATION_INSERT_FONT = 'Figtree';
+
+/**
+ * Format state for the English translation paragraph: same size, variant, bold, color as Arabic; Figtree family.
+ * @param {Object|null|undefined} formatState - Sidebar format state
+ * @return {Object}
+ */
+function formatStateForEnglishTranslation(formatState) {
+  if (!formatState) {
+    return { fontName: ENGLISH_TRANSLATION_INSERT_FONT };
+  }
+  var out = {};
+  for (var k in formatState) {
+    if (Object.prototype.hasOwnProperty.call(formatState, k)) {
+      out[k] = formatState[k];
+    }
+  }
+  out.fontName = ENGLISH_TRANSLATION_INSERT_FONT;
+  return out;
+}
 
 /**
  * Builds the font family string Google Docs accepts for weighted Google Fonts.

--- a/FormatService.js
+++ b/FormatService.js
@@ -15,7 +15,7 @@ var ENGLISH_TRANSLATION_FONT_SIZE_DELTA = 2;
 
 /**
  * Format state for the English translation paragraph: Figtree; font size two points smaller than Arabic;
- * never bold; same variant and color as Arabic.
+ * never bold; regular font variant (no weight or italic from the Arabic font variant); same color as Arabic.
  * @param {Object|null|undefined} formatState - Sidebar format state
  * @return {Object}
  */
@@ -30,6 +30,7 @@ function formatStateForEnglishTranslation(formatState) {
     }
   }
   out.fontName = ENGLISH_TRANSLATION_INSERT_FONT;
+  out.fontVariant = 'regular';
   out.bold = false;
   if (formatState.fontSize != null && !isNaN(Number(formatState.fontSize))) {
     var sz = Number(formatState.fontSize);

--- a/FormatService.js
+++ b/FormatService.js
@@ -10,14 +10,18 @@ var FALLBACK_FONT = 'Amiri';
 /** Google Docs font family for inserted English translation (Google Fonts name). */
 var ENGLISH_TRANSLATION_INSERT_FONT = 'Figtree';
 
+/** Points smaller than the ayah font size for inserted English translation. */
+var ENGLISH_TRANSLATION_FONT_SIZE_DELTA = 2;
+
 /**
- * Format state for the English translation paragraph: same size, variant, bold, color as Arabic; Figtree family.
+ * Format state for the English translation paragraph: Figtree; font size two points smaller than Arabic;
+ * never bold; same variant and color as Arabic.
  * @param {Object|null|undefined} formatState - Sidebar format state
  * @return {Object}
  */
 function formatStateForEnglishTranslation(formatState) {
   if (!formatState) {
-    return { fontName: ENGLISH_TRANSLATION_INSERT_FONT };
+    return { fontName: ENGLISH_TRANSLATION_INSERT_FONT, bold: false };
   }
   var out = {};
   for (var k in formatState) {
@@ -26,6 +30,11 @@ function formatStateForEnglishTranslation(formatState) {
     }
   }
   out.fontName = ENGLISH_TRANSLATION_INSERT_FONT;
+  out.bold = false;
+  if (formatState.fontSize != null && !isNaN(Number(formatState.fontSize))) {
+    var sz = Number(formatState.fontSize);
+    out.fontSize = Math.max(1, sz - ENGLISH_TRANSLATION_FONT_SIZE_DELTA);
+  }
   return out;
 }
 

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -301,8 +301,8 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[0]).toBe(fs);
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
     expect(applyFormatCalls[1].fontVariant).toBe('700');
-    expect(applyFormatCalls[1].fontSize).toBe(14);
-    expect(applyFormatCalls[1].bold).toBe(true);
+    expect(applyFormatCalls[1].fontSize).toBe(12);
+    expect(applyFormatCalls[1].bold).toBe(false);
     expect(applyFormatCalls[1].textColor).toBe('#112233');
   });
 

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -126,7 +126,8 @@ function runDocumentServiceTests() {
       },
       {
         text: '"translation" (Al-Fatiha 1:1)',
-        align: DocumentApp.HorizontalAlignment.CENTER
+        align: DocumentApp.HorizontalAlignment.CENTER,
+        useEnglishTranslationFont: true
       }
     ];
   }
@@ -134,7 +135,11 @@ function runDocumentServiceTests() {
   // Save original applyFormat and stub it
   var originalApplyFormat = applyFormat;
   var applyFormatReturnValue = null;
-  applyFormat = function () { return applyFormatReturnValue; };
+  var applyFormatCalls = [];
+  applyFormat = function (textEl, state) {
+    applyFormatCalls.push(state);
+    return applyFormatReturnValue;
+  };
 
   // ── Tests ───────────────────────────────────────────────────
 
@@ -266,6 +271,7 @@ function runDocumentServiceTests() {
   results.push('\ninsertParagraphsAtPosition_() — multi-paragraph & font warning');
 
   it('font warning is propagated from applyFormat', function () {
+    applyFormatCalls = [];
     applyFormatReturnValue = 'Font "Custom" not found. Using Amiri.';
     var body = createMockBody(['']);
     var doc = createMockDoc(body, body._children[0]);
@@ -274,6 +280,30 @@ function runDocumentServiceTests() {
 
     expect(result.fontWarning).toBe('Font "Custom" not found. Using Amiri.');
     applyFormatReturnValue = null;
+  });
+
+  it('translation paragraph uses Figtree and copies other format fields from sidebar state', function () {
+    applyFormatCalls = [];
+    applyFormatReturnValue = null;
+    var fs = {
+      fontName: 'Scheherazade New',
+      fontVariant: '700',
+      fontSize: 14,
+      bold: true,
+      textColor: '#112233'
+    };
+    var body = createMockBody(['existing']);
+    var doc = createMockDoc(body, body._children[0]);
+
+    insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), fs);
+
+    expect(applyFormatCalls.length).toBe(2);
+    expect(applyFormatCalls[0]).toBe(fs);
+    expect(applyFormatCalls[1].fontName).toBe('Figtree');
+    expect(applyFormatCalls[1].fontVariant).toBe('700');
+    expect(applyFormatCalls[1].fontSize).toBe(14);
+    expect(applyFormatCalls[1].bold).toBe(true);
+    expect(applyFormatCalls[1].textColor).toBe('#112233');
   });
 
   it('two content paragraphs at end — both inserted, cleanup follows', function () {

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -300,7 +300,7 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls.length).toBe(2);
     expect(applyFormatCalls[0]).toBe(fs);
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
-    expect(applyFormatCalls[1].fontVariant).toBe('700');
+    expect(applyFormatCalls[1].fontVariant).toBe('regular');
     expect(applyFormatCalls[1].fontSize).toBe(12);
     expect(applyFormatCalls[1].bold).toBe(false);
     expect(applyFormatCalls[1].textColor).toBe('#112233');

--- a/tests/FormatService.test.gs
+++ b/tests/FormatService.test.gs
@@ -59,14 +59,19 @@ function runFormatServiceTests() {
     expect(a.fontName).toBe('Figtree');
     expect(a.bold).toBe(false);
   });
-  it('copies fields; Figtree; font size minus 2; never bold', function () {
+  it('copies fields; Figtree; regular variant (no Arabic weight); size minus 2; never bold', function () {
     var fs = { fontName: 'Scheherazade New', fontVariant: '700', fontSize: 14, bold: true, textColor: '#000' };
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontName).toBe('Figtree');
-    expect(b.fontVariant).toBe('700');
+    expect(b.fontVariant).toBe('regular');
     expect(b.fontSize).toBe(12);
     expect(b.bold).toBe(false);
     expect(b.textColor).toBe('#000');
+  });
+  it('strips italic from Arabic variant for translation', function () {
+    var fs = { fontName: 'X', fontVariant: '700italic', fontSize: 12 };
+    var b = formatStateForEnglishTranslation(fs);
+    expect(b.fontVariant).toBe('regular');
   });
   it('font size floors at 1 when ayah size is very small', function () {
     var fs = { fontName: 'X', fontSize: 2 };

--- a/tests/FormatService.test.gs
+++ b/tests/FormatService.test.gs
@@ -49,21 +49,29 @@ function runFormatServiceTests() {
 
   results.push('\nformatStateForEnglishTranslation()');
 
-  it('null yields Figtree-only state', function () {
+  it('null yields Figtree state with bold off', function () {
     var a = formatStateForEnglishTranslation(null);
     expect(a.fontName).toBe('Figtree');
+    expect(a.bold).toBe(false);
   });
-  it('undefined yields Figtree-only state', function () {
+  it('undefined yields Figtree state with bold off', function () {
     var a = formatStateForEnglishTranslation(undefined);
     expect(a.fontName).toBe('Figtree');
+    expect(a.bold).toBe(false);
   });
-  it('copies fields and overrides fontName to Figtree', function () {
-    var fs = { fontName: 'Scheherazade New', fontVariant: '700', fontSize: 11, bold: false };
+  it('copies fields; Figtree; font size minus 2; never bold', function () {
+    var fs = { fontName: 'Scheherazade New', fontVariant: '700', fontSize: 14, bold: true, textColor: '#000' };
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontName).toBe('Figtree');
     expect(b.fontVariant).toBe('700');
-    expect(b.fontSize).toBe(11);
+    expect(b.fontSize).toBe(12);
     expect(b.bold).toBe(false);
+    expect(b.textColor).toBe('#000');
+  });
+  it('font size floors at 1 when ayah size is very small', function () {
+    var fs = { fontName: 'X', fontSize: 2 };
+    var b = formatStateForEnglishTranslation(fs);
+    expect(b.fontSize).toBe(1);
   });
   it('does not mutate original formatState', function () {
     var fs = { fontName: 'Amiri', fontSize: 10 };

--- a/tests/FormatService.test.gs
+++ b/tests/FormatService.test.gs
@@ -47,6 +47,30 @@ function runFormatServiceTests() {
     expect(toArabicIndic(null)).toBe('null');
   });
 
+  results.push('\nformatStateForEnglishTranslation()');
+
+  it('null yields Figtree-only state', function () {
+    var a = formatStateForEnglishTranslation(null);
+    expect(a.fontName).toBe('Figtree');
+  });
+  it('undefined yields Figtree-only state', function () {
+    var a = formatStateForEnglishTranslation(undefined);
+    expect(a.fontName).toBe('Figtree');
+  });
+  it('copies fields and overrides fontName to Figtree', function () {
+    var fs = { fontName: 'Scheherazade New', fontVariant: '700', fontSize: 11, bold: false };
+    var b = formatStateForEnglishTranslation(fs);
+    expect(b.fontName).toBe('Figtree');
+    expect(b.fontVariant).toBe('700');
+    expect(b.fontSize).toBe(11);
+    expect(b.bold).toBe(false);
+  });
+  it('does not mutate original formatState', function () {
+    var fs = { fontName: 'Amiri', fontSize: 10 };
+    formatStateForEnglishTranslation(fs);
+    expect(fs.fontName).toBe('Amiri');
+  });
+
   results.push('\n─────────────────────────────────────────');
   results.push('Results: ' + passed + ' passed, ' + failed + ' failed');
   Logger.log(results.join('\n'));


### PR DESCRIPTION
Closes #72

English translation paragraphs inserted from the sidebar now use the Figtree font family while keeping the same size, weight/variant, bold, and color as the Arabic line from the format bar.