### PR TITLE
Sync client _settings after translation save so insert matches immediately

### DIFF
--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -109,6 +109,10 @@ function initSettingsPanelHandlers() {
 
       google.script.run
         .withSuccessHandler(function() {
+          if (typeof _settings !== 'object' || !_settings) {
+            _settings = {};
+          }
+          _settings.showTranslation = showTranslation;
           btnSave.disabled = false;
           btnSave.textContent = 'Save';
           showSavedMessage('Settings saved!', false);


### PR DESCRIPTION
Updates in-memory `_settings.showTranslation` in the `saveSettings` success handler so insert uses the saved preference without waiting for overlay dismiss / `refreshSettings`.

Closes #94