### PR TITLE
Rename Insert to Browse, live-only exact search, placeholder copy

### DIFF
--- a/sidebar/components/tab-ai-search.html
+++ b/sidebar/components/tab-ai-search.html
@@ -4,7 +4,7 @@
   <div id="ai-search-empty" class="empty-state hidden"></div>
   <div class="tab-input-area">
     <div class="tab-input-wrap">
-      <textarea id="ai-search-query" rows="2" placeholder="Describe what you're looking for…"></textarea>
+      <textarea id="ai-search-query" rows="2" placeholder="Search themes (e.g., patience, charity)..."></textarea>
       <button type="button" class="btn-send" id="btn-ai-search" title="Send" aria-label="Send">&#10148;</button>
     </div>
   </div>

--- a/sidebar/components/tab-exact-search.html
+++ b/sidebar/components/tab-exact-search.html
@@ -4,7 +4,7 @@
   <div id="exact-search-empty" class="empty-state hidden"></div>
   <div class="tab-input-area">
     <div class="tab-input-wrap">
-      <textarea id="exact-search-query" rows="2" placeholder="الحمد لله رب العالمين" dir="rtl"></textarea>
+      <textarea id="exact-search-query" rows="2" placeholder='e.g., "الحمد لله رب العالمين"' dir="rtl"></textarea>
     </div>
   </div>
 </div>

--- a/sidebar/components/tab-exact-search.html
+++ b/sidebar/components/tab-exact-search.html
@@ -4,8 +4,7 @@
   <div id="exact-search-empty" class="empty-state hidden"></div>
   <div class="tab-input-area">
     <div class="tab-input-wrap">
-      <textarea id="exact-search-query" rows="2" placeholder="Enter Arabic text to search…" dir="rtl"></textarea>
-      <button type="button" class="btn-send" id="btn-exact-search" title="Search" aria-label="Search">&#10148;</button>
+      <textarea id="exact-search-query" rows="2" placeholder="الحمد لله رب العالمين" dir="rtl"></textarea>
     </div>
   </div>
 </div>

--- a/sidebar/components/tab-exact-search.html
+++ b/sidebar/components/tab-exact-search.html
@@ -4,7 +4,7 @@
   <div id="exact-search-empty" class="empty-state hidden"></div>
   <div class="tab-input-area">
     <div class="tab-input-wrap">
-      <textarea id="exact-search-query" rows="2" placeholder='e.g., "الحمد لله رب العالمين"' dir="rtl"></textarea>
+      <textarea id="exact-search-query" rows="2" placeholder='"الحمد لله رب العالمين"' dir="rtl"></textarea>
     </div>
   </div>
 </div>

--- a/sidebar/js/tab-exact-search-js.html
+++ b/sidebar/js/tab-exact-search-js.html
@@ -6,7 +6,6 @@
 
 function initExactSearchTab() {
   var queryEl = document.getElementById('exact-search-query');
-  var btnSearch = document.getElementById('btn-exact-search');
   var resultsEl = document.getElementById('exact-search-results');
   var emptyEl = document.getElementById('exact-search-empty');
   var debounceTimer = null;
@@ -68,7 +67,6 @@ function initExactSearchTab() {
     }
   });
 
-  if (btnSearch) btnSearch.addEventListener('click', doExactSearch);
   if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
   if (resultsEl) resultsEl.addEventListener('click', onToggleTranslationClick);
 }

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -26,7 +26,7 @@
     <?!= include_('sidebar/components/format-bar') ?>
 
     <nav class="tab-nav">
-      <button type="button" class="tab-btn active" data-tab="direct-insert">Insert</button>
+      <button type="button" class="tab-btn active" data-tab="direct-insert">Browse</button>
       <button type="button" class="tab-btn" data-tab="exact-search">Search</button>
       <button type="button" class="tab-btn" data-tab="ai-search">AI Search</button>
     </nav>


### PR DESCRIPTION
Closes #85

- Tab label **Insert** → **Browse** (`direct-insert` unchanged).
- **Search**: removed green send button and click handler; debounced live search and Enter unchanged.
- Placeholders: Arabic on exact search; themes hint on AI search.

Tests: `npm test` passed. `clasp push` done.