### PR TITLE
Security hardening: Lock down RPC surface, migrate Claude key to Script Properties, add .gitignore

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -10,3 +10,4 @@ README.md
 sidebar/assets/**
 package.json
 tests/*.test.js
+tests/*.test.gs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Clasp config (contains scriptId and parentId)
+.clasp.json
+
+# Claude Code worktrees and settings
+.claude/
+
+# Dependencies
+node_modules/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor directories
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Environment files
+.env
+.env.*

--- a/ClaudeAPI.js
+++ b/ClaudeAPI.js
@@ -62,12 +62,12 @@ function performAISearch(messages) {
     return { type: 'error', error: 'Please enter a query.' };
   }
 
-  var apiKey = getClaudeApiKey();
+  var apiKey = getClaudeApiKey_();
   if (!apiKey) {
-    return { type: 'error', error: 'NO_API_KEY' };
+    return { type: 'error', error: 'AI search is temporarily unavailable. Please try again later.' };
   }
 
-  var count = incrementAiSearchCount();
+  var count = incrementAiSearchCount_();
   if (count === -1) {
     return {
       type: 'error',
@@ -113,10 +113,11 @@ function performAISearch(messages) {
 
 /**
  * Thin wrapper for frontend compatibility.
+ * Trailing underscore hides this from google.script.run.
  * @param {Array<{role: string, content: string}>} messages
  * @return {Object} Unified response
  */
-function processUnifiedQuery(messages) {
+function processUnifiedQuery_(messages) {
   return performAISearch(messages);
 }
 
@@ -206,8 +207,9 @@ function _trimConversationContext(messages) {
   var valid = [];
   for (var i = 0; i < messages.length; i++) {
     var m = messages[i];
-    if (m && m.role && m.content && typeof m.content === 'string') {
-      valid.push({ role: String(m.role), content: String(m.content) });
+    if (m && m.content && typeof m.content === 'string' &&
+        (m.role === 'user' || m.role === 'assistant')) {
+      valid.push({ role: m.role, content: String(m.content) });
     }
   }
   if (valid.length > CONVERSATION_CONTEXT_LIMIT) {

--- a/Code.js
+++ b/Code.js
@@ -22,11 +22,12 @@ function showSidebar() {
 
 /**
  * Includes an HTML file's content for use in Apps Script HTML templates.
- * Usage in templates: <?!= include('sidebar/sidebar-css') ?>
+ * Usage in templates: <?!= include_('sidebar/sidebar-css') ?>
+ * Trailing underscore hides this from google.script.run (prevents source disclosure).
  * @param {string} filename - The file to include (without .html extension).
  * @return {string} The file's HTML content.
  */
-function include(filename) {
+function include_(filename) {
   return HtmlService.createHtmlOutputFromFile(filename).getContent();
 }
 

--- a/FontService.js
+++ b/FontService.js
@@ -69,7 +69,7 @@ function sortFontVariantTokens_(variants) {
 /**
  * @return {Array<string>} Sorted unique font names, or empty if invalid.
  */
-function buildSortedFontsFromJson(json) {
+function buildSortedFontsFromJson_(json) {
   var raw = json && json.approved_fonts;
   if (!Array.isArray(raw) || raw.length === 0) {
     return [];
@@ -90,7 +90,7 @@ function buildSortedFontsFromJson(json) {
 /**
  * @return {Array<string>} Sorted list of font family names (approved only).
  */
-function getArabicFonts() {
+function getArabicFonts_() {
   var fallback = FALLBACK_APPROVED_FONTS.slice().sort(function (a, b) {
     return a.localeCompare(b, 'en');
   });
@@ -98,7 +98,7 @@ function getArabicFonts() {
   try {
     var response = UrlFetchApp.fetch(QURAN_FONTS_JSON_URL);
     var json = JSON.parse(response.getContentText());
-    var list = buildSortedFontsFromJson(json);
+    var list = buildSortedFontsFromJson_(json);
     return list.length > 0 ? list : fallback;
   } catch (e) {
     return fallback;
@@ -107,12 +107,12 @@ function getArabicFonts() {
 
 /**
  * Fetches Google Fonts metadata (arabic subset) intersected with quran-fonts approved_fonts.
- * Requires Script Properties google_fonts_api_key via getGoogleFontsApiKey().
+ * Requires Script Properties google_fonts_api_key via getGoogleFontsApiKey_().
  * @return {{ ok: boolean, error: string|null, catalog: Array<{family: string, variants: string[]}> }}
  */
 function getCuratedFontCatalog() {
   var empty = { ok: false, error: null, catalog: [] };
-  var apiKey = getGoogleFontsApiKey();
+  var apiKey = getGoogleFontsApiKey_();
   if (!apiKey || String(apiKey).trim().length === 0) {
     empty.error = 'NO_GOOGLE_FONTS_API_KEY';
     return empty;
@@ -121,7 +121,7 @@ function getCuratedFontCatalog() {
   var approved = [];
   try {
     var rQ = UrlFetchApp.fetch(QURAN_FONTS_JSON_URL);
-    approved = buildSortedFontsFromJson(JSON.parse(rQ.getContentText()));
+    approved = buildSortedFontsFromJson_(JSON.parse(rQ.getContentText()));
   } catch (e) {
     approved = FALLBACK_APPROVED_FONTS.slice().sort(function (a, b) {
       return a.localeCompare(b, 'en');
@@ -156,7 +156,7 @@ function getCuratedFontCatalog() {
     });
     return { ok: true, error: null, catalog: catalog };
   } catch (e) {
-    empty.error = String(e.message || e);
+    empty.error = 'Failed to load font catalog.';
     return empty;
   }
 }

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -1,10 +1,11 @@
 /**
  * SettingsService.gs
- * Manages user preferences and Claude API key via PropertiesService.
- * All settings are persisted to User Properties (per-user, per-script).
+ * Manages user preferences via PropertiesService.
+ * User settings are persisted to User Properties (per-user, per-script).
+ * API keys (Claude, Google Fonts) are in Script Properties (shared, developer-owned).
  */
 
-var AI_SEARCH_DAILY_LIMIT = 100;
+var AI_SEARCH_DAILY_LIMIT = 10;
 
 var SETTINGS_DEFAULTS = {
   showTranslation: true,
@@ -51,7 +52,7 @@ function getSettings() {
  * @param {*}      value - The value to store.
  * @throws {Error} If key is not a recognised setting.
  */
-function saveSetting(key, value) {
+function saveSetting_(key, value) {
   if (!SETTINGS_DEFAULTS.hasOwnProperty(key)) {
     throw new Error('Unknown setting key: ' + key);
   }
@@ -66,62 +67,30 @@ function saveSetting(key, value) {
  */
 function saveSettings(settingsObj) {
   for (var key in settingsObj) {
-    saveSetting(key, settingsObj[key]);
+    saveSetting_(key, settingsObj[key]);
   }
 }
 
 /**
- * Returns the stored Claude API key, or null if not set.
+ * Returns the shared Claude API key from Script Properties, or null if not set.
+ * Set once by the developer in Project Settings → Script Properties.
+ * Trailing underscore hides this from google.script.run (prevents client access).
  * @return {string|null}
  */
-function getClaudeApiKey() {
-  return PropertiesService.getUserProperties()
+function getClaudeApiKey_() {
+  return PropertiesService.getScriptProperties()
     .getProperty(PROPERTY_KEYS.CLAUDE_API_KEY) || null;
 }
 
 /**
- * Returns true if a Claude API key has been stored, false otherwise.
- * Use this instead of getClaudeApiKey() when you only need to check existence
- * (avoids sending the key value to the client).
- * @return {boolean}
- */
-function hasClaudeApiKey() {
-  var key = PropertiesService.getUserProperties()
-    .getProperty(PROPERTY_KEYS.CLAUDE_API_KEY);
-  return !!(key && key.length > 0);
-}
-
-/**
- * Persists the Claude API key to User Properties.
- * Pass an empty string or null to delete the stored key.
- * @param {string} key - The API key to store.
- */
-function setClaudeApiKey(key) {
-  var props = PropertiesService.getUserProperties();
-  if (!key || key.trim().length === 0) {
-    props.deleteProperty(PROPERTY_KEYS.CLAUDE_API_KEY);
-  } else {
-    props.setProperty(PROPERTY_KEYS.CLAUDE_API_KEY, key.trim());
-  }
-}
-
-/**
  * Returns the Google Fonts Developer API key from Script Properties (shared by all users).
- * Set once in Project settings → Script properties as google_fonts_api_key.
+ * Set once by the developer in Project Settings → Script Properties.
+ * Trailing underscore hides this from google.script.run (prevents client access).
  * @return {string|null}
  */
-function getGoogleFontsApiKey() {
+function getGoogleFontsApiKey_() {
   return PropertiesService.getScriptProperties()
     .getProperty(PROPERTY_KEYS.GOOGLE_FONTS_API_KEY) || null;
-}
-
-/**
- * Persists the Google Fonts API key to Script Properties (optional; prefer Script editor UI).
- * @param {string} key - The API key to store.
- */
-function setGoogleFontsApiKey(key) {
-  PropertiesService.getScriptProperties()
-    .setProperty(PROPERTY_KEYS.GOOGLE_FONTS_API_KEY, String(key || '').trim());
 }
 
 /**
@@ -129,7 +98,7 @@ function setGoogleFontsApiKey(key) {
  * If the stored date is not today, the count is treated as 0.
  * @return {number} The current count for today.
  */
-function getAiSearchCount() {
+function getAiSearchCount_() {
   var raw = PropertiesService.getUserProperties()
     .getProperty(PROPERTY_KEYS.AI_SEARCH_COUNT);
 
@@ -148,8 +117,8 @@ function getAiSearchCount() {
  * Increments today's AI search count and persists it.
  * @return {number} The new count, or -1 if the daily limit has been reached.
  */
-function incrementAiSearchCount() {
-  var current = getAiSearchCount();
+function incrementAiSearchCount_() {
+  var current = getAiSearchCount_();
 
   if (current >= AI_SEARCH_DAILY_LIMIT) return -1;
 

--- a/appsscript.json
+++ b/appsscript.json
@@ -6,7 +6,6 @@
   "oauthScopes": [
     "https://www.googleapis.com/auth/documents.currentonly",
     "https://www.googleapis.com/auth/script.container.ui",
-    "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/script.external_request"
   ]
 }

--- a/sidebar/components/settings-panel.html
+++ b/sidebar/components/settings-panel.html
@@ -12,12 +12,6 @@
     </div>
   </div>
 
-  <div class="settings-section">
-    <label for="claude-api-key">Claude API key</label>
-    <input type="text" id="claude-api-key" placeholder="sk-ant-..." data-masked>
-    <p class="hint">Required for all queries (browse, search, AI)</p>
-  </div>
-
   <div class="settings-save-row">
     <button type="button" class="btn-primary" id="btn-save-settings">Save</button>
     <p id="settings-saved-msg" class="settings-saved-msg hidden"></p>

--- a/sidebar/components/tab-ai-search.html
+++ b/sidebar/components/tab-ai-search.html
@@ -1,7 +1,4 @@
 <div class="tab-panel" id="panel-ai-search">
-  <div id="ai-no-key" class="empty-state hidden">
-    To use AI Search, add your Claude API key in Settings.
-  </div>
   <div id="ai-search-results" class="results-list"></div>
   <div id="ai-search-clarify" class="clarify-message hidden"></div>
   <div id="ai-search-empty" class="empty-state hidden"></div>

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -46,15 +46,7 @@ function loadSettingsIntoPanel() {
   google.script.run
     .withSuccessHandler(function(s) {
       var trans = document.getElementById('insert-translation');
-      var apiKey = document.getElementById('claude-api-key');
       if (trans) trans.checked = s.showTranslation !== false;
-      if (apiKey) {
-        // Never populate the input with the actual key value — check existence only
-        google.script.run.withSuccessHandler(function(hasKey) {
-          apiKey.value = '';
-          apiKey.placeholder = hasKey ? '••••••••••' : 'sk-ant-...';
-        }).hasClaudeApiKey();
-      }
     })
     .withFailureHandler(function() {})
     .getSettings();
@@ -63,7 +55,6 @@ function loadSettingsIntoPanel() {
 function initSettingsPanelHandlers() {
   var trans = document.getElementById('insert-translation');
   var btnSave = document.getElementById('btn-save-settings');
-  var apiKeyInput = document.getElementById('claude-api-key');
   var savedMsg = document.getElementById('settings-saved-msg');
 
   function showSavedMessage(text, isError) {
@@ -77,7 +68,6 @@ function initSettingsPanelHandlers() {
   if (btnSave) {
     btnSave.addEventListener('click', function() {
       var showTranslation = trans ? trans.checked : true;
-      var key = apiKeyInput ? apiKeyInput.value.trim() : '';
 
       btnSave.disabled = true;
       btnSave.textContent = 'Saving…';
@@ -86,15 +76,6 @@ function initSettingsPanelHandlers() {
         .withSuccessHandler(function() {
           btnSave.disabled = false;
           btnSave.textContent = 'Save';
-          // Save API key only if the user typed something
-          if (key) {
-            google.script.run
-              .withSuccessHandler(function() {
-                if (apiKeyInput) { apiKeyInput.value = ''; apiKeyInput.placeholder = '••••••••••'; }
-              })
-              .withFailureHandler(function() {})
-              .setClaudeApiKey(key);
-          }
           showSavedMessage('Settings saved!', false);
         })
         .withFailureHandler(function() {

--- a/sidebar/js/tab-ai-search-js.html
+++ b/sidebar/js/tab-ai-search-js.html
@@ -13,8 +13,6 @@ function initAISearchTab() {
   var resultsEl = document.getElementById('ai-search-results');
   var clarifyEl = document.getElementById('ai-search-clarify');
   var emptyEl = document.getElementById('ai-search-empty');
-  var noKeyEl = document.getElementById('ai-no-key');
-
   function setEnabled(enabled) {
     if (btnSend) btnSend.disabled = !enabled;
     if (queryEl) queryEl.disabled = !enabled;
@@ -27,7 +25,6 @@ function initAISearchTab() {
     clarifyEl.textContent = '';
     emptyEl.classList.add('hidden');
     emptyEl.textContent = '';
-    if (noKeyEl) noKeyEl.classList.add('hidden');
   }
 
   function getLastMessages(limit) {
@@ -79,10 +76,6 @@ function initAISearchTab() {
     }
 
     if (response.type === 'error') {
-      if (response.error === 'NO_API_KEY') {
-        if (noKeyEl) noKeyEl.classList.remove('hidden');
-        return;
-      }
       emptyEl.textContent = response.error;
       emptyEl.classList.remove('hidden');
       return;
@@ -148,11 +141,9 @@ function clearAISearch() {
   var resultsEl = document.getElementById('ai-search-results');
   var clarifyEl = document.getElementById('ai-search-clarify');
   var emptyEl = document.getElementById('ai-search-empty');
-  var noKeyEl = document.getElementById('ai-no-key');
   if (queryEl) { queryEl.value = ''; queryEl.style.height = 'auto'; queryEl.focus(); }
   if (resultsEl) resultsEl.innerHTML = '';
   if (clarifyEl) { clarifyEl.classList.add('hidden'); clarifyEl.textContent = ''; }
   if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
-  if (noKeyEl) noKeyEl.classList.add('hidden');
 }
 </script>

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -3,7 +3,7 @@
 <head>
   <base target="_top">
   <meta charset="UTF-8">
-  <?!= include('sidebar/sidebar-css') ?>
+  <?!= include_('sidebar/sidebar-css') ?>
 </head>
 <body>
   <div class="sidebar">
@@ -14,7 +14,7 @@
 
     <header class="header">
       <div class="header-brand">
-        <?!= include('sidebar/components/logo-img') ?>
+        <?!= include_('sidebar/components/logo-img') ?>
         <span class="title">Tasneef AI</span>
       </div>
       <div class="header-actions">
@@ -23,7 +23,7 @@
       </div>
     </header>
 
-    <?!= include('sidebar/components/format-bar') ?>
+    <?!= include_('sidebar/components/format-bar') ?>
 
     <nav class="tab-nav">
       <button type="button" class="tab-btn active" data-tab="direct-insert">Insert</button>
@@ -32,30 +32,30 @@
     </nav>
 
     <main class="tab-content">
-      <?!= include('sidebar/components/tab-direct-insert') ?>
-      <?!= include('sidebar/components/tab-exact-search') ?>
-      <?!= include('sidebar/components/tab-ai-search') ?>
+      <?!= include_('sidebar/components/tab-direct-insert') ?>
+      <?!= include_('sidebar/components/tab-exact-search') ?>
+      <?!= include_('sidebar/components/tab-ai-search') ?>
     </main>
   </div>
 
   <div id="settings-overlay" class="settings-overlay hidden">
-    <?!= include('sidebar/components/settings-panel') ?>
+    <?!= include_('sidebar/components/settings-panel') ?>
   </div>
 
-  <?!= include('client/makeClientCache') ?>
-  <?!= include('client/normalizeArabic') ?>
-  <?!= include('sidebar/js/quran-caches') ?>
-  <?!= include('sidebar/js/search-utils') ?>
-  <?!= include('sidebar/js/shared-state') ?>
-  <?!= include('sidebar/js/font-variant-utils') ?>
-  <?!= include('sidebar/js/card-builder') ?>
-  <?!= include('sidebar/js/pagination') ?>
-  <?!= include('sidebar/js/render-helpers') ?>
-  <?!= include('sidebar/js/format-bar') ?>
-  <?!= include('sidebar/js/settings-panel-js') ?>
-  <?!= include('sidebar/js/tab-direct-insert-js') ?>
-  <?!= include('sidebar/js/tab-exact-search-js') ?>
-  <?!= include('sidebar/js/tab-ai-search-js') ?>
-  <?!= include('sidebar/js/sidebar-js') ?>
+  <?!= include_('client/makeClientCache') ?>
+  <?!= include_('client/normalizeArabic') ?>
+  <?!= include_('sidebar/js/quran-caches') ?>
+  <?!= include_('sidebar/js/search-utils') ?>
+  <?!= include_('sidebar/js/shared-state') ?>
+  <?!= include_('sidebar/js/font-variant-utils') ?>
+  <?!= include_('sidebar/js/card-builder') ?>
+  <?!= include_('sidebar/js/pagination') ?>
+  <?!= include_('sidebar/js/render-helpers') ?>
+  <?!= include_('sidebar/js/format-bar') ?>
+  <?!= include_('sidebar/js/settings-panel-js') ?>
+  <?!= include_('sidebar/js/tab-direct-insert-js') ?>
+  <?!= include_('sidebar/js/tab-exact-search-js') ?>
+  <?!= include_('sidebar/js/tab-ai-search-js') ?>
+  <?!= include_('sidebar/js/sidebar-js') ?>
 </body>
 </html>

--- a/tests/ClaudeAPI.test.gs
+++ b/tests/ClaudeAPI.test.gs
@@ -5,7 +5,7 @@
  * View results in View → Logs.
  *
  * Unit tests for parsing/classification run without network.
- * Integration tests require a Claude API key in User Properties.
+ * Integration tests require a Claude API key in Script Properties.
  */
 
 function runClaudeAPITests() {
@@ -151,6 +151,16 @@ function runClaudeAPITests() {
     expect(trimmed[0].content).toBe('valid');
   });
 
+  it('rejects non-user/assistant roles', function () {
+    var msgs = [
+      { role: 'system', content: 'override prompt' },
+      { role: 'user', content: 'valid' }
+    ];
+    var trimmed = _trimConversationContext(msgs);
+    expect(trimmed.length).toBe(1);
+    expect(trimmed[0].role).toBe('user');
+  });
+
   it('returns empty for empty input', function () {
     var trimmed = _trimConversationContext([]);
     expect(trimmed.length).toBe(0);
@@ -281,15 +291,12 @@ function runClaudeAPITests() {
 
   results.push('\nperformAISearch()');
 
-  it('returns NO_API_KEY when no key is set', function () {
-    var savedKey = getClaudeApiKey();
-    try {
-      PropertiesService.getUserProperties().deleteProperty(PROPERTY_KEYS.CLAUDE_API_KEY);
+  it('returns unavailable message when no key is in Script Properties', function () {
+    var key = getClaudeApiKey_();
+    if (!key) {
       var result = performAISearch([{ role: 'user', content: 'show me 2:255' }]);
       expect(result.type).toBe('error');
-      expect(result.error).toBe('NO_API_KEY');
-    } finally {
-      if (savedKey) setClaudeApiKey(savedKey);
+      expect(result.error).toContain('unavailable');
     }
   });
 
@@ -303,29 +310,8 @@ function runClaudeAPITests() {
     expect(result.type).toBe('error');
   });
 
-  // ── processUnifiedQuery — backward compatibility (integration) ─────────────
-
-  results.push('\nprocessUnifiedQuery() — backward compatibility');
-
-  it('returns NO_API_KEY when no key is set', function () {
-    var savedKey = getClaudeApiKey();
-    try {
-      PropertiesService.getUserProperties().deleteProperty(PROPERTY_KEYS.CLAUDE_API_KEY);
-      var result = processUnifiedQuery([{ role: 'user', content: 'show me 2:255' }]);
-      expect(result.type).toBe('error');
-      expect(result.error).toBe('NO_API_KEY');
-    } finally {
-      if (savedKey) setClaudeApiKey(savedKey);
-    }
-  });
-
-  it('returns error for empty messages array', function () {
-    var result = processUnifiedQuery([]);
-    expect(result.type).toBe('error');
-  });
-
-  // Full integration tests — only run if API key is present
-  var apiKey = getClaudeApiKey();
+  // Full integration tests — only run if API key is present in Script Properties
+  var apiKey = getClaudeApiKey_();
   if (apiKey) {
     it('performAISearch("show me ayat al kursi") returns references (live API)', function () {
       var result = performAISearch([{ role: 'user', content: 'show me ayat al kursi' }]);
@@ -350,7 +336,7 @@ function runClaudeAPITests() {
         { role: 'user', content: 'Al-Baqarah' }
       ];
       var result = performAISearch(messages);
-      if (result.type === 'clarify') return; // acceptable if Claude still needs more info
+      if (result.type === 'clarify') return;
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
       expect(result.type).toBe('references');
       expect(result.references.length).toBeGreaterThan(0);
@@ -358,7 +344,7 @@ function runClaudeAPITests() {
 
     it('performAISearch("show me Al-Imran 190 to 194") returns references (live API)', function () {
       var result = performAISearch([{ role: 'user', content: 'show me Al-Imran 190 to 194' }]);
-      if (result.type === 'clarify') return; // acceptable
+      if (result.type === 'clarify') return;
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
       expect(result.type).toBe('references');
       expect(result.references.length).toBeGreaterThan(0);
@@ -367,22 +353,14 @@ function runClaudeAPITests() {
 
     it('performAISearch("give me the last 3 ayahs of surah Al-Baqarah") returns references (live API)', function () {
       var result = performAISearch([{ role: 'user', content: 'give me the last 3 ayahs of surah Al-Baqarah' }]);
-      if (result.type === 'clarify') return; // acceptable
+      if (result.type === 'clarify') return;
       if (result.type === 'error') throw new Error('Got error: ' + result.error);
       expect(result.type).toBe('references');
       expect(result.references.length).toBeGreaterThan(0);
       expect(result.references[0].surah).toBe(2);
     });
-
-    it('processUnifiedQuery delegates to performAISearch (live API)', function () {
-      var result = processUnifiedQuery([{ role: 'user', content: 'show me ayat al kursi' }]);
-      if (result.type === 'error') throw new Error('Got error: ' + result.error);
-      expect(result.type).toBe('references');
-      expect(result.references.length).toBeGreaterThan(0);
-      expect(result.rawResponse).toBeTruthy();
-    });
   } else {
-    results.push('  ⊘ Skipped live API tests (no Claude API key configured)');
+    results.push('  ⊘ Skipped live API tests (no Claude API key in Script Properties)');
   }
 
   // ── Summary ───────────────────────────────────────────────────────────────

--- a/tests/FontService.test.gs
+++ b/tests/FontService.test.gs
@@ -84,12 +84,12 @@ function runFontServiceTests() {
   results.push('\ngetArabicFonts()');
 
   it('returns an array', function () {
-    var fonts = getArabicFonts();
+    var fonts = getArabicFonts_();
     if (!(fonts instanceof Array)) throw new Error('Expected array');
   });
 
   it('matches sorted curated list from quran-fonts.json', function () {
-    var fonts = getArabicFonts();
+    var fonts = getArabicFonts_();
     expectArraysEqual(fonts, EXPECTED_APPROVED_FONTS_SORTED);
   });
 

--- a/tests/SettingsService.test.gs
+++ b/tests/SettingsService.test.gs
@@ -3,7 +3,7 @@
  * Run from Apps Script editor: select runSettingsServiceTests, click Run.
  * View results in View → Logs.
  *
- * Note: These tests write to real User Properties and clean up after themselves.
+ * Note: These tests write to real User/Script Properties and clean up after themselves.
  */
 
 function runSettingsServiceTests() {
@@ -41,56 +41,17 @@ function runSettingsServiceTests() {
     };
   }
 
-  // ─── hasClaudeApiKey ──────────────────────────────────────────────────────
+  // ─── getClaudeApiKey_ (reads from Script Properties) ──────────────────────
 
-  results.push('\nhasClaudeApiKey()');
+  results.push('\ngetClaudeApiKey_()');
 
-  it('returns false when no key is stored', function () {
-    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
-    expect(hasClaudeApiKey()).toBeFalsy();
+  it('returns the Claude key from Script Properties', function () {
+    var key = getClaudeApiKey_();
+    // Returns whatever is in Script Properties (null if not set)
+    expect(key === null || typeof key === 'string').toBeTruthy();
   });
 
-  it('returns true after storing a key', function () {
-    PropertiesService.getUserProperties().setProperty('claude_api_key', 'sk-ant-test-key');
-    expect(hasClaudeApiKey()).toBeTruthy();
-    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
-  });
-
-  // ─── setClaudeApiKey ──────────────────────────────────────────────────────
-
-  results.push('\nsetClaudeApiKey()');
-
-  it('stores a key and can be retrieved', function () {
-    setClaudeApiKey('sk-ant-example');
-    expect(getClaudeApiKey()).toBe('sk-ant-example');
-    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
-  });
-
-  it('trims whitespace before storing', function () {
-    setClaudeApiKey('  sk-ant-trimmed  ');
-    expect(getClaudeApiKey()).toBe('sk-ant-trimmed');
-    PropertiesService.getUserProperties().deleteProperty('claude_api_key');
-  });
-
-  it('deletes the key when passed an empty string', function () {
-    setClaudeApiKey('sk-ant-to-delete');
-    setClaudeApiKey('');
-    expect(getClaudeApiKey()).toBeNull();
-  });
-
-  it('deletes the key when passed a whitespace-only string', function () {
-    setClaudeApiKey('sk-ant-to-delete');
-    setClaudeApiKey('   ');
-    expect(getClaudeApiKey()).toBeNull();
-  });
-
-  it('deletes the key when passed null', function () {
-    setClaudeApiKey('sk-ant-to-delete');
-    setClaudeApiKey(null);
-    expect(getClaudeApiKey()).toBeNull();
-  });
-
-  // ─── getSettings / saveSetting defaults ──────────────────────────────────
+  // ─── getSettings / saveSetting_ defaults ──────────────────────────────────
 
   results.push('\ngetSettings() defaults');
 
@@ -100,20 +61,28 @@ function runSettingsServiceTests() {
     expect(s.showTranslation).toBe(true);
   });
 
-  it('saveSetting persists showTranslation false', function () {
-    saveSetting('showTranslation', false);
+  it('saveSetting_ persists showTranslation false', function () {
+    saveSetting_('showTranslation', false);
     var s = getSettings();
     expect(s.showTranslation).toBe(false);
     PropertiesService.getUserProperties().deleteProperty('setting_showTranslation');
   });
 
-  it('saveSetting rejects unknown keys', function () {
+  it('saveSetting_ rejects unknown keys', function () {
     try {
-      saveSetting('unknownKey', true);
+      saveSetting_('unknownKey', true);
       throw new Error('Expected an error but none was thrown');
     } catch (e) {
       if (e.message.indexOf('Unknown setting key') === -1) throw e;
     }
+  });
+
+  // ─── AI search daily limit ────────────────────────────────────────────────
+
+  results.push('\nAI_SEARCH_DAILY_LIMIT');
+
+  it('daily limit is 10', function () {
+    expect(AI_SEARCH_DAILY_LIMIT).toBe(10);
   });
 
   results.push('\n─────────────────────────────────────────');


### PR DESCRIPTION
Closes #76

## Summary

- Migrate Claude API key from per-user User Properties to shared developer-owned Script Properties
- Remove user-facing Claude API key input from settings panel entirely
- Reduce AI search daily limit from 100 to 10 per user per day
- Underscore-suffix all secret-returning and internal functions to block `google.script.run` client access
- Create `.gitignore` to exclude `.clasp.json`, `.claude/`, `node_modules/` before open-sourcing
- Add `tests/*.test.gs` to `.claspignore` to prevent test files from deploying to production
- Remove unused `userinfo.email` OAuth scope
- Whitelist conversation roles to `user`/`assistant` only (prevents system role injection)
- Replace raw error messages with generic strings to prevent info leaks

## Test plan

- [x] All 90 Node.js tests pass
- [x] GAS-native test files updated for renamed functions and new key model
- [x] `clasp push` succeeds (31 files, no test files included)
- [x] Verify sidebar loads and AI search works with Script Properties key
- [x] Verify settings panel no longer shows API key field
- [x] Verify `google.script.run.getClaudeApiKey_` is not callable from DevTools