### PR TITLE
Sidebar UI: result cards layout, Insert loader, new AI chat control, AI tab sparkles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,10 +40,10 @@ tasneef-ai/
 │       ├── render-helpers.html    renderPreview(), onInsertClick(), makeSkeleton()
 │       ├── format-bar.html        debouncedSave(), applyFormatStateToUI(), initFormatBar()
 │       ├── settings-panel-js.html initSettings(), refreshSettings(), loadSettingsIntoPanel(), initSettingsPanelHandlers(), onSettingsLoaded(), onFontsLoaded()
-│       ├── tab-direct-insert-js.html  initDirectInsertTab(), clearDirectInsert()
-│       ├── tab-exact-search-js.html   initExactSearchTab(), clearExactSearch()
+│       ├── tab-direct-insert-js.html  initDirectInsertTab()
+│       ├── tab-exact-search-js.html   initExactSearchTab()
 │       ├── tab-ai-search-js.html      _conversationMessages, initAISearchTab(), clearAISearch()
-│       └── sidebar-js.html        IIFE: tab nav, clearActiveTab, setupTextarea, init() bootstrap
+│       └── sidebar-js.html        IIFE: tab nav, setupTextarea, init() bootstrap
 │
 └── tests/
     ├── makeClientCache.test.js    Node tests for cache factory
@@ -72,11 +72,11 @@ sidebar/js/card-builder         — pure rendering utils; no runtime deps on ear
 sidebar/js/pagination           — calls buildCardHtml (card-builder), window.getFormatState (shared-state)
 sidebar/js/render-helpers       — calls buildCardHtml, buildRangeData (card-builder); _buildAyahDataForInsert (search-utils)
 sidebar/js/format-bar           — reads/writes formatState, SAVE_DEBOUNCE_MS (shared-state); reads window._activeTab, window._refreshDirectInsert
-sidebar/js/settings-panel-js    — reads/writes _settings, formatState; calls applyFormatStateToUI (format-bar); calls window.clearActiveTab
+sidebar/js/settings-panel-js    — reads/writes _settings, formatState; calls applyFormatStateToUI (format-bar); header New chat → clearAISearch
 sidebar/js/tab-direct-insert-js — reads _surahList, MAX_RESULTS; calls cache accessors, renderPreview, onInsertClick; sets window._refreshDirectInsert
 sidebar/js/tab-exact-search-js  — calls pagClear/Reset/RenderPage, searchImlaeiClient, onInsertClick
 sidebar/js/tab-ai-search-js     — calls all of the above; reads/writes _conversationMessages; calls window.setupTextarea
-sidebar/js/sidebar-js           — IIFE: exposes window.clearActiveTab, window.setupTextarea; calls init() on DOMContentLoaded
+sidebar/js/sidebar-js           — IIFE: exposes window.setupTextarea; calls init() on DOMContentLoaded
 ```
 
 **Key ordering constraints:**
@@ -104,9 +104,9 @@ sidebar/js/sidebar-js           — IIFE: exposes window.clearActiveTab, window.
 ### Window-bridge properties (set by IIFE, read by global scripts)
 | Property | Set by | Read by |
 |---|---|---|
-| `window._activeTab` | `sidebar-js` IIFE (`switchTab`) | `format-bar` (`initFormatBar` event handlers), `settings-panel-js` (`clearActiveTab`) |
+| `window._activeTab` | `sidebar-js` IIFE (`switchTab`) | `format-bar` (`initFormatBar` event handlers) |
 | `window._refreshDirectInsert` | `tab-direct-insert-js` (`initDirectInsertTab`) | `format-bar` (`initFormatBar` event handlers) |
-| `window.clearActiveTab` | `sidebar-js` IIFE | `settings-panel-js` (`initSettings` clear button) |
+| `clearAISearch()` | `tab-ai-search-js` (global fn) | `settings-panel-js` (`initSettings` header New chat button) |
 | `window.setupTextarea` | `sidebar-js` IIFE | `tab-ai-search-js` (`initAISearchTab`) |
 | `window.getFormatState` | `shared-state` | `render-helpers` (`onInsertClick`), `pagination` (`pagRenderPage`) |
 
@@ -266,8 +266,8 @@ Any non-clarify response resets _conversationMessages = [].
 | `window._refreshDirectInsert` | IIFE (`sidebar-js`) initial `null` | Set to `autoRenderPreview` by `initDirectInsertTab` |
 | `_conversationMessages` | `tab-ai-search-js.html` global | `clearAISearch()`, any non-clarify AI response |
 | Pagination state `_pagState` | `pagination.html` module-private | `pagReset()` (new search), `pagClear()` (tab clear) |
-| Direct Insert DOM state | DOM only | `clearDirectInsert()` — resets selects + results |
-| Exact Search DOM state | DOM only | `clearExactSearch()` — clears input + results |
-| AI Search DOM state | DOM only | `clearAISearch()` — clears input, results, clarify, no-key banner |
+| Direct Insert DOM state | DOM only | User changes surah/ayah selects; tab switch does not clear |
+| Exact Search DOM state | DOM only | User clears query or edits search; tab switch does not clear |
+| AI Search DOM state | DOM only | `clearAISearch()` — clears input, results, clarify, conversation; invoked by header **New chat** (sparkle) button |
 
-**What triggers a clear:** `window.clearActiveTab()` is called by the 🗑 button in the header and dispatches to the active tab's `clear*()` function. Tab switches do **not** clear state — switching back restores previous results.
+**What triggers AI reset:** The header **New chat** control calls `clearAISearch()` only. Browse and Search tabs are not cleared from the header. Tab switches do **not** clear state — switching back restores previous results for Browse/Search.

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -1,11 +1,11 @@
 <script>
 // Depends on globals: _settings, formatState (shared-state.html),
 //   applyFormatStateToUI (format-bar.html)
-// Reads window.clearActiveTab (set by sidebar-js.html IIFE)
+// Header "New chat" calls clearAISearch (tab-ai-search-js.html)
 
 function initSettings() {
   var btnSettings = document.getElementById('btn-settings');
-  var btnClear = document.getElementById('btn-clear');
+  var btnNewAiChat = document.getElementById('btn-new-ai-chat');
   var overlay = document.getElementById('settings-overlay');
   var btnBack = document.getElementById('btn-settings-back');
 
@@ -15,9 +15,9 @@ function initSettings() {
       loadSettingsIntoPanel();
     });
   }
-  if (btnClear) {
-    btnClear.addEventListener('click', function() {
-      if (window.clearActiveTab) window.clearActiveTab();
+  if (btnNewAiChat) {
+    btnNewAiChat.addEventListener('click', function() {
+      if (typeof clearAISearch === 'function') clearAISearch();
     });
   }
   if (btnBack && overlay) {

--- a/sidebar/js/sidebar-js.html
+++ b/sidebar/js/sidebar-js.html
@@ -40,21 +40,6 @@
     }
   }
 
-  function clearActiveTab() {
-    switch (window._activeTab) {
-      case 'direct-insert':
-        clearDirectInsert();
-        break;
-      case 'exact-search':
-        clearExactSearch();
-        break;
-      case 'ai-search':
-        clearAISearch();
-        break;
-    }
-  }
-  window.clearActiveTab = clearActiveTab;
-
   function setupTextarea(el, onSubmit) {
     if (!el) return;
     el.addEventListener('input', function() {

--- a/sidebar/js/tab-direct-insert-js.html
+++ b/sidebar/js/tab-direct-insert-js.html
@@ -125,17 +125,4 @@ function initDirectInsertTab() {
   if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
   if (resultsEl) resultsEl.addEventListener('click', onToggleTranslationClick);
 }
-
-function clearDirectInsert() {
-  var surahSelect = document.getElementById('surah-select');
-  var ayahStart = document.getElementById('ayah-start');
-  var ayahEnd = document.getElementById('ayah-end');
-  var resultsEl = document.getElementById('direct-insert-results');
-  var emptyEl = document.getElementById('direct-insert-empty');
-  if (surahSelect) surahSelect.value = '';
-  if (ayahStart) { ayahStart.innerHTML = '<option value="">From</option>'; ayahStart.disabled = true; }
-  if (ayahEnd) { ayahEnd.innerHTML = '<option value="">To</option>'; ayahEnd.disabled = true; }
-  if (resultsEl) resultsEl.innerHTML = '';
-  if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
-}
 </script>

--- a/sidebar/js/tab-exact-search-js.html
+++ b/sidebar/js/tab-exact-search-js.html
@@ -70,14 +70,4 @@ function initExactSearchTab() {
   if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
   if (resultsEl) resultsEl.addEventListener('click', onToggleTranslationClick);
 }
-
-function clearExactSearch() {
-  pagClear('exact-search');
-  var queryEl = document.getElementById('exact-search-query');
-  var resultsEl = document.getElementById('exact-search-results');
-  var emptyEl = document.getElementById('exact-search-empty');
-  if (queryEl) { queryEl.value = ''; queryEl.style.height = 'auto'; }
-  if (resultsEl) resultsEl.innerHTML = '';
-  if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
-}
 </script>

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -39,30 +39,27 @@
   .tab-btn:hover { color: #333; }
   .tab-btn.active { color: #2e7d32; border-bottom-color: #2e7d32; }
 
-  /* Sparkles sit in a corner badge so the label can use the full tab width (single line). */
+  /* AI tab: one flex row — label + sparkles centered as a group, vertically aligned */
   .tab-btn--ai {
-    position: relative;
     display: flex;
+    flex-direction: row;
     align-items: center;
     justify-content: center;
+    gap: 6px;
     white-space: nowrap;
   }
   .tab-btn--ai .tab-btn-ai-label {
+    flex-shrink: 0;
     white-space: nowrap;
-    text-align: center;
     line-height: 1.2;
-    /* Reserve top-right for sparkle cluster + extra gap before stars */
-    padding: 0 40px 0 2px;
+    padding: 0;
   }
   .tab-btn--ai .tab-btn-ai-sparkles {
-    position: absolute;
-    top: 4px;
-    right: 3px;
     display: inline-flex;
-    align-items: flex-start;
+    align-items: center;
+    flex-shrink: 0;
     gap: 0;
     line-height: 0;
-    pointer-events: none;
   }
   .tab-btn--ai .tab-ai-sparkle { display: inline-flex; align-items: center; justify-content: center; transform-origin: center center; color: #66bb6a; opacity: 0.65; transition: opacity 0.2s ease, color 0.2s ease; }
   .tab-btn--ai .tab-ai-sparkle svg { width: 18px; height: 18px; flex-shrink: 0; display: block; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -39,12 +39,33 @@
   .tab-btn.active { color: #2e7d32; border-bottom-color: #2e7d32; }
 
   .tab-btn--ai { display: inline-flex; align-items: center; justify-content: center; gap: 4px; }
-  .tab-btn--ai .tab-btn-ai-sparkles { display: inline-flex; align-items: center; gap: 2px; line-height: 0; }
-  .tab-btn--ai .tab-btn-ai-sparkles svg { width: 9px; height: 9px; flex-shrink: 0; fill: #7986cb; opacity: 0.55; transition: opacity 0.2s ease, filter 0.2s ease; }
-  .tab-btn--ai .tab-btn-ai-sparkles svg:last-child { width: 7px; height: 7px; fill: #5c6bc0; }
-  .tab-btn--ai:hover .tab-btn-ai-sparkles svg { opacity: 0.95; filter: drop-shadow(0 0 4px rgba(26, 115, 232, 0.45)); }
-  .tab-btn--ai.active .tab-btn-ai-sparkles svg { opacity: 0.9; fill: #3949ab; }
-  .tab-btn--ai.active:hover .tab-btn-ai-sparkles svg { filter: drop-shadow(0 0 5px rgba(26, 115, 232, 0.55)); }
+  .tab-btn--ai .tab-btn-ai-sparkles { display: inline-flex; align-items: center; gap: 3px; line-height: 0; }
+  .tab-btn--ai .tab-ai-sparkle { display: inline-flex; align-items: center; justify-content: center; transform-origin: center center; color: #66bb6a; opacity: 0.65; transition: opacity 0.2s ease, color 0.2s ease; }
+  .tab-btn--ai .tab-ai-sparkle svg { width: 18px; height: 18px; flex-shrink: 0; display: block; }
+  .tab-btn--ai .tab-ai-sparkle--sm svg { width: 14px; height: 14px; }
+  .tab-btn--ai.active .tab-ai-sparkle { color: #2e7d32; opacity: 0.88; }
+
+  @keyframes ai-tab-sparkle-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+  @keyframes ai-tab-sparkle-green {
+    0% { color: #1b5e20; }
+    20% { color: #2e7d32; }
+    40% { color: #43a047; }
+    60% { color: #66bb6a; }
+    80% { color: #81c784; }
+    100% { color: #1b5e20; }
+  }
+  @keyframes ai-tab-sparkle-glitter {
+    0%, 100% { opacity: 1; filter: drop-shadow(0 0 1px rgba(46, 125, 50, 0.45)); }
+    50% { opacity: 0.88; filter: drop-shadow(0 0 6px rgba(129, 199, 132, 0.95)); }
+  }
+
+  .tab-btn--ai:hover .tab-ai-sparkle:nth-child(1) {
+    animation: ai-tab-sparkle-spin 2.4s linear infinite, ai-tab-sparkle-green 2s ease-in-out infinite, ai-tab-sparkle-glitter 1s ease-in-out infinite;
+  }
+  .tab-btn--ai:hover .tab-ai-sparkle:nth-child(2) {
+    animation: ai-tab-sparkle-spin 2.8s linear infinite reverse, ai-tab-sparkle-green 2.3s ease-in-out infinite, ai-tab-sparkle-glitter 1.15s ease-in-out infinite;
+    animation-delay: 0s, -0.6s, -0.35s;
+  }
 
   /* Tab content area — fills space below nav */
   .tab-content { flex: 1; overflow: hidden; min-height: 0; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -39,7 +39,7 @@
   .tab-btn:hover { color: #333; }
   .tab-btn.active { color: #2e7d32; border-bottom-color: #2e7d32; }
 
-  /* AI tab: one flex row — label + sparkles centered as a group, vertically aligned */
+  /* AI tab: Lucide-style sparkles (1em) left of label; color inherits = same as tab text */
   .tab-btn--ai {
     display: flex;
     flex-direction: row;
@@ -48,45 +48,25 @@
     gap: 6px;
     white-space: nowrap;
   }
+  .tab-btn--ai .tab-btn-ai-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    line-height: 0;
+    color: inherit;
+  }
+  .tab-btn--ai .tab-btn-ai-icon svg {
+    width: 1em;
+    height: 1em;
+    display: block;
+    flex-shrink: 0;
+  }
   .tab-btn--ai .tab-btn-ai-label {
     flex-shrink: 0;
     white-space: nowrap;
     line-height: 1.2;
     padding: 0;
-  }
-  .tab-btn--ai .tab-btn-ai-sparkles {
-    display: inline-flex;
-    align-items: center;
-    flex-shrink: 0;
-    gap: 0;
-    line-height: 0;
-  }
-  .tab-btn--ai .tab-ai-sparkle { display: inline-flex; align-items: center; justify-content: center; transform-origin: center center; color: #66bb6a; opacity: 0.65; transition: opacity 0.2s ease, color 0.2s ease; }
-  .tab-btn--ai .tab-ai-sparkle svg { width: 18px; height: 18px; flex-shrink: 0; display: block; }
-  .tab-btn--ai .tab-ai-sparkle--sm { margin-left: -4px; }
-  .tab-btn--ai .tab-ai-sparkle--sm svg { width: 14px; height: 14px; }
-  .tab-btn--ai.active .tab-ai-sparkle { color: #2e7d32; opacity: 0.88; }
-
-  @keyframes ai-tab-sparkle-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-  @keyframes ai-tab-sparkle-green {
-    0% { color: #1b5e20; }
-    20% { color: #2e7d32; }
-    40% { color: #43a047; }
-    60% { color: #66bb6a; }
-    80% { color: #81c784; }
-    100% { color: #1b5e20; }
-  }
-  @keyframes ai-tab-sparkle-glitter {
-    0%, 100% { opacity: 1; filter: drop-shadow(0 0 1px rgba(46, 125, 50, 0.45)); }
-    50% { opacity: 0.88; filter: drop-shadow(0 0 6px rgba(129, 199, 132, 0.95)); }
-  }
-
-  .tab-btn--ai:hover .tab-ai-sparkle:nth-child(1) {
-    animation: ai-tab-sparkle-spin 2.4s linear infinite, ai-tab-sparkle-green 2s ease-in-out infinite, ai-tab-sparkle-glitter 1s ease-in-out infinite;
-  }
-  .tab-btn--ai:hover .tab-ai-sparkle:nth-child(2) {
-    animation: ai-tab-sparkle-spin 2.8s linear infinite reverse, ai-tab-sparkle-green 2.3s ease-in-out infinite, ai-tab-sparkle-glitter 1.15s ease-in-out infinite;
-    animation-delay: 0s, -0.6s, -0.35s;
   }
 
   /* Tab content area — fills space below nav */

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -38,6 +38,14 @@
   .tab-btn:hover { color: #333; }
   .tab-btn.active { color: #2e7d32; border-bottom-color: #2e7d32; }
 
+  .tab-btn--ai { display: inline-flex; align-items: center; justify-content: center; gap: 4px; }
+  .tab-btn--ai .tab-btn-ai-sparkles { display: inline-flex; align-items: center; gap: 2px; line-height: 0; }
+  .tab-btn--ai .tab-btn-ai-sparkles svg { width: 9px; height: 9px; flex-shrink: 0; fill: #7986cb; opacity: 0.55; transition: opacity 0.2s ease, filter 0.2s ease; }
+  .tab-btn--ai .tab-btn-ai-sparkles svg:last-child { width: 7px; height: 7px; fill: #5c6bc0; }
+  .tab-btn--ai:hover .tab-btn-ai-sparkles svg { opacity: 0.95; filter: drop-shadow(0 0 4px rgba(26, 115, 232, 0.45)); }
+  .tab-btn--ai.active .tab-btn-ai-sparkles svg { opacity: 0.9; fill: #3949ab; }
+  .tab-btn--ai.active:hover .tab-btn-ai-sparkles svg { filter: drop-shadow(0 0 5px rgba(26, 115, 232, 0.55)); }
+
   /* Tab content area — fills space below nav */
   .tab-content { flex: 1; overflow: hidden; min-height: 0; }
   .tab-panel { display: none; flex-direction: column; height: 100%; }
@@ -66,7 +74,7 @@
   .result-card .translation { font-size: 12px; color: #555; margin: 6px 0 0; line-height: 1.5; }
   .result-card .btn-toggle-translation { display: inline-block; font-size: 11px; color: #2e7d32; cursor: pointer; margin-top: 4px; user-select: none; }
   .result-card .btn-toggle-translation:hover { text-decoration: underline; }
-  .result-card .btn-insert-result { margin-top: 8px; padding: 6px 12px; font-size: 12px; }
+  .result-card .btn-insert-result { display: block; width: 100%; margin-top: 8px; padding: 6px 12px; font-size: 12px; }
 
   /* Clarify message from Claude */
   .clarify-message { padding: 12px 16px; margin: 8px 16px; background: #f5f5f5; border-radius: 8px; font-size: 13px; color: #333; line-height: 1.5; }
@@ -96,7 +104,8 @@
 
   /* Insert button loading spinner */
   .btn-insert-result.btn-loading { color: transparent; pointer-events: none; position: relative; }
-  .btn-insert-result.btn-loading::after { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 12px; height: 12px; border: 2px solid rgba(255,255,255,0.5); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; }
+  /* margin centers ::after so rotate-only @keyframes spin does not fight translate(-50%,-50%) */
+  .btn-insert-result.btn-loading::after { content: ''; position: absolute; top: 50%; left: 50%; width: 12px; height: 12px; margin: -6px 0 0 -6px; border: 2px solid rgba(255,255,255,0.5); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; }
 
   /* Input area pinned to bottom of tab */
   .tab-input-area { flex-shrink: 0; padding: 12px 16px; border-top: 1px solid #e0e0e0; background: #fff; }
@@ -119,6 +128,7 @@
 
   .btn-icon { padding: 8px; border: none; background: none; cursor: pointer; color: #666; border-radius: 4px; font-size: 16px; }
   .btn-icon:hover { background: #f0f0f0; color: #333; }
+  .btn-icon svg { display: block; vertical-align: middle; }
 
   /* Settings overlay */
   .settings-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); z-index: 100; display: flex; align-items: center; justify-content: center; padding: 20px; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -128,7 +128,7 @@
 
   .btn-icon { padding: 8px; border: none; background: none; cursor: pointer; color: #666; border-radius: 4px; font-size: 16px; }
   .btn-icon:hover { background: #f0f0f0; color: #333; }
-  .btn-icon svg { display: block; vertical-align: middle; }
+  .btn-icon svg { display: block; }
 
   /* Settings overlay */
   .settings-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); z-index: 100; display: flex; align-items: center; justify-content: center; padding: 20px; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -38,8 +38,31 @@
   .tab-btn:hover { color: #333; }
   .tab-btn.active { color: #2e7d32; border-bottom-color: #2e7d32; }
 
-  .tab-btn--ai { display: inline-flex; align-items: center; justify-content: center; gap: 4px; }
-  .tab-btn--ai .tab-btn-ai-sparkles { display: inline-flex; align-items: center; gap: 3px; line-height: 0; }
+  /* Sparkles sit in a corner badge so the label can use the full tab width (single line). */
+  .tab-btn--ai {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+  }
+  .tab-btn--ai .tab-btn-ai-label {
+    white-space: nowrap;
+    text-align: center;
+    line-height: 1.2;
+    /* Reserve top-right for sparkle cluster (~18+14px + gap); keeps "AI Search" one line */
+    padding: 0 30px 0 2px;
+  }
+  .tab-btn--ai .tab-btn-ai-sparkles {
+    position: absolute;
+    top: 4px;
+    right: 2px;
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 2px;
+    line-height: 0;
+    pointer-events: none;
+  }
   .tab-btn--ai .tab-ai-sparkle { display: inline-flex; align-items: center; justify-content: center; transform-origin: center center; color: #66bb6a; opacity: 0.65; transition: opacity 0.2s ease, color 0.2s ease; }
   .tab-btn--ai .tab-ai-sparkle svg { width: 18px; height: 18px; flex-shrink: 0; display: block; }
   .tab-btn--ai .tab-ai-sparkle--sm svg { width: 14px; height: 14px; }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -34,7 +34,8 @@
 
   /* Tab navigation */
   .tab-nav { display: flex; border-bottom: 2px solid #e0e0e0; flex-shrink: 0; padding: 0 8px; }
-  .tab-btn { flex: 1; padding: 10px 4px; border: none; background: none; font-size: 13px; font-weight: 500; color: #666; cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -2px; transition: color 0.15s, border-color 0.15s; }
+  /* flex-basis 0 + min-width 0 so each tab gets equal width and the active underline spans the full column */
+  .tab-btn { flex: 1 1 0; min-width: 0; padding: 10px 4px; border: none; background: none; font-size: 13px; font-weight: 500; color: #666; cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -2px; transition: color 0.15s, border-color 0.15s; }
   .tab-btn:hover { color: #333; }
   .tab-btn.active { color: #2e7d32; border-bottom-color: #2e7d32; }
 
@@ -50,21 +51,22 @@
     white-space: nowrap;
     text-align: center;
     line-height: 1.2;
-    /* Reserve top-right for sparkle cluster (~18+14px + gap); keeps "AI Search" one line */
-    padding: 0 30px 0 2px;
+    /* Reserve top-right for sparkle cluster + extra gap before stars */
+    padding: 0 40px 0 2px;
   }
   .tab-btn--ai .tab-btn-ai-sparkles {
     position: absolute;
     top: 4px;
-    right: 2px;
+    right: 3px;
     display: inline-flex;
     align-items: flex-start;
-    gap: 2px;
+    gap: 0;
     line-height: 0;
     pointer-events: none;
   }
   .tab-btn--ai .tab-ai-sparkle { display: inline-flex; align-items: center; justify-content: center; transform-origin: center center; color: #66bb6a; opacity: 0.65; transition: opacity 0.2s ease, color 0.2s ease; }
   .tab-btn--ai .tab-ai-sparkle svg { width: 18px; height: 18px; flex-shrink: 0; display: block; }
+  .tab-btn--ai .tab-ai-sparkle--sm { margin-left: -4px; }
   .tab-btn--ai .tab-ai-sparkle--sm svg { width: 14px; height: 14px; }
   .tab-btn--ai.active .tab-ai-sparkle { color: #2e7d32; opacity: 0.88; }
 

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -18,7 +18,9 @@
         <span class="title">Tasneef AI</span>
       </div>
       <div class="header-actions">
-        <button type="button" class="btn-icon" id="btn-clear" title="Clear" aria-label="Clear">&#128465;</button>
+        <button type="button" class="btn-icon" id="btn-new-ai-chat" title="New chat" aria-label="New chat">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
+        </button>
         <button type="button" class="btn-icon" id="btn-settings" title="Settings" aria-label="Settings">&#9881;</button>
       </div>
     </header>
@@ -28,7 +30,13 @@
     <nav class="tab-nav">
       <button type="button" class="tab-btn active" data-tab="direct-insert">Browse</button>
       <button type="button" class="tab-btn" data-tab="exact-search">Search</button>
-      <button type="button" class="tab-btn" data-tab="ai-search">AI Search</button>
+      <button type="button" class="tab-btn tab-btn--ai" data-tab="ai-search">
+        <span class="tab-btn-ai-label">AI Search</span>
+        <span class="tab-btn-ai-sparkles" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
+        </span>
+      </button>
     </nav>
 
     <main class="tab-content">

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -34,15 +34,17 @@
       <button type="button" class="tab-btn active" data-tab="direct-insert">Browse</button>
       <button type="button" class="tab-btn" data-tab="exact-search">Search</button>
       <button type="button" class="tab-btn tab-btn--ai" data-tab="ai-search">
-        <span class="tab-btn-ai-label">AI Search</span>
-        <span class="tab-btn-ai-sparkles" aria-hidden="true">
-          <span class="tab-ai-sparkle">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
-          </span>
-          <span class="tab-ai-sparkle tab-ai-sparkle--sm">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
-          </span>
+        <span class="tab-btn-ai-icon" aria-hidden="true">
+          <!-- Lucide sparkles (ISC) — stroke only, flat; color from tab via currentColor -->
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+            <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/>
+            <path d="M20 3v4"/>
+            <path d="M22 5h-4"/>
+            <path d="M4 17v2"/>
+            <path d="M5 18H3"/>
+          </svg>
         </span>
+        <span class="tab-btn-ai-label">AI Search</span>
       </button>
     </nav>
 

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -19,7 +19,10 @@
       </div>
       <div class="header-actions">
         <button type="button" class="btn-icon" id="btn-new-ai-chat" title="New chat" aria-label="New chat">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+            <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.506l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>
+          </svg>
         </button>
         <button type="button" class="btn-icon" id="btn-settings" title="Settings" aria-label="Settings">&#9881;</button>
       </div>
@@ -33,8 +36,12 @@
       <button type="button" class="tab-btn tab-btn--ai" data-tab="ai-search">
         <span class="tab-btn-ai-label">AI Search</span>
         <span class="tab-btn-ai-sparkles" aria-hidden="true">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
+          <span class="tab-ai-sparkle">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
+          </span>
+          <span class="tab-ai-sparkle tab-ai-sparkle--sm">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2l1.5 7.5L21 11l-7.5 1.5L12 20l-1.5-7.5L3 11l7.5-1.5L12 2z"/></svg>
+          </span>
         </span>
       </button>
     </nav>


### PR DESCRIPTION
Closes #87

## Summary

- Result cards: **Insert** is full-width and sits below the translation toggle.
- **Insert** loading spinner stays centered (negative margin centering so `spin` keyframes no longer wipe `translate`).
- Header trash is replaced with a **New chat** sparkle control that only calls `clearAISearch()`; Browse/Search header clear paths removed (`clearDirectInsert`, `clearExactSearch`, `clearActiveTab`).
- **AI Search** tab shows paired sparkle SVGs with a light blue hover glow.
- `ARCHITECTURE.md` updated for the new behavior.

## Testing

- `npm test` (all green)
- `clasp push`