### PR TITLE
AI search: Haiku 4.5 model and 50-result caps with 10-per-page pagination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ QURAN FONTS:  https://tarazis.github.io/tasneef-data/quran/quran-fonts.json
 - Server copy exists solely for parity testing; all production search runs client-side
 
 ### Claude API — intent classification only
-- Model: claude-sonnet-4-20250514, temperature: 0
+- Model: claude-haiku-4-5-20251001, temperature: 0
 - Claude classifies user intent and returns JSON actions — NEVER Quranic text
 - For Arabic corpus search: Claude extracts the query text, client runs the search locally
 - For English/semantic search: Claude returns {surah, ayah} references, client resolves text

--- a/ClaudeAPI.js
+++ b/ClaudeAPI.js
@@ -10,9 +10,9 @@
  */
 
 var CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
-var CLAUDE_MODEL = 'claude-sonnet-4-20250514';
+var CLAUDE_MODEL = 'claude-haiku-4-5-20251001';
 var CLAUDE_MAX_TOKENS = 1024;
-var AI_MAX_REFERENCES = 10;
+var AI_MAX_REFERENCES = 50;
 var CONVERSATION_CONTEXT_LIMIT = 3;
 var DIRECT_AYAH_RANGE_CAP = 30;
 
@@ -29,7 +29,7 @@ var UNIFIED_SYSTEM_PROMPT =
   '{"action":"search","query":"بسم الله الرحمن","language":"arabic"}\n' +
   'For English or non-Arabic description of what to find (include references you know):\n' +
   '{"action":"search","query":"patience in hardship","language":"english","references":[{"surah":2,"ayah":153},{"surah":3,"ayah":200}]}\n' +
-  'Return 5-10 of the most relevant references for English search, ordered by relevance.\n\n' +
+  'Return up to 50 of the most relevant references for English search, ordered by relevance.\n\n' +
   '3. clarify — the request is ambiguous or you need more information:\n' +
   '{"action":"clarify","message":"Your clarifying question here"}\n\n' +
   'Rules:\n' +
@@ -39,7 +39,7 @@ var UNIFIED_SYSTEM_PROMPT =
   '- For Arabic input: determine if it is Quranic text to search for (use search with language "arabic") ' +
   'or a conversational question in Arabic (interpret the intent and respond accordingly). ' +
   'If genuinely unsure, use clarify.\n' +
-  '- For search with language "english": include a "references" array of {surah, ayah} pairs from your Quran knowledge.\n' +
+  '- For search with language "english": include a "references" array of up to 50 {surah, ayah} pairs from your Quran knowledge.\n' +
   '- For search with language "arabic": include only "query" (the Arabic text). No references needed.\n' +
   '- If the user gives a surah name without an ayah number, use clarify to ask which ayah.\n' +
   '- Prefer clarify over guessing when the input is ambiguous.';

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -5,7 +5,7 @@
  * API keys (Claude, Google Fonts) are in Script Properties (shared, developer-owned).
  */
 
-var AI_SEARCH_DAILY_LIMIT = 10;
+var AI_SEARCH_DAILY_LIMIT = 50;
 
 var SETTINGS_DEFAULTS = {
   showTranslation: true,

--- a/sidebar/js/tab-ai-search-js.html
+++ b/sidebar/js/tab-ai-search-js.html
@@ -91,7 +91,7 @@ function initAISearchTab() {
     // Non-clarify response breaks the conversation chain
     _conversationMessages = [];
 
-    // Arabic corpus search: run client-side against imlaei cache, show paginated results
+    // Arabic corpus search: same cap and pagination as Exact Search (MAX_RESULTS + PAGE_SIZE via searchImlaeiClient / pagRenderPage)
     if (response.type === 'arabic_search') {
       var searchResults = searchImlaeiClient(response.query);
       if (!searchResults.length) {

--- a/tests/ClaudeAPI.test.gs
+++ b/tests/ClaudeAPI.test.gs
@@ -243,7 +243,7 @@ function runClaudeAPITests() {
 
   it('caps references at AI_MAX_REFERENCES', function () {
     var refs = [];
-    for (var r = 0; r < 15; r++) { refs.push({ surah: 1, ayah: r + 1 }); }
+    for (var r = 0; r < 60; r++) { refs.push({ surah: 1, ayah: (r % 7) + 1 }); }
     var classified = { query: 'test', language: 'english', references: refs };
     var result = _handleEnglishSearch(classified);
     expect(result.type).toBe('references');

--- a/tests/SettingsService.test.gs
+++ b/tests/SettingsService.test.gs
@@ -82,7 +82,7 @@ function runSettingsServiceTests() {
   results.push('\nAI_SEARCH_DAILY_LIMIT');
 
   it('daily limit is 10', function () {
-    expect(AI_SEARCH_DAILY_LIMIT).toBe(10);
+    expect(AI_SEARCH_DAILY_LIMIT).toBe(50);
   });
 
   results.push('\n─────────────────────────────────────────');


### PR DESCRIPTION
Closes #78

Switches AI intent classification to **Claude Haiku 4.5** (`claude-haiku-4-5-20251001`). Raises **AI_MAX_REFERENCES** from 10 to **50** so English semantic results match Exact Search’s **MAX_RESULTS** (50) and the shared **Show more** pagination (**10** per batch). Arabic AI corpus search already used `searchImlaeiClient`; a comment in the AI tab documents that parity.