### PR TITLE
Sidebar preview font (pt), font CSS load order, translation 80%, citation spacing

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -132,7 +132,7 @@ function insertAyah(ayahData, formatState, settings) {
   var surahNameEn = ayahData.surahNameEnglish || '';
   var ayahNumAr = toArabicIndic(ayahData.ayah);
 
-  /** U+00A0 between ornate parens and ayah (non-breaking; matches preview). */
+  /** U+00A0: ornate Quranic parens (matches preview); Arabic :/ayah and range hyphen; English name/num only. */
   var qNbsp = '\u00A0';
   var paragraphsToInsert = [];
   if (showTranslation && translationText) {
@@ -142,13 +142,13 @@ function insertAyah(ayahData, formatState, settings) {
       rtl: true
     });
     paragraphsToInsert.push({
-      text: '\u201C' + translationText + '\u201D (' + surahNameEn + ' ' + ayahData.surah + ':' + ayahData.ayah + ')',
+      text: '\u201C' + translationText + '\u201D (' + surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true
     });
   } else {
     paragraphsToInsert.push({
-      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' + surahNameAr + ': ' + ayahNumAr + ']',
+      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' + surahNameAr + ':' + qNbsp + ayahNumAr + ']',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true
     });
@@ -193,7 +193,7 @@ function insertAyahRange(rangeData, formatState, settings) {
     });
     paragraphsToInsert.push({
       text: '\u201C' + translationText + '\u201D (' +
-            surahNameEn + ' ' + rangeData.surah + ':' +
+            surahNameEn + qNbsp + rangeData.surah + ':' +
             rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true
@@ -201,7 +201,7 @@ function insertAyahRange(rangeData, formatState, settings) {
   } else {
     paragraphsToInsert.push({
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' +
-            surahNameAr + ': ' + ayahStartAr + ' - ' + ayahEndAr + ']',
+            surahNameAr + ':' + qNbsp + ayahStartAr + qNbsp + '-' + qNbsp + ayahEndAr + ']',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true
     });

--- a/FormatService.js
+++ b/FormatService.js
@@ -10,11 +10,11 @@ var FALLBACK_FONT = 'Amiri';
 /** Google Docs font family for inserted English translation (Google Fonts name). */
 var ENGLISH_TRANSLATION_INSERT_FONT = 'Figtree';
 
-/** Points smaller than the ayah font size for inserted English translation. */
-var ENGLISH_TRANSLATION_FONT_SIZE_DELTA = 4;
+/** Inserted English translation uses this fraction of the ayah font size (points), rounded. */
+var ENGLISH_TRANSLATION_FONT_SIZE_RATIO = 0.8;
 
 /**
- * Format state for the English translation paragraph: Figtree; font size four points smaller than Arabic;
+ * Format state for the English translation paragraph: Figtree; font size 80% of Arabic (rounded, min 1 pt);
  * never bold; regular font variant (no weight or italic from the Arabic font variant); same color as Arabic.
  * @param {Object|null|undefined} formatState - Sidebar format state
  * @return {Object}
@@ -34,7 +34,7 @@ function formatStateForEnglishTranslation(formatState) {
   out.bold = false;
   if (formatState.fontSize != null && !isNaN(Number(formatState.fontSize))) {
     var sz = Number(formatState.fontSize);
-    out.fontSize = Math.max(1, sz - ENGLISH_TRANSLATION_FONT_SIZE_DELTA);
+    out.fontSize = Math.max(1, Math.round(sz * ENGLISH_TRANSLATION_FONT_SIZE_RATIO));
   }
   return out;
 }

--- a/sidebar/js/font-variant-utils.html
+++ b/sidebar/js/font-variant-utils.html
@@ -95,18 +95,34 @@ function buildGoogleFontsPreviewHref(family, variantTokens) {
     pairs.join(';') + '&display=swap';
 }
 
-function ensureGoogleFontsPreviewStylesheet(family, variantTokens) {
-  if (!family || !variantTokens || !variantTokens.length) return;
+/**
+ * Injects Google Fonts CSS for sidebar preview. Invokes onReady after the stylesheet
+ * is cached (sync) or after load/error when a new link is appended.
+ * @param {string} family
+ * @param {Array<string>} variantTokens
+ * @param {function()=} onReady
+ */
+function ensureGoogleFontsPreviewStylesheet(family, variantTokens, onReady) {
+  var done = typeof onReady === 'function' ? onReady : function () {};
+  if (!family || !variantTokens || !variantTokens.length) {
+    done();
+    return;
+  }
   var id = 'gf-preview-' + family.replace(/[^a-zA-Z0-9]+/g, '-');
   var href = buildGoogleFontsPreviewHref(family, variantTokens);
   var existing = document.getElementById(id);
-  if (existing && existing.getAttribute('data-href') === href) return;
+  if (existing && existing.getAttribute('data-href') === href) {
+    done();
+    return;
+  }
   if (existing) existing.remove();
   var link = document.createElement('link');
   link.id = id;
   link.rel = 'stylesheet';
   link.href = href;
   link.setAttribute('data-href', href);
+  link.onload = function () { done(); };
+  link.onerror = function () { done(); };
   document.head.appendChild(link);
 }
 
@@ -132,6 +148,7 @@ function previewTextColorCss(fs) {
  * Inline style for Arabic preview (.arabic) from formatState.
  * Bold/weight rules align with FormatService.applyFormat (Docs).
  * @param {Object} fs - formatState-like { fontName, fontVariant, fontSize?, bold?, textColor? }
+ *   fontSize is in points (matches DocumentApp Text.setFontSize / Google Docs).
  * @return {string}
  */
 function arabicPreviewFontStyle(fs) {
@@ -147,7 +164,7 @@ function arabicPreviewFontStyle(fs) {
   var color = previewTextColorCss(fs);
   return "font-family:'" + safeFam + "',serif;font-weight:" + w +
     ';font-style:' + (p.italic ? 'italic' : 'normal') +
-    ';font-size:' + sz + 'px;color:' + color;
+    ';font-size:' + sz + 'pt;color:' + color;
 }
 
 var _settleArabicPreviewFontsTimer = null;
@@ -181,7 +198,7 @@ function settleArabicPreviewFonts() {
   if (isNaN(sz) || sz < 1) sz = 18;
   var p = parseGoogleFontVariantClient(fs && fs.fontVariant ? fs.fontVariant : 'regular');
 
-  var styleSpec = (p.italic ? 'italic ' : 'normal ') + p.weight + ' ' + sz + 'px "' +
+  var styleSpec = (p.italic ? 'italic ' : 'normal ') + p.weight + ' ' + sz + 'pt "' +
     String(fam).replace(/"/g, '') + '"';
 
   if (document.fonts && document.fonts.check && document.fonts.check(styleSpec)) {
@@ -204,7 +221,7 @@ function settleArabicPreviewFonts() {
    * fonts.load() can resolve slightly before the first composited frame uses the face.
    * Brief delay + double rAF nudges reveal after raster; longer CSS transition only smooths opacity.
    */
-  var PREVIEW_FONT_POST_LOAD_MS = 100;
+  var PREVIEW_FONT_POST_LOAD_MS = 200;
 
   function doReveal() {
     setTimeout(function() {

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -13,8 +13,17 @@ function updateFontPickerLabel() {
   el.textContent = formatState.fontName || 'Amiri';
 }
 
-function refreshArabicPreviewFontFace() {
-  if (!window._fontCatalog || !formatState.fontName) return;
+/**
+ * Ensures the Google Fonts stylesheet for the current family; calls onReady when
+ * the link is already satisfied or after load/error (see ensureGoogleFontsPreviewStylesheet).
+ * @param {function()=} onReady
+ */
+function refreshArabicPreviewFontFace(onReady) {
+  var done = typeof onReady === 'function' ? onReady : function () {};
+  if (!window._fontCatalog || !formatState.fontName) {
+    done();
+    return;
+  }
   var entry = null;
   for (var i = 0; i < window._fontCatalog.length; i++) {
     if (window._fontCatalog[i].family === formatState.fontName) {
@@ -23,7 +32,9 @@ function refreshArabicPreviewFontFace() {
     }
   }
   if (entry && entry.variants && entry.variants.length) {
-    ensureGoogleFontsPreviewStylesheet(entry.family, entry.variants);
+    ensureGoogleFontsPreviewStylesheet(entry.family, entry.variants, done);
+  } else {
+    done();
   }
 }
 
@@ -76,13 +87,14 @@ function selectFontAndVariant(family, variant, closeMenu) {
   formatState.fontName = family;
   formatState.fontVariant = variant || 'regular';
   updateFontPickerLabel();
-  refreshArabicPreviewFontFace();
   syncFontPickerSelectionClasses();
   debouncedSave();
   if (closeMenu) closeFontPicker();
-  if (typeof window.refreshAllResultCardPreviews === 'function') {
-    window.refreshAllResultCardPreviews();
-  }
+  refreshArabicPreviewFontFace(function () {
+    if (typeof window.refreshAllResultCardPreviews === 'function') {
+      window.refreshAllResultCardPreviews();
+    }
+  });
 }
 
 function buildFontPickerDom() {
@@ -144,16 +156,17 @@ function reconcileFontCatalogState() {
     changed = true;
   }
   updateFontPickerLabel();
-  refreshArabicPreviewFontFace();
   syncFontPickerSelectionClasses();
   if (changed) {
     google.script.run
       .withFailureHandler(function () {})
       .saveSettings({ fontName: formatState.fontName, fontVariant: formatState.fontVariant });
-    if (typeof window.refreshAllResultCardPreviews === 'function') {
+  }
+  refreshArabicPreviewFontFace(function () {
+    if (changed && typeof window.refreshAllResultCardPreviews === 'function') {
       window.refreshAllResultCardPreviews();
     }
-  }
+  });
 }
 
 function onFontCatalogLoaded(result) {

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -404,7 +404,7 @@
   .result-card .ref-english { font-size: 11px; color: #888; margin-top: 4px; margin-bottom: 2px; }
   @keyframes arabic-font-in { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: translateY(0); } }
   .result-card .arabic {
-    font-size: 18px; direction: rtl; text-align: right; font-family: Amiri, serif; margin: 8px 0; line-height: 1.8;
+    font-size: 18pt; direction: rtl; text-align: right; font-family: Amiri, serif; margin: 8px 0; line-height: 1.8;
     animation: arabic-font-in 0.2s ease;
     transition: opacity 0.42s ease-out;
   }

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -125,7 +125,7 @@ function runDocumentServiceTests() {
         rtl: true
       },
       {
-        text: '"translation" (Al-Fatiha 1:1)',
+        text: '"translation" (Al-Fatiha\u00A01:1)',
         align: DocumentApp.HorizontalAlignment.CENTER,
         useEnglishTranslationFont: true
       }
@@ -301,7 +301,7 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[0]).toBe(fs);
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
     expect(applyFormatCalls[1].fontVariant).toBe('regular');
-    expect(applyFormatCalls[1].fontSize).toBe(10);
+    expect(applyFormatCalls[1].fontSize).toBe(11);
     expect(applyFormatCalls[1].bold).toBe(false);
     expect(applyFormatCalls[1].textColor).toBe('#112233');
   });
@@ -317,7 +317,7 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(4);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[1]._ltr).toBe(false);
-    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha 1:1)');
+    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
     expect(body._children[2]._ltr).toBe(null);
     expect(body._children[3]._text).toBe('');
     expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
@@ -334,7 +334,7 @@ function runDocumentServiceTests() {
     // [existing, arabic, translation, after] — no cleanup
     expect(body._children.length).toBe(4);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha 1:1)');
+    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
     expect(body._children[3]._text).toBe('after');
     expect(body._children[3]._heading).toBe(null);
   });

--- a/tests/FormatService.test.gs
+++ b/tests/FormatService.test.gs
@@ -59,12 +59,12 @@ function runFormatServiceTests() {
     expect(a.fontName).toBe('Figtree');
     expect(a.bold).toBe(false);
   });
-  it('copies fields; Figtree; regular variant (no Arabic weight); size minus 4; never bold', function () {
+  it('copies fields; Figtree; regular variant (no Arabic weight); size 80% rounded; never bold', function () {
     var fs = { fontName: 'Scheherazade New', fontVariant: '700', fontSize: 14, bold: true, textColor: '#000' };
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontName).toBe('Figtree');
     expect(b.fontVariant).toBe('regular');
-    expect(b.fontSize).toBe(10);
+    expect(b.fontSize).toBe(11);
     expect(b.bold).toBe(false);
     expect(b.textColor).toBe('#000');
   });
@@ -73,8 +73,8 @@ function runFormatServiceTests() {
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontVariant).toBe('regular');
   });
-  it('font size floors at 1 when ayah size is very small', function () {
-    var fs = { fontName: 'X', fontSize: 2 };
+  it('font size floors at 1 when 80% rounds below 1', function () {
+    var fs = { fontName: 'X', fontSize: 1 };
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontSize).toBe(1);
   });

--- a/tests/buildResultCardHtml.test.js
+++ b/tests/buildResultCardHtml.test.js
@@ -75,7 +75,7 @@ function arabicPreviewFontStyle(fs) {
   var color = previewTextColorCss(fs);
   return 'font-family:\'' + safeFam + '\',serif;font-weight:' + w +
     ';font-style:' + (p.italic ? 'italic' : 'normal') +
-    ';font-size:' + sz + 'px;color:' + color;
+    ';font-size:' + sz + 'pt;color:' + color;
 }
 
 // ─── isConsecutiveRange ───────────────────────────────────────────────────────
@@ -581,7 +581,7 @@ function runTests() {
       textColor: '#2e7d32'
     };
     var html = buildCardHtml(r, fs);
-    assert.ok(html.indexOf('font-size:24px') >= 0, 'font size in inline style');
+    assert.ok(html.indexOf('font-size:24pt') >= 0, 'font size in inline style (points, matches Docs)');
     assert.ok(html.indexOf('color:#2E7D32') >= 0 || html.indexOf('color:#2e7d32') >= 0, 'color in inline style');
   });
 


### PR DESCRIPTION
Closes #92

## Changes
- Arabic result-card preview uses **points** to match `DocumentApp` / Docs; `document.fonts` spec uses the same units.
- **Google Fonts** `<link>` **onload** before rebuilding result cards; **200ms** post-`fonts.load` buffer.
- Inserted English translation font size is **80%** of Arabic (rounded, min 1 pt).
- **Citation spacing** in `DocumentService`: English NBSP only between surah name and number; Arabic bracket uses NBSP for colon/ayah and range hyphen; normal space between ornate close and `[`.

## Verification
- `npm test` passed locally.
- Run `runFormatServiceTests` / `runDocumentServiceTests` in the Apps Script editor when convenient.