### PR TITLE
UI Revamp: Modern emerald design system with cohesive sidebar experience

### DIFF
--- a/FormatService.js
+++ b/FormatService.js
@@ -10,11 +10,11 @@ var FALLBACK_FONT = 'Amiri';
 /** Google Docs font family for inserted English translation (Google Fonts name). */
 var ENGLISH_TRANSLATION_INSERT_FONT = 'Figtree';
 
-/** Inserted English translation uses this fraction of the ayah font size (points), rounded. */
-var ENGLISH_TRANSLATION_FONT_SIZE_RATIO = 0.8;
+/** Inserted English translation: this fraction of the ayah font size (points), rounded up (15% smaller than Arabic). */
+var ENGLISH_TRANSLATION_FONT_SIZE_RATIO = 0.85;
 
 /**
- * Format state for the English translation paragraph: Figtree; font size 80% of Arabic (rounded, min 1 pt);
+ * Format state for the English translation paragraph: Figtree; font size 85% of Arabic, rounded up (min 1 pt);
  * never bold; regular font variant (no weight or italic from the Arabic font variant); same color as Arabic.
  * @param {Object|null|undefined} formatState - Sidebar format state
  * @return {Object}
@@ -34,7 +34,7 @@ function formatStateForEnglishTranslation(formatState) {
   out.bold = false;
   if (formatState.fontSize != null && !isNaN(Number(formatState.fontSize))) {
     var sz = Number(formatState.fontSize);
-    out.fontSize = Math.max(1, Math.round(sz * ENGLISH_TRANSLATION_FONT_SIZE_RATIO));
+    out.fontSize = Math.max(1, Math.ceil(sz * ENGLISH_TRANSLATION_FONT_SIZE_RATIO));
   }
   return out;
 }

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -106,6 +106,15 @@ function getGoogleFontsApiKey_() {
 }
 
 /**
+ * Public feedback form URL from Script Properties (e.g. Google Form).
+ * @return {string} URL or empty string if unset
+ */
+function getFeedbackFormUrl() {
+  var url = PropertiesService.getScriptProperties().getProperty('feedback_form_url');
+  return url ? String(url) : '';
+}
+
+/**
  * Returns today's AI search count (UTC date).
  * If the stored date is not today, the count is treated as 0.
  * @return {number} The current count for today.

--- a/sidebar/components/bottom-bar.html
+++ b/sidebar/components/bottom-bar.html
@@ -4,7 +4,6 @@
       <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
       <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
     </svg>
-    <span class="bottom-bar-name">Tasneef</span>
   </div>
   <a class="bottom-bar-link" href="https://github.com/tarazis/tasneef-ai" target="_blank" rel="noopener noreferrer" title="Star us on GitHub">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">

--- a/sidebar/components/bottom-bar.html
+++ b/sidebar/components/bottom-bar.html
@@ -1,0 +1,15 @@
+<div class="bottom-bar-inner">
+  <div class="bottom-bar-logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+      <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+      <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
+    </svg>
+    <span class="bottom-bar-name">Tasneef</span>
+  </div>
+  <a class="bottom-bar-link" href="https://github.com/tarazis/tasneef-ai" target="_blank" rel="noopener noreferrer" title="Star us on GitHub">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+    </svg>
+    <span>Star on GitHub</span>
+  </a>
+</div>

--- a/sidebar/components/format-bar.html
+++ b/sidebar/components/format-bar.html
@@ -8,14 +8,17 @@
       <ul class="font-picker-families" id="font-picker-families"></ul>
     </div>
   </div>
-  <div class="size-stepper" id="size-stepper">
-    <button type="button" class="size-stepper-btn" id="btn-size-down" aria-label="Decrease font size">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/></svg>
-    </button>
-    <span class="size-stepper-value" id="size-stepper-value">18</span>
-    <button type="button" class="size-stepper-btn" id="btn-size-up" aria-label="Increase font size">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
-    </button>
+  <div class="size-stepper-wrap" id="size-stepper-wrap">
+    <div class="size-stepper" id="size-stepper">
+      <button type="button" class="size-stepper-btn" id="btn-size-down" aria-label="Decrease font size">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/></svg>
+      </button>
+      <button type="button" class="size-stepper-value-btn" id="size-stepper-value" aria-haspopup="listbox" aria-expanded="false" title="Font size presets" aria-label="Font size presets">18</button>
+      <button type="button" class="size-stepper-btn" id="btn-size-up" aria-label="Increase font size">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+      </button>
+    </div>
+    <ul class="font-size-presets-dropdown hidden" id="font-size-presets-dropdown" role="listbox" aria-label="Font size"></ul>
   </div>
   <button type="button" class="btn-format" id="btn-bold" title="Bold">B</button>
   <div class="color-wrap">

--- a/sidebar/components/format-bar.html
+++ b/sidebar/components/format-bar.html
@@ -8,16 +8,15 @@
       <ul class="font-picker-families" id="font-picker-families"></ul>
     </div>
   </div>
-  <select class="size-select" id="size-select" title="Font size">
-    <option value="12">12</option>
-    <option value="14">14</option>
-    <option value="16">16</option>
-    <option value="18" selected>18</option>
-    <option value="20">20</option>
-    <option value="24">24</option>
-    <option value="28">28</option>
-    <option value="36">36</option>
-  </select>
+  <div class="size-stepper" id="size-stepper">
+    <button type="button" class="size-stepper-btn" id="btn-size-down" aria-label="Decrease font size">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/></svg>
+    </button>
+    <span class="size-stepper-value" id="size-stepper-value">18</span>
+    <button type="button" class="size-stepper-btn" id="btn-size-up" aria-label="Increase font size">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+    </button>
+  </div>
   <button type="button" class="btn-format" id="btn-bold" title="Bold">B</button>
   <div class="color-wrap">
     <button type="button" class="color-trigger" id="color-trigger" title="Text color" aria-label="Text color" aria-haspopup="dialog" aria-expanded="false"></button>

--- a/sidebar/components/settings-panel.html
+++ b/sidebar/components/settings-panel.html
@@ -1,26 +1,36 @@
-<div class="settings-panel">
-  <h2>
-    <button type="button" class="back-btn" id="btn-settings-back" aria-label="Close">&#8592;</button>
-    Settings
-  </h2>
+<div class="settings-page-inner">
+  <header class="settings-header">
+    <button type="button" class="btn-icon" id="btn-settings-back" aria-label="Back">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <path d="m15 18-6-6 6-6"/>
+      </svg>
+    </button>
+    <h2 class="settings-title">Settings</h2>
+  </header>
 
   <div id="settings-panel-loading" class="settings-panel-loading hidden" aria-busy="false">
     <div class="startup-spinner" aria-hidden="true"></div>
     <span class="startup-text" role="status" aria-live="polite">Loading…</span>
   </div>
 
-  <div id="settings-panel-body">
-    <div class="settings-section">
-      <label>Insert content</label>
-      <div class="settings-check">
-        <input type="checkbox" id="insert-translation" checked>
-        <label for="insert-translation">Translation</label>
-      </div>
-    </div>
+  <div id="settings-panel-body" class="settings-body">
+    <section class="settings-section">
+      <h3 class="settings-section-title">Translation</h3>
 
-    <div class="settings-save-row">
-      <button type="button" class="btn-primary" id="btn-save-settings">Save</button>
-      <p id="settings-saved-msg" class="settings-saved-msg hidden"></p>
-    </div>
+      <div class="settings-row">
+        <span class="settings-row-label">Insert translation</span>
+        <label class="toggle-switch">
+          <input type="checkbox" id="insert-translation" checked>
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+
+      <div class="settings-row settings-row--stacked">
+        <label class="settings-row-label" for="translation-edition">Choose edition</label>
+        <select id="translation-edition" class="form-select" disabled>
+          <option value="saheeh-international" selected>Saheeh International</option>
+        </select>
+      </div>
+    </section>
   </div>
 </div>

--- a/sidebar/components/tab-ai-search.html
+++ b/sidebar/components/tab-ai-search.html
@@ -1,4 +1,15 @@
 <div class="tab-panel" id="panel-ai-search">
+  <div id="ai-welcome" class="ai-welcome">
+    <div class="ai-welcome-content">
+      <p class="ai-welcome-greeting">What would you like to find?</p>
+      <p class="ai-welcome-hint">Search the Quran by theme, topic, or meaning</p>
+    </div>
+    <div class="ai-welcome-chips" id="ai-welcome-chips">
+      <button type="button" class="ai-chip" data-query="Verses about patience">Verses about patience</button>
+      <button type="button" class="ai-chip" data-query="Ayat about charity">Ayat about charity</button>
+      <button type="button" class="ai-chip" data-query="Duas for guidance">Duas for guidance</button>
+    </div>
+  </div>
   <div id="ai-search-results" class="results-list"></div>
   <div id="ai-search-clarify" class="clarify-message hidden"></div>
   <div id="ai-search-empty" class="empty-state hidden"></div>
@@ -7,5 +18,6 @@
       <textarea id="ai-search-query" rows="2" placeholder="Search themes (e.g., patience, charity)..."></textarea>
       <button type="button" class="btn-send" id="btn-ai-search" title="Send" aria-label="Send">&#10148;</button>
     </div>
+    <p class="ai-disclaimer">Tasneef uses AI and may contain inaccuracies</p>
   </div>
 </div>

--- a/sidebar/components/tab-ai-search.html
+++ b/sidebar/components/tab-ai-search.html
@@ -18,6 +18,6 @@
       <textarea id="ai-search-query" rows="2" placeholder="Search themes (e.g., patience, charity)..."></textarea>
       <button type="button" class="btn-send" id="btn-ai-search" title="Send" aria-label="Send">&#10148;</button>
     </div>
-    <p class="ai-disclaimer">Tasneef uses AI and may contain inaccuracies</p>
+    <p class="ai-disclaimer">AI can make mistakes.</p>
   </div>
 </div>

--- a/sidebar/components/tab-direct-insert.html
+++ b/sidebar/components/tab-direct-insert.html
@@ -8,7 +8,7 @@
     </div>
     <div class="form-row">
       <div class="form-group form-group-half">
-        <label for="ayah-start">Ayah</label>
+        <label for="ayah-start">From</label>
         <select id="ayah-start" class="form-select" disabled>
           <option value="">From</option>
         </select>

--- a/sidebar/components/tab-exact-search.html
+++ b/sidebar/components/tab-exact-search.html
@@ -1,5 +1,15 @@
 <div class="tab-panel" id="panel-exact-search">
   <div id="imlaei-cache-status" class="cache-status hidden"></div>
+  <div id="exact-search-welcome" class="search-welcome">
+    <div class="search-welcome-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="40" height="40" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <circle cx="11" cy="11" r="8"/>
+        <path d="m21 21-4.3-4.3"/>
+      </svg>
+    </div>
+    <p class="search-welcome-title">Search the Quran</p>
+    <p class="search-welcome-hint">Type Arabic text below to find matching ayat</p>
+  </div>
   <div id="exact-search-results" class="results-list"></div>
   <div id="exact-search-empty" class="empty-state hidden"></div>
   <div class="tab-input-area">

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -198,21 +198,25 @@ function debouncedSave() {
   }, SAVE_DEBOUNCE_MS);
 }
 
+var MIN_FONT_SIZE = 8;
+var MAX_FONT_SIZE = 72;
+
+function updateSizeUI() {
+  var sizeValue = document.getElementById('size-stepper-value');
+  var btnDown = document.getElementById('btn-size-down');
+  var btnUp = document.getElementById('btn-size-up');
+  if (sizeValue) sizeValue.textContent = String(formatState.fontSize);
+  if (btnDown) btnDown.disabled = (formatState.fontSize <= MIN_FONT_SIZE);
+  if (btnUp) btnUp.disabled = (formatState.fontSize >= MAX_FONT_SIZE);
+}
+
 function applyFormatStateToUI() {
-  var sizeSelect = document.getElementById('size-select');
   var boldBtn = document.getElementById('btn-bold');
   var colorPicker = document.getElementById('color-picker');
   var colorTrigger = document.getElementById('color-trigger');
   updateFontPickerLabel();
   syncFontPickerSelectionClasses();
-  if (sizeSelect) {
-    var sizeVal = String(formatState.fontSize);
-    if (sizeSelect.querySelector('option[value="' + sizeVal + '"]')) {
-      sizeSelect.value = sizeVal;
-    } else {
-      sizeSelect.value = '18';
-    }
-  }
+  updateSizeUI();
   if (boldBtn) boldBtn.classList.toggle('active', formatState.bold);
   var tc = formatState.textColor || '#000000';
   if (typeof normalizeHex6 === 'function') {
@@ -227,7 +231,8 @@ function applyFormatStateToUI() {
 window.reconcileFontCatalogState = reconcileFontCatalogState;
 
 function initFormatBar() {
-  var sizeSelect = document.getElementById('size-select');
+  var btnSizeDown = document.getElementById('btn-size-down');
+  var btnSizeUp = document.getElementById('btn-size-up');
   var boldBtn = document.getElementById('btn-bold');
   var colorTrigger = document.getElementById('color-trigger');
   var colorPicker = document.getElementById('color-picker');
@@ -239,12 +244,27 @@ function initFormatBar() {
       toggleFontPicker();
     });
   }
-  if (sizeSelect) {
-    sizeSelect.addEventListener('change', function () {
-      formatState.fontSize = parseInt(sizeSelect.value, 10) || 18;
-      debouncedSave();
-      if (typeof window.refreshAllResultCardPreviews === 'function') {
-        window.refreshAllResultCardPreviews();
+  if (btnSizeDown) {
+    btnSizeDown.addEventListener('click', function () {
+      if (formatState.fontSize > MIN_FONT_SIZE) {
+        formatState.fontSize--;
+        updateSizeUI();
+        debouncedSave();
+        if (typeof window.refreshAllResultCardPreviews === 'function') {
+          window.refreshAllResultCardPreviews();
+        }
+      }
+    });
+  }
+  if (btnSizeUp) {
+    btnSizeUp.addEventListener('click', function () {
+      if (formatState.fontSize < MAX_FONT_SIZE) {
+        formatState.fontSize++;
+        updateSizeUI();
+        debouncedSave();
+        if (typeof window.refreshAllResultCardPreviews === 'function') {
+          window.refreshAllResultCardPreviews();
+        }
       }
     });
   }

--- a/sidebar/js/format-bar.html
+++ b/sidebar/js/format-bar.html
@@ -46,12 +46,59 @@ function closeFontPicker() {
   document.removeEventListener('click', onFontPickerDocClick, true);
 }
 
+function onFontSizePresetsDocClick(e) {
+  var wrap = document.getElementById('size-stepper-wrap');
+  if (wrap && !wrap.contains(e.target)) closeFontSizePresetsDropdown();
+}
+
+function closeFontSizePresetsDropdown() {
+  var drop = document.getElementById('font-size-presets-dropdown');
+  var trig = document.getElementById('size-stepper-value');
+  if (drop) drop.classList.add('hidden');
+  if (trig) trig.setAttribute('aria-expanded', 'false');
+  document.removeEventListener('click', onFontSizePresetsDocClick, true);
+}
+
+function syncFontSizePresetSelection() {
+  var items = document.querySelectorAll('.font-size-preset-item');
+  var cur = formatState.fontSize;
+  for (var i = 0; i < items.length; i++) {
+    var btn = items[i];
+    var sz = parseInt(btn.getAttribute('data-size'), 10);
+    var sel = !isNaN(sz) && sz === cur;
+    btn.classList.toggle('is-selected', sel);
+    btn.setAttribute('aria-selected', sel ? 'true' : 'false');
+  }
+}
+
+function openFontSizePresetsDropdown() {
+  closeFontPicker();
+  if (typeof closeJsColorPickerPopover === 'function') closeJsColorPickerPopover();
+  var drop = document.getElementById('font-size-presets-dropdown');
+  var trig = document.getElementById('size-stepper-value');
+  if (!drop || !trig) return;
+  syncFontSizePresetSelection();
+  drop.classList.remove('hidden');
+  trig.setAttribute('aria-expanded', 'true');
+  setTimeout(function () {
+    document.addEventListener('click', onFontSizePresetsDocClick, true);
+  }, 0);
+}
+
+function toggleFontSizePresetsDropdown() {
+  var drop = document.getElementById('font-size-presets-dropdown');
+  if (!drop) return;
+  if (drop.classList.contains('hidden')) openFontSizePresetsDropdown();
+  else closeFontSizePresetsDropdown();
+}
+
 function onFontPickerDocClick(e) {
   var picker = document.getElementById('font-picker');
   if (picker && !picker.contains(e.target)) closeFontPicker();
 }
 
 function openFontPicker() {
+  closeFontSizePresetsDropdown();
   if (typeof closeJsColorPickerPopover === 'function') closeJsColorPickerPopover();
   var drop = document.getElementById('font-picker-dropdown');
   var trig = document.getElementById('font-picker-trigger');
@@ -200,6 +247,7 @@ function debouncedSave() {
 
 var MIN_FONT_SIZE = 8;
 var MAX_FONT_SIZE = 72;
+var FONT_SIZE_PRESETS = [8, 10, 12, 14, 16, 18, 24, 30, 36, 48];
 
 function updateSizeUI() {
   var sizeValue = document.getElementById('size-stepper-value');
@@ -208,6 +256,7 @@ function updateSizeUI() {
   if (sizeValue) sizeValue.textContent = String(formatState.fontSize);
   if (btnDown) btnDown.disabled = (formatState.fontSize <= MIN_FONT_SIZE);
   if (btnUp) btnUp.disabled = (formatState.fontSize >= MAX_FONT_SIZE);
+  syncFontSizePresetSelection();
 }
 
 function applyFormatStateToUI() {
@@ -233,10 +282,46 @@ window.reconcileFontCatalogState = reconcileFontCatalogState;
 function initFormatBar() {
   var btnSizeDown = document.getElementById('btn-size-down');
   var btnSizeUp = document.getElementById('btn-size-up');
+  var sizeValueBtn = document.getElementById('size-stepper-value');
+  var presetUl = document.getElementById('font-size-presets-dropdown');
   var boldBtn = document.getElementById('btn-bold');
   var colorTrigger = document.getElementById('color-trigger');
   var colorPicker = document.getElementById('color-picker');
   var trig = document.getElementById('font-picker-trigger');
+
+  if (presetUl && presetUl.children.length === 0) {
+    for (var pi = 0; pi < FONT_SIZE_PRESETS.length; pi++) {
+      (function (sz) {
+        var li = document.createElement('li');
+        li.setAttribute('role', 'none');
+        var b = document.createElement('button');
+        b.type = 'button';
+        b.className = 'font-size-preset-item';
+        b.setAttribute('role', 'option');
+        b.setAttribute('data-size', String(sz));
+        b.textContent = String(sz);
+        b.addEventListener('click', function (e) {
+          e.stopPropagation();
+          formatState.fontSize = sz;
+          updateSizeUI();
+          debouncedSave();
+          closeFontSizePresetsDropdown();
+          if (typeof window.refreshAllResultCardPreviews === 'function') {
+            window.refreshAllResultCardPreviews();
+          }
+        });
+        li.appendChild(b);
+        presetUl.appendChild(li);
+      })(FONT_SIZE_PRESETS[pi]);
+    }
+  }
+
+  if (sizeValueBtn) {
+    sizeValueBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      toggleFontSizePresetsDropdown();
+    });
+  }
 
   if (trig) {
     trig.addEventListener('click', function (e) {
@@ -246,6 +331,7 @@ function initFormatBar() {
   }
   if (btnSizeDown) {
     btnSizeDown.addEventListener('click', function () {
+      closeFontSizePresetsDropdown();
       if (formatState.fontSize > MIN_FONT_SIZE) {
         formatState.fontSize--;
         updateSizeUI();
@@ -258,6 +344,7 @@ function initFormatBar() {
   }
   if (btnSizeUp) {
     btnSizeUp.addEventListener('click', function () {
+      closeFontSizePresetsDropdown();
       if (formatState.fontSize < MAX_FONT_SIZE) {
         formatState.fontSize++;
         updateSizeUI();
@@ -287,7 +374,10 @@ function initFormatBar() {
     }
   }
   if (typeof initJsColorPicker === 'function') {
-    initJsColorPicker(onFormatBarColorChosen, closeFontPicker);
+    initJsColorPicker(onFormatBarColorChosen, function () {
+      closeFontPicker();
+      closeFontSizePresetsDropdown();
+    });
   }
 }
 </script>

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -100,7 +100,12 @@ function initHeaderMenu() {
   if (btnFeedback) {
     btnFeedback.addEventListener('click', function () {
       closeMenu();
-      // Feedback form not yet implemented
+      var u = typeof window._feedbackFormUrl === 'string' ? window._feedbackFormUrl : '';
+      if (u) {
+        window.open(u, '_blank', 'noopener,noreferrer');
+      } else if (typeof console !== 'undefined' && console.warn) {
+        console.warn('feedback_form_url script property is not set');
+      }
     });
   }
 }
@@ -113,6 +118,7 @@ function initSettings() {
 
   if (btnNewAiChat) {
     btnNewAiChat.addEventListener('click', function () {
+      if (btnNewAiChat.disabled) return;
       if (typeof clearAISearch === 'function') clearAISearch();
     });
   }
@@ -172,7 +178,16 @@ function onSettingsLoaded(settings) {
   _settings = settings;
   formatState.fontName = settings.fontName || 'Amiri';
   formatState.fontVariant = settings.fontVariant || 'regular';
-  formatState.fontSize = settings.fontSize || 18;
+  var storedSize = settings.fontSize;
+  var parsedStored = parseInt(storedSize, 10);
+  var rawSize = isNaN(parsedStored) ? 18 : parsedStored;
+  var clampedSize = Math.max(8, Math.min(72, rawSize));
+  formatState.fontSize = clampedSize;
+  if (!isNaN(parsedStored) && parsedStored !== clampedSize) {
+    google.script.run
+      .withFailureHandler(function () {})
+      .saveSettings({ fontSize: clampedSize });
+  }
   formatState.bold = settings.bold || false;
   formatState.textColor = settings.textColor || '#000000';
   formatState.customSwatchColors = Array.isArray(settings.customSwatchColors)

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -27,59 +27,118 @@ function applyTranslationCheckboxFromPayload(s) {
   trans.checked = showTrans;
 }
 
-function dismissSettingsOverlay(overlay) {
+// ─── Settings Page (replaces overlay) ──────────────────────────────────────
+
+function showSettingsPage() {
+  var ids = ['sidebar-header', 'sidebar-format-bar', 'sidebar-tab-nav', 'sidebar-tab-content', 'bottom-bar'];
+  for (var i = 0; i < ids.length; i++) {
+    var el = document.getElementById(ids[i]);
+    if (el) el.classList.add('hidden');
+  }
+  var page = document.getElementById('settings-page');
+  if (page) page.classList.remove('hidden');
+
+  var gen = ++settingsPanelLoadGen;
+  setSettingsPanelLoading(true);
+  loadSettingsIntoPanel(gen);
+}
+
+function hideSettingsPage() {
   settingsPanelLoadGen++;
-  overlay.classList.add('hidden');
+  var page = document.getElementById('settings-page');
+  if (page) page.classList.add('hidden');
+  var ids = ['sidebar-header', 'sidebar-format-bar', 'sidebar-tab-nav', 'sidebar-tab-content', 'bottom-bar'];
+  for (var i = 0; i < ids.length; i++) {
+    var el = document.getElementById(ids[i]);
+    if (el) el.classList.remove('hidden');
+  }
   refreshSettings();
 }
 
-function initSettings() {
-  var btnSettings = document.getElementById('btn-settings');
-  var btnNewAiChat = document.getElementById('btn-new-ai-chat');
-  var overlay = document.getElementById('settings-overlay');
-  var btnBack = document.getElementById('btn-settings-back');
+// ─── Header Menu ───────────────────────────────────────────────────────────
 
-  if (btnSettings && overlay) {
-    btnSettings.addEventListener('click', function() {
-      var gen = ++settingsPanelLoadGen;
-      overlay.classList.remove('hidden');
-      setSettingsPanelLoading(true);
-      loadSettingsIntoPanel(gen);
-    });
+function initHeaderMenu() {
+  var btnMenu = document.getElementById('btn-header-menu');
+  var dropdown = document.getElementById('header-menu-dropdown');
+  var btnSettings = document.getElementById('btn-menu-settings');
+  var btnFeedback = document.getElementById('btn-menu-feedback');
+
+  function closeMenu() {
+    if (dropdown) dropdown.classList.add('hidden');
+    if (btnMenu) btnMenu.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', onMenuDocClick, true);
   }
-  if (btnNewAiChat) {
-    btnNewAiChat.addEventListener('click', function() {
-      if (typeof clearAISearch === 'function') clearAISearch();
-    });
+
+  function onMenuDocClick(e) {
+    var menu = document.getElementById('header-menu');
+    if (menu && !menu.contains(e.target)) closeMenu();
   }
-  if (btnBack && overlay) {
-    btnBack.addEventListener('click', function() {
-      dismissSettingsOverlay(overlay);
-    });
-  }
-  if (overlay) {
-    overlay.addEventListener('click', function(e) {
-      if (e.target === overlay) {
-        dismissSettingsOverlay(overlay);
+
+  if (btnMenu && dropdown) {
+    btnMenu.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var isOpen = !dropdown.classList.contains('hidden');
+      if (isOpen) {
+        closeMenu();
+      } else {
+        dropdown.classList.remove('hidden');
+        btnMenu.setAttribute('aria-expanded', 'true');
+        setTimeout(function () {
+          document.addEventListener('click', onMenuDocClick, true);
+        }, 0);
       }
+    });
+  }
+
+  if (btnSettings) {
+    btnSettings.addEventListener('click', function () {
+      closeMenu();
+      showSettingsPage();
+    });
+  }
+
+  if (btnFeedback) {
+    btnFeedback.addEventListener('click', function () {
+      closeMenu();
+      // Feedback form not yet implemented
     });
   }
 }
 
+// ─── Init ──────────────────────────────────────────────────────────────────
+
+function initSettings() {
+  var btnNewAiChat = document.getElementById('btn-new-ai-chat');
+  var btnBack = document.getElementById('btn-settings-back');
+
+  if (btnNewAiChat) {
+    btnNewAiChat.addEventListener('click', function () {
+      if (typeof clearAISearch === 'function') clearAISearch();
+    });
+  }
+  if (btnBack) {
+    btnBack.addEventListener('click', function () {
+      hideSettingsPage();
+    });
+  }
+
+  initHeaderMenu();
+}
+
 function refreshSettings() {
-  google.script.run.withSuccessHandler(function(s) {
+  google.script.run.withSuccessHandler(function (s) {
     _settings = s;
   }).getSettings();
 }
 
 function loadSettingsIntoPanel(gen) {
   google.script.run
-    .withSuccessHandler(function(s) {
+    .withSuccessHandler(function (s) {
       if (gen !== settingsPanelLoadGen) return;
       applyTranslationCheckboxFromPayload(s);
       setSettingsPanelLoading(false);
     })
-    .withFailureHandler(function() {
+    .withFailureHandler(function () {
       if (gen !== settingsPanelLoadGen) return;
       applyTranslationCheckboxFromPayload(null);
       setSettingsPanelLoading(false);
@@ -89,38 +148,20 @@ function loadSettingsIntoPanel(gen) {
 
 function initSettingsPanelHandlers() {
   var trans = document.getElementById('insert-translation');
-  var btnSave = document.getElementById('btn-save-settings');
-  var savedMsg = document.getElementById('settings-saved-msg');
 
-  function showSavedMessage(text, isError) {
-    if (!savedMsg) return;
-    savedMsg.textContent = text;
-    savedMsg.className = 'settings-saved-msg ' + (isError ? 'error' : 'success');
-    savedMsg.classList.remove('hidden');
-    setTimeout(function() { savedMsg.classList.add('hidden'); }, 3000);
-  }
-
-  if (btnSave) {
-    btnSave.addEventListener('click', function() {
-      var showTranslation = trans ? trans.checked : true;
-
-      btnSave.disabled = true;
-      btnSave.textContent = 'Saving…';
-
+  // Auto-save on toggle change
+  if (trans) {
+    trans.addEventListener('change', function () {
+      var showTranslation = trans.checked;
+      if (typeof _settings !== 'object' || !_settings) {
+        _settings = {};
+      }
+      _settings.showTranslation = showTranslation;
       google.script.run
-        .withSuccessHandler(function() {
-          if (typeof _settings !== 'object' || !_settings) {
-            _settings = {};
-          }
-          _settings.showTranslation = showTranslation;
-          btnSave.disabled = false;
-          btnSave.textContent = 'Save';
-          showSavedMessage('Settings saved!', false);
-        })
-        .withFailureHandler(function() {
-          btnSave.disabled = false;
-          btnSave.textContent = 'Save';
-          showSavedMessage('Failed to save settings.', true);
+        .withFailureHandler(function () {
+          // Revert on failure
+          _settings.showTranslation = !showTranslation;
+          trans.checked = !showTranslation;
         })
         .saveSettings({ showTranslation: showTranslation });
     });

--- a/sidebar/js/sidebar-js.html
+++ b/sidebar/js/sidebar-js.html
@@ -38,6 +38,11 @@
     if (tabId === 'exact-search') {
       ensureImlaeiCache();       // no-op if already loading or loaded
     }
+
+    // Show/hide new-chat button based on active tab + conversation state
+    if (typeof updateNewChatVisibility === 'function') {
+      updateNewChatVisibility();
+    }
   }
 
   function setupTextarea(el, onSubmit) {

--- a/sidebar/js/sidebar-js.html
+++ b/sidebar/js/sidebar-js.html
@@ -63,7 +63,8 @@
   // ─── Init ────────────────────────────────────────────────────────────────────
 
   function init() {
-    var pendingInit = 6;
+    window._feedbackFormUrl = '';
+    var pendingInit = 7;
     function onInitDone() {
       if (--pendingInit <= 0) {
         var overlay = document.getElementById('startup-overlay');
@@ -75,6 +76,17 @@
       .withSuccessHandler(function(s) { onSettingsLoaded(s); onInitDone(); })
       .withFailureHandler(function() { applyFormatStateToUI(); onInitDone(); })
       .getSettings();
+
+    google.script.run
+      .withSuccessHandler(function (url) {
+        window._feedbackFormUrl = url ? String(url) : '';
+        onInitDone();
+      })
+      .withFailureHandler(function () {
+        window._feedbackFormUrl = '';
+        onInitDone();
+      })
+      .getFeedbackFormUrl();
 
     google.script.run
       .withSuccessHandler(function(res) { onFontCatalogLoaded(res); onInitDone(); })

--- a/sidebar/js/tab-ai-search-js.html
+++ b/sidebar/js/tab-ai-search-js.html
@@ -6,11 +6,27 @@
 
 var _conversationMessages = [];
 
+function aiSearchPanelIsDirty() {
+  if (_conversationMessages.length > 0) return true;
+  var resultsEl = document.getElementById('ai-search-results');
+  var clarifyEl = document.getElementById('ai-search-clarify');
+  var emptyEl = document.getElementById('ai-search-empty');
+  if (resultsEl && resultsEl.children.length > 0) return true;
+  if (clarifyEl && !clarifyEl.classList.contains('hidden')) return true;
+  if (emptyEl && !emptyEl.classList.contains('hidden')) return true;
+  return false;
+}
+
 function updateNewChatVisibility() {
   var btn = document.getElementById('btn-new-ai-chat');
   if (!btn) return;
-  var show = (window._activeTab === 'ai-search') && _conversationMessages.length > 0;
-  btn.classList.toggle('hidden', !show);
+  if (window._activeTab !== 'ai-search') {
+    btn.classList.add('hidden');
+    btn.disabled = false;
+    return;
+  }
+  btn.classList.remove('hidden');
+  btn.disabled = !aiSearchPanelIsDirty();
 }
 
 function showAIWelcome() {
@@ -71,6 +87,7 @@ function initAISearchTab() {
     skeletonDiv.id = 'ai-skeleton';
     skeletonDiv.innerHTML = makeSkeleton(3);
     resultsEl.appendChild(skeletonDiv);
+    updateNewChatVisibility();
 
     setEnabled(false);
 
@@ -96,6 +113,7 @@ function initAISearchTab() {
         updateNewChatVisibility();
         emptyEl.textContent = 'Something went wrong. Please try again.';
         emptyEl.classList.remove('hidden');
+        updateNewChatVisibility();
       })
       .performAISearch(messagesToSend);
   }
@@ -104,12 +122,14 @@ function initAISearchTab() {
     if (!response) {
       emptyEl.textContent = 'No response received. Please try again.';
       emptyEl.classList.remove('hidden');
+      updateNewChatVisibility();
       return;
     }
 
     if (response.type === 'error') {
       emptyEl.textContent = response.error;
       emptyEl.classList.remove('hidden');
+      updateNewChatVisibility();
       return;
     }
 
@@ -117,12 +137,12 @@ function initAISearchTab() {
       clarifyEl.textContent = response.message || 'Could you be more specific?';
       clarifyEl.classList.remove('hidden');
       if (queryEl) queryEl.focus();
+      updateNewChatVisibility();
       return;
     }
 
     // Non-clarify response breaks the conversation chain
     _conversationMessages = [];
-    updateNewChatVisibility();
 
     // Arabic corpus search
     if (response.type === 'arabic_search') {
@@ -130,10 +150,12 @@ function initAISearchTab() {
       if (!searchResults.length) {
         emptyEl.textContent = 'No exact matches found for that text.';
         emptyEl.classList.remove('hidden');
+        updateNewChatVisibility();
         return;
       }
       pagReset('ai-search', searchResults);
       pagRenderPage('ai-search', resultsEl, emptyEl, 'No exact matches found for that text.');
+      updateNewChatVisibility();
       return;
     }
 
@@ -144,15 +166,18 @@ function initAISearchTab() {
       if (!cards.length) {
         emptyEl.textContent = 'No verified results found. Try a different query.';
         emptyEl.classList.remove('hidden');
+        updateNewChatVisibility();
         return;
       }
       pagReset('ai-search', cards);
       pagRenderPage('ai-search', resultsEl, emptyEl, 'No verified results found. Try a different query.');
+      updateNewChatVisibility();
       return;
     }
 
     emptyEl.textContent = 'Unexpected response. Please try again.';
     emptyEl.classList.remove('hidden');
+    updateNewChatVisibility();
   }
 
   // Suggestion chip handlers

--- a/sidebar/js/tab-ai-search-js.html
+++ b/sidebar/js/tab-ai-search-js.html
@@ -6,6 +6,23 @@
 
 var _conversationMessages = [];
 
+function updateNewChatVisibility() {
+  var btn = document.getElementById('btn-new-ai-chat');
+  if (!btn) return;
+  var show = (window._activeTab === 'ai-search') && _conversationMessages.length > 0;
+  btn.classList.toggle('hidden', !show);
+}
+
+function showAIWelcome() {
+  var el = document.getElementById('ai-welcome');
+  if (el) el.classList.remove('hidden');
+}
+
+function hideAIWelcome() {
+  var el = document.getElementById('ai-welcome');
+  if (el) el.classList.add('hidden');
+}
+
 function initAISearchTab() {
   var queryEl = document.getElementById('ai-search-query');
   var btnSend = document.getElementById('btn-ai-search');
@@ -39,16 +56,30 @@ function initAISearchTab() {
     queryEl.style.height = 'auto';
 
     _conversationMessages.push({ role: 'user', content: query });
+    updateNewChatVisibility();
 
+    hideAIWelcome();
     clearAIResults();
-    resultsEl.innerHTML = makeSkeleton(3);
+
+    // Show query header + skeleton
+    var headerDiv = document.createElement('div');
+    headerDiv.className = 'ai-query-header';
+    headerDiv.innerHTML = '<span class="ai-query-label">Results for</span> <span class="ai-query-text">\u201c' + query.replace(/[<>&"]/g, function (c) { return '&#' + c.charCodeAt(0) + ';'; }) + '\u201d</span>';
+    resultsEl.appendChild(headerDiv);
+
+    var skeletonDiv = document.createElement('div');
+    skeletonDiv.id = 'ai-skeleton';
+    skeletonDiv.innerHTML = makeSkeleton(3);
+    resultsEl.appendChild(skeletonDiv);
+
     setEnabled(false);
 
     var messagesToSend = getLastMessages(3);
 
     google.script.run
       .withSuccessHandler(function(response) {
-        resultsEl.innerHTML = '';
+        var skel = document.getElementById('ai-skeleton');
+        if (skel) skel.remove();
         setEnabled(true);
 
         if (response && response.rawResponse) {
@@ -58,9 +89,11 @@ function initAISearchTab() {
         handleAIResponse(response);
       })
       .withFailureHandler(function() {
-        resultsEl.innerHTML = '';
+        var skel = document.getElementById('ai-skeleton');
+        if (skel) skel.remove();
         setEnabled(true);
         _conversationMessages.pop();
+        updateNewChatVisibility();
         emptyEl.textContent = 'Something went wrong. Please try again.';
         emptyEl.classList.remove('hidden');
       })
@@ -89,8 +122,9 @@ function initAISearchTab() {
 
     // Non-clarify response breaks the conversation chain
     _conversationMessages = [];
+    updateNewChatVisibility();
 
-    // Arabic corpus search: same cap and pagination as Exact Search (MAX_RESULTS + PAGE_SIZE via searchImlaeiClient / pagRenderPage)
+    // Arabic corpus search
     if (response.type === 'arabic_search') {
       var searchResults = searchImlaeiClient(response.query);
       if (!searchResults.length) {
@@ -103,8 +137,7 @@ function initAISearchTab() {
       return;
     }
 
-    // References type: backend returns merged groups [{surah, ayahStart, ayahEnd}].
-    // Resolve each group into a card (single or range) and paginate.
+    // References type
     if (response.type === 'references') {
       var groups = response.references || [];
       var cards = _resolveGroups(groups);
@@ -120,6 +153,20 @@ function initAISearchTab() {
 
     emptyEl.textContent = 'Unexpected response. Please try again.';
     emptyEl.classList.remove('hidden');
+  }
+
+  // Suggestion chip handlers
+  var chipsEl = document.getElementById('ai-welcome-chips');
+  if (chipsEl) {
+    chipsEl.addEventListener('click', function (e) {
+      var chip = e.target.closest('.ai-chip');
+      if (!chip) return;
+      var chipQuery = chip.getAttribute('data-query');
+      if (chipQuery && queryEl) {
+        queryEl.value = chipQuery;
+        doAISearch();
+      }
+    });
   }
 
   window.setupTextarea(queryEl, doAISearch);
@@ -139,5 +186,7 @@ function clearAISearch() {
   if (resultsEl) resultsEl.innerHTML = '';
   if (clarifyEl) { clarifyEl.classList.add('hidden'); clarifyEl.textContent = ''; }
   if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
+  showAIWelcome();
+  updateNewChatVisibility();
 }
 </script>

--- a/sidebar/js/tab-exact-search-js.html
+++ b/sidebar/js/tab-exact-search-js.html
@@ -8,12 +8,18 @@ function initExactSearchTab() {
   var queryEl = document.getElementById('exact-search-query');
   var resultsEl = document.getElementById('exact-search-results');
   var emptyEl = document.getElementById('exact-search-empty');
+  var welcomeEl = document.getElementById('exact-search-welcome');
   var debounceTimer = null;
+
+  function updateWelcome(query) {
+    if (welcomeEl) welcomeEl.classList.toggle('hidden', !!query);
+  }
 
   function doExactSearch() {
     if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
 
     var query = queryEl ? queryEl.value.trim() : '';
+    updateWelcome(query);
     if (!query) {
       pagClear('exact-search');
       if (resultsEl) resultsEl.innerHTML = '';
@@ -39,6 +45,7 @@ function initExactSearchTab() {
     queryEl.style.height = Math.min(queryEl.scrollHeight, 120) + 'px';
 
     var val = queryEl.value;
+    updateWelcome(val && val.trim());
     if (!val || !val.trim()) {
       if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
       pagClear('exact-search');

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -1,35 +1,114 @@
 <style>
+  /* ─── Design Tokens ──────────────────────────────────────────────────────── */
+  :root {
+    /* Primary emerald */
+    --color-primary: #0d6e4f;
+    --color-primary-hover: #095c42;
+    --color-primary-light: #ecfdf5;
+    --color-primary-lighter: #f0fdf8;
+    /* Accent mint */
+    --color-accent: #34d399;
+    --color-accent-light: #d1fae5;
+    /* Neutrals */
+    --color-text-primary: #1a1a2e;
+    --color-text-secondary: #5c6370;
+    --color-text-muted: #8b95a5;
+    --color-border: #e2e8f0;
+    --color-border-hover: #cbd5e1;
+    --color-bg: #ffffff;
+    --color-bg-secondary: #f8fafc;
+    --color-bg-hover: #f1f5f9;
+    /* Error */
+    --color-error: #c0392b;
+    /* Spacing */
+    --space-xs: 4px;
+    --space-sm: 8px;
+    --space-md: 12px;
+    --space-lg: 16px;
+    --space-xl: 20px;
+    /* Radii */
+    --radius-sm: 6px;
+    --radius-md: 10px;
+    --radius-lg: 14px;
+    --radius-full: 9999px;
+    /* Shadows */
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+    --shadow-md: 0 2px 8px rgba(0,0,0,0.08);
+    --shadow-lg: 0 4px 16px rgba(0,0,0,0.1);
+    /* Transitions */
+    --transition-fast: 0.15s ease;
+    --transition-normal: 0.2s ease;
+  }
+
+  /* ─── Base ────────────────────────────────────────────────────────────────── */
   * { box-sizing: border-box; }
-  body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 13px; color: #333; background: #fff; }
+  body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 13px; color: var(--color-text-primary); background: var(--color-bg); }
   .sidebar { display: flex; flex-direction: column; height: 100vh; width: 350px; max-width: 100%; position: relative; }
 
-  .header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #e0e0e0; flex-shrink: 0; }
-  .header-brand { display: flex; align-items: center; gap: 8px; }
-  .logo-img { width: 32px; height: 32px; object-fit: contain; flex-shrink: 0; }
-  .title { font-weight: 600; font-size: 15px; color: #1a1a1a; }
-  .header-actions { display: flex; align-items: center; gap: 4px; }
+  /* ─── Header ──────────────────────────────────────────────────────────────── */
+  .header { display: flex; align-items: center; justify-content: space-between; padding: var(--space-md) var(--space-lg); border-bottom: 1px solid var(--color-border); flex-shrink: 0; }
+  .header-brand { display: flex; align-items: center; gap: var(--space-sm); }
+  .header-actions { display: flex; align-items: center; gap: var(--space-xs); }
+  .header-menu { position: relative; }
+  .header-menu-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    min-width: 180px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    z-index: 300;
+    padding: var(--space-xs) 0;
+  }
+  .header-menu-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    width: 100%;
+    padding: 10px var(--space-lg);
+    border: none;
+    background: none;
+    font-size: 13px;
+    color: var(--color-text-primary);
+    cursor: pointer;
+    text-align: left;
+  }
+  .header-menu-item:hover { background: var(--color-bg-hover); }
+  .header-menu-item svg { width: 16px; height: 16px; flex-shrink: 0; color: var(--color-text-secondary); }
 
-  .format-bar { display: flex; align-items: center; gap: 8px; padding: 10px 16px; border-bottom: 1px solid #e0e0e0; flex-wrap: wrap; flex-shrink: 0; }
-  .format-bar select, .format-bar input[type="number"] { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 12px; min-width: 0; }
+  /* ─── Format Bar ──────────────────────────────────────────────────────────── */
+  .format-bar { display: flex; align-items: center; gap: var(--space-sm); padding: 10px var(--space-lg); border-bottom: 1px solid var(--color-border); flex-wrap: wrap; flex-shrink: 0; }
+  .format-bar select, .format-bar input[type="number"] { padding: 6px 8px; border: 1px solid var(--color-border); border-radius: var(--radius-sm); font-size: 12px; min-width: 0; }
   .format-bar .font-picker { position: relative; flex: 1; min-width: 80px; max-width: 200px; }
-  .format-bar .font-picker-trigger { width: 100%; text-align: left; display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 12px; background: #fff; cursor: pointer; }
-  .format-bar .font-picker-trigger:hover { border-color: #999; }
+  .format-bar .font-picker-trigger { width: 100%; text-align: left; display: flex; justify-content: space-between; align-items: center; gap: 6px; padding: 6px 8px; border: 1px solid var(--color-border); border-radius: var(--radius-sm); font-size: 12px; background: var(--color-bg); cursor: pointer; height: 30px; }
+  .format-bar .font-picker-trigger:hover { border-color: var(--color-border-hover); }
   .format-bar .font-picker-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-  .format-bar .font-picker-caret { flex-shrink: 0; color: #666; font-size: 10px; }
-  .format-bar .font-picker-dropdown { position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; width: max-content; max-width: min(318px, calc(100vw - 32px)); max-height: 240px; overflow-y: auto; overflow-x: hidden; background: #fff; border: 1px solid #ccc; border-radius: 4px; z-index: 300; box-shadow: 0 2px 10px rgba(0,0,0,0.12); scrollbar-width: none; -ms-overflow-style: none; }
+  .format-bar .font-picker-caret { flex-shrink: 0; color: var(--color-text-secondary); font-size: 10px; }
+  .format-bar .font-picker-dropdown { position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; width: max-content; max-width: min(318px, calc(100vw - 32px)); max-height: 240px; overflow-y: auto; overflow-x: hidden; background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-sm); z-index: 300; box-shadow: var(--shadow-lg); scrollbar-width: none; -ms-overflow-style: none; }
   .format-bar .font-picker-dropdown::-webkit-scrollbar { display: none; }
-  .format-bar .font-picker-families { list-style: none; margin: 0; padding: 4px 0; min-width: 100%; }
+  .format-bar .font-picker-families { list-style: none; margin: 0; padding: var(--space-xs) 0; min-width: 100%; }
   .format-bar .font-picker-family-name { white-space: nowrap; min-width: 0; }
   .format-bar .font-picker-family-item { position: relative; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; gap: 6px; font-size: 12px; }
-  .format-bar .font-picker-family-item:hover { background: #f0f0f0; }
-  .format-bar .font-picker-family-item.is-selected { background: #e8f5e9; box-shadow: inset 3px 0 0 #2e7d32; }
-  .format-bar .font-picker-family-item.is-selected:hover { background: #dcedc8; }
-  .format-bar .font-picker-empty { padding: 8px 10px; font-size: 11px; color: #888; list-style: none; }
-  .format-bar .size-select { width: 52px; }
-  .format-bar .btn-format { padding: 6px 10px; border: 1px solid #ccc; background: #fafafa; border-radius: 4px; font-size: 12px; font-weight: 700; cursor: pointer; }
-  .format-bar .btn-format.active { background: #e8e8e8; border-color: #999; }
+  .format-bar .font-picker-family-item:hover { background: var(--color-bg-hover); }
+  .format-bar .font-picker-family-item.is-selected { background: var(--color-primary-light); box-shadow: inset 3px 0 0 var(--color-primary); }
+  .format-bar .font-picker-family-item.is-selected:hover { background: var(--color-accent-light); }
+  .format-bar .font-picker-empty { padding: 8px 10px; font-size: 11px; color: var(--color-text-muted); list-style: none; }
+
+  /* Size stepper */
+  .size-stepper { display: flex; align-items: center; border: 1px solid var(--color-border); border-radius: var(--radius-sm); height: 30px; overflow: hidden; }
+  .size-stepper-btn { display: flex; align-items: center; justify-content: center; width: 28px; height: 100%; border: none; background: none; cursor: pointer; color: var(--color-text-secondary); padding: 0; }
+  .size-stepper-btn:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
+  .size-stepper-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+  .size-stepper-btn:disabled:hover { background: none; }
+  .size-stepper-value { min-width: 28px; text-align: center; font-size: 12px; font-weight: 500; color: var(--color-text-primary); user-select: none; line-height: 30px; }
+
+  .format-bar .btn-format { padding: 6px 10px; border: 1px solid var(--color-border); background: var(--color-bg); border-radius: var(--radius-sm); font-size: 12px; font-weight: 700; cursor: pointer; height: 30px; }
+  .format-bar .btn-format:hover { border-color: var(--color-border-hover); }
+  .format-bar .btn-format.active { background: var(--color-bg-hover); border-color: var(--color-border-hover); }
   .format-bar .color-wrap { position: relative; }
-  .format-bar .color-trigger { width: 28px; height: 28px; padding: 0; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; background: #000; }
+  .format-bar .color-trigger { width: 28px; height: 28px; padding: 0; border: 1px solid var(--color-border); border-radius: var(--radius-sm); cursor: pointer; background: #000; }
   .format-bar .color-picker-hidden { position: absolute; width: 0; height: 0; opacity: 0; pointer-events: none; }
 
   .format-bar .color-picker-popover {
@@ -38,10 +117,10 @@
     right: 0;
     width: min(302px, calc(100vw - 32px));
     padding: 10px 10px 8px;
-    background: #fff;
-    border: 1px solid #dadce0;
-    border-radius: 8px;
-    box-shadow: 0 2px 12px rgba(60, 64, 67, 0.25);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
     z-index: 320;
   }
   .format-bar .color-swatch-grid {
@@ -53,7 +132,7 @@
   .format-bar .color-custom-row {
     margin-bottom: 10px;
     padding-bottom: 8px;
-    border-bottom: 1px solid #e8eaed;
+    border-bottom: 1px solid var(--color-border);
   }
   .format-bar .color-custom-row-label {
     display: block;
@@ -61,7 +140,7 @@
     font-weight: 500;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: #5f6368;
+    color: var(--color-text-secondary);
     margin-bottom: 6px;
   }
   .format-bar .color-custom-row-inner {
@@ -90,15 +169,15 @@
     width: 28px;
     height: 28px;
     padding: 0;
-    border: 1px solid #dadce0;
-    border-radius: 6px;
-    background: #fff;
-    color: #5f6368;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg);
+    color: var(--color-text-secondary);
     cursor: pointer;
   }
   .format-bar .color-custom-clear-btn:hover {
-    background: #f1f3f4;
-    color: #202124;
+    background: var(--color-bg-hover);
+    color: var(--color-text-primary);
   }
   .format-bar .color-swatch {
     width: 100%;
@@ -114,13 +193,13 @@
     vertical-align: middle;
   }
   .format-bar .color-swatch--outline {
-    border: 1px solid #ccc;
+    border: 1px solid var(--color-border);
   }
   .format-bar .color-swatch:hover {
-    box-shadow: 0 0 0 2px rgba(66, 133, 244, 0.5);
+    box-shadow: 0 0 0 2px rgba(13, 110, 79, 0.4);
   }
   .format-bar .color-swatch.is-selected {
-    box-shadow: 0 0 0 2px #1a73e8, 0 1px 3px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 0 0 2px var(--color-primary), 0 1px 3px rgba(0, 0, 0, 0.25);
   }
   .format-bar .color-picker-custom-label {
     display: block;
@@ -128,7 +207,7 @@
     font-weight: 500;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: #5f6368;
+    color: var(--color-text-secondary);
     margin-bottom: 6px;
   }
   .format-bar .color-picker-custom-actions {
@@ -146,12 +225,12 @@
     border: none;
     border-radius: 50%;
     background: transparent;
-    color: #5f6368;
+    color: var(--color-text-secondary);
     cursor: pointer;
   }
   .format-bar .color-picker-icon-btn:hover {
-    background: #f1f3f4;
-    color: #202124;
+    background: var(--color-bg-hover);
+    color: var(--color-text-primary);
   }
 
   .format-bar .custom-color-dialog {
@@ -173,26 +252,26 @@
   .format-bar .custom-color-dialog-panel {
     width: 100%;
     max-width: 280px;
-    padding: 16px;
-    background: #fff;
-    border-radius: 8px;
-    box-shadow: 0 4px 24px rgba(60, 64, 67, 0.28);
-    border: 1px solid #dadce0;
+    padding: var(--space-lg);
+    background: var(--color-bg);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    border: 1px solid var(--color-border);
   }
   .format-bar .custom-color-dialog-title {
     margin: 0 0 12px;
     font-size: 16px;
     font-weight: 400;
-    color: #202124;
+    color: var(--color-text-primary);
   }
   .format-bar .custom-color-sv {
     position: relative;
     width: 100%;
     height: 140px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     overflow: hidden;
     cursor: crosshair;
-    border: 1px solid #dadce0;
+    border: 1px solid var(--color-border);
     margin-bottom: 12px;
     touch-action: none;
   }
@@ -224,7 +303,7 @@
     width: 28px;
     height: 28px;
     border-radius: 50%;
-    border: 1px solid #dadce0;
+    border: 1px solid var(--color-border);
     flex-shrink: 0;
     background: #000;
   }
@@ -235,22 +314,22 @@
     width: 32px;
     height: 32px;
     padding: 0;
-    border: 1px solid #dadce0;
-    border-radius: 6px;
-    background: #fff;
-    color: #5f6368;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg);
+    color: var(--color-text-secondary);
     cursor: pointer;
     flex-shrink: 0;
   }
   .format-bar .custom-color-eyedropper-btn:hover {
-    background: #f1f3f4;
-    color: #202124;
+    background: var(--color-bg-hover);
+    color: var(--color-text-primary);
   }
   .format-bar .custom-color-hue-track {
     position: relative;
     flex: 1;
     height: 12px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     background: linear-gradient(
       to right,
       #f00 0%,
@@ -261,7 +340,7 @@
       #f0f 83%,
       #f00 100%
     );
-    border: 1px solid #dadce0;
+    border: 1px solid var(--color-border);
     cursor: pointer;
     touch-action: none;
   }
@@ -288,21 +367,21 @@
   .format-bar .custom-color-field label {
     display: block;
     font-size: 11px;
-    color: #5f6368;
+    color: var(--color-text-secondary);
     margin-bottom: 4px;
   }
   .format-bar .custom-color-input {
     width: 100%;
     padding: 6px 8px;
     font-size: 12px;
-    border: 1px solid #dadce0;
-    border-radius: 4px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
     box-sizing: border-box;
   }
   .format-bar .custom-color-input:focus {
     outline: none;
-    border-color: #1a73e8;
-    box-shadow: 0 0 0 1px #1a73e8;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 1px var(--color-primary);
   }
   .format-bar .custom-color-footer {
     display: flex;
@@ -312,36 +391,35 @@
   .format-bar .custom-color-btn-cancel {
     padding: 8px 16px;
     font-size: 13px;
-    border: 1px solid #dadce0;
-    border-radius: 4px;
-    background: #fff;
-    color: #1a73e8;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg);
+    color: var(--color-primary);
     cursor: pointer;
   }
   .format-bar .custom-color-btn-cancel:hover {
-    background: #f8f9fa;
+    background: var(--color-bg-secondary);
   }
   .format-bar .custom-color-btn-ok {
     padding: 8px 20px;
     font-size: 13px;
     border: none;
-    border-radius: 4px;
-    background: #1a73e8;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary);
     color: #fff;
     cursor: pointer;
   }
   .format-bar .custom-color-btn-ok:hover {
-    background: #1765cc;
+    background: var(--color-primary-hover);
   }
 
-  /* Tab navigation */
-  .tab-nav { display: flex; border-bottom: 2px solid #e0e0e0; flex-shrink: 0; padding: 0 8px; }
-  /* flex-basis 0 + min-width 0 so each tab gets equal width and the active underline spans the full column */
-  .tab-btn { flex: 1 1 0; min-width: 0; padding: 10px 4px; border: none; background: none; font-size: 13px; font-weight: 500; color: #666; cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -2px; transition: color 0.15s, border-color 0.15s; }
-  .tab-btn:hover { color: #2e7d32; }
-  .tab-btn.active { color: #2e7d32; border-bottom-color: #2e7d32; }
+  /* ─── Tab Navigation ──────────────────────────────────────────────────────── */
+  .tab-nav { display: flex; border-bottom: 2px solid var(--color-border); flex-shrink: 0; padding: 0 var(--space-sm); }
+  .tab-btn { flex: 1 1 0; min-width: 0; padding: 10px var(--space-xs); border: none; background: none; font-size: 13px; font-weight: 500; color: var(--color-text-secondary); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -2px; transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast); border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
+  .tab-btn:hover { color: var(--color-primary); background: var(--color-primary-lighter); }
+  .tab-btn.active { color: var(--color-primary); border-bottom-color: var(--color-primary); background: var(--color-primary-light); }
 
-  /* AI tab: sparkles left of label; hover color same as all tabs (.tab-btn:hover) */
+  /* AI tab: sparkles left of label */
   .tab-btn--ai {
     display: flex;
     flex-direction: row;
@@ -358,8 +436,12 @@
     line-height: 0;
     color: inherit;
   }
+  @keyframes sparkle-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.6; transform: scale(0.85); }
+  }
   .tab-btn--ai:hover .tab-btn-ai-icon {
-    animation: spin 4s linear infinite;
+    animation: sparkle-pulse 1.5s ease-in-out infinite;
   }
   .tab-btn--ai .tab-btn-ai-icon svg {
     width: 1em;
@@ -381,30 +463,30 @@
     }
   }
 
-  /* Tab content area — fills space below nav */
+  /* ─── Tab Content ─────────────────────────────────────────────────────────── */
   .tab-content { flex: 1; overflow: hidden; min-height: 0; }
   .tab-panel { display: none; flex-direction: column; height: 100%; }
   .tab-panel.active { display: flex; }
 
-  /* Direct Insert form */
-  .direct-insert-form { padding: 16px; flex-shrink: 0; }
-  .form-group { margin-bottom: 12px; }
-  .form-group label { display: block; font-weight: 500; margin-bottom: 4px; font-size: 12px; color: #555; }
-  .form-select, .form-input { width: 100%; padding: 8px 10px; border: 1px solid #ccc; border-radius: 4px; font-size: 13px; }
-  .form-select:focus, .form-input:focus { outline: none; border-color: #2e7d32; }
-  .form-row { display: flex; gap: 12px; }
+  /* ─── Direct Insert (Browse) ──────────────────────────────────────────────── */
+  .direct-insert-form { padding: var(--space-lg); flex-shrink: 0; }
+  .form-group { margin-bottom: var(--space-md); }
+  .form-group label { display: block; font-weight: 500; margin-bottom: var(--space-xs); font-size: 12px; color: var(--color-text-secondary); }
+  .form-select, .form-input { width: 100%; padding: 8px 10px; border: 1px solid var(--color-border); border-radius: var(--radius-sm); font-size: 13px; }
+  .form-select:focus, .form-input:focus { outline: none; border-color: var(--color-primary); }
+  .form-row { display: flex; gap: var(--space-md); }
   .form-group-half { flex: 1; }
-  .hint-inline { font-weight: 400; color: #999; font-size: 11px; }
+  .hint-inline { font-weight: 400; color: var(--color-text-muted); font-size: 11px; }
   .btn-block { width: 100%; }
 
-  /* Results scroll area */
-  .results-list { flex: 1; overflow-y: auto; padding: 16px; min-height: 0; }
-  .result-card { padding: 12px; border: 1px solid #e0e0e0; border-radius: 4px; margin-bottom: 8px; font-size: 12px; }
-  .result-card .ref-arabic { font-size: 13px; direction: rtl; text-align: right; color: #555; margin-bottom: 4px; font-family: Amiri, serif; }
-  .result-card .ref-english { font-size: 11px; color: #888; margin-top: 4px; margin-bottom: 2px; }
+  /* ─── Results ─────────────────────────────────────────────────────────────── */
+  .results-list { flex: 1; overflow-y: auto; padding: var(--space-lg); min-height: 0; }
+  .result-card { padding: var(--space-md); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: var(--space-sm); font-size: 12px; }
+  .result-card .ref-arabic { font-size: 13px; direction: rtl; text-align: right; color: var(--color-text-secondary); margin-bottom: var(--space-xs); font-family: Amiri, serif; }
+  .result-card .ref-english { font-size: 11px; color: var(--color-text-muted); margin-top: var(--space-xs); margin-bottom: 2px; }
   @keyframes arabic-font-in { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: translateY(0); } }
   .result-card .arabic {
-    font-size: 18pt; direction: rtl; text-align: right; font-family: Amiri, serif; margin: 8px 0; line-height: 1.8;
+    font-size: 18pt; direction: rtl; text-align: right; font-family: Amiri, serif; margin: var(--space-sm) 0; line-height: 1.8;
     animation: arabic-font-in 0.2s ease;
     transition: opacity 0.42s ease-out;
   }
@@ -415,30 +497,30 @@
   }
   .result-card .arabic.range-block { line-height: 2.2; white-space: normal; word-break: normal; }
   .result-card mark { background: #fff59d; padding: 0 2px; }
-  .result-card .translation { font-size: 12px; color: #555; margin: 6px 0 0; line-height: 1.5; }
-  .result-card .btn-toggle-translation { display: inline-block; font-size: 11px; color: #2e7d32; cursor: pointer; margin-top: 4px; user-select: none; }
+  .result-card .translation { font-size: 12px; color: var(--color-text-secondary); margin: 6px 0 0; line-height: 1.5; }
+  .result-card .btn-toggle-translation { display: inline-block; font-size: 11px; color: var(--color-primary); cursor: pointer; margin-top: var(--space-xs); user-select: none; }
   .result-card .btn-toggle-translation:hover { text-decoration: underline; }
-  .result-card .btn-insert-result { display: block; width: 100%; margin-top: 8px; padding: 6px 12px; font-size: 12px; }
+  .result-card .btn-insert-result { display: block; width: 100%; margin-top: var(--space-sm); padding: 6px 12px; font-size: 12px; }
 
-  /* Clarify message from Claude */
-  .clarify-message { padding: 12px 16px; margin: 8px 16px; background: #f5f5f5; border-radius: 8px; font-size: 13px; color: #333; line-height: 1.5; }
+  /* ─── Clarify Message ─────────────────────────────────────────────────────── */
+  .clarify-message { padding: var(--space-md) var(--space-lg); margin: var(--space-sm) var(--space-lg); background: var(--color-bg-hover); border-radius: var(--radius-md); font-size: 13px; color: var(--color-text-primary); line-height: 1.5; }
 
-  /* Loading and empty states */
+  /* ─── Loading & Empty States ──────────────────────────────────────────────── */
   @keyframes spin { to { transform: rotate(360deg); } }
-  .empty-state { color: #666; font-size: 13px; padding: 24px 16px; text-align: center; }
-  .cache-status { display: flex; align-items: center; gap: 8px; padding: 6px 16px; font-size: 12px; }
-  .cache-status-text { color: #888; }
-  .cache-status-error { color: #c0392b; }
-  .cache-status-retry { font-size: 12px; padding: 2px 8px; border: 1px solid #c0392b; border-radius: 4px; background: none; color: #c0392b; cursor: pointer; }
+  .empty-state { color: var(--color-text-secondary); font-size: 13px; padding: 24px var(--space-lg); text-align: center; }
+  .cache-status { display: flex; align-items: center; gap: var(--space-sm); padding: 6px var(--space-lg); font-size: 12px; }
+  .cache-status-text { color: var(--color-text-muted); }
+  .cache-status-error { color: var(--color-error); }
+  .cache-status-retry { font-size: 12px; padding: 2px 8px; border: 1px solid var(--color-error); border-radius: var(--radius-sm); background: none; color: var(--color-error); cursor: pointer; }
 
-  /* Startup overlay */
-  .startup-overlay { position: absolute; inset: 0; background: #fff; display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 200; gap: 12px; }
-  .startup-spinner { width: 32px; height: 32px; border: 3px solid #e0e0e0; border-top-color: #2e7d32; border-radius: 50%; animation: spin 0.8s linear infinite; }
-  .startup-text { font-size: 13px; color: #888; }
+  /* ─── Startup Overlay ─────────────────────────────────────────────────────── */
+  .startup-overlay { position: absolute; inset: 0; background: var(--color-bg); display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 200; gap: var(--space-md); }
+  .startup-spinner { width: 32px; height: 32px; border: 3px solid var(--color-border); border-top-color: var(--color-primary); border-radius: 50%; animation: spin 0.8s linear infinite; }
+  .startup-text { font-size: 13px; color: var(--color-text-muted); }
 
-  /* Skeleton cards */
-  .skeleton-card { border: 1px solid #e0e0e0; border-radius: 4px; padding: 12px; margin-bottom: 8px; }
-  .skeleton-line { height: 12px; background: #e0e0e0; border-radius: 3px; margin-bottom: 8px; animation: skeleton-pulse 1.4s ease-in-out infinite; }
+  /* ─── Skeleton Cards ──────────────────────────────────────────────────────── */
+  .skeleton-card { border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-md); margin-bottom: var(--space-sm); }
+  .skeleton-line { height: 12px; background: var(--color-border); border-radius: 3px; margin-bottom: var(--space-sm); animation: skeleton-pulse 1.4s ease-in-out infinite; }
   .skeleton-line:last-child { margin-bottom: 0; }
   .sk-short { width: 40%; }
   .sk-arabic { height: 20px; width: 85%; margin-left: auto; }
@@ -446,54 +528,128 @@
   .sk-long { width: 100%; }
   @keyframes skeleton-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
-  /* Insert button loading spinner */
+  /* ─── Insert Button Spinner ───────────────────────────────────────────────── */
   .btn-insert-result.btn-loading { color: transparent; pointer-events: none; position: relative; }
-  /* margin centers ::after so rotate-only @keyframes spin does not fight translate(-50%,-50%) */
   .btn-insert-result.btn-loading::after { content: ''; position: absolute; top: 50%; left: 50%; width: 12px; height: 12px; margin: -6px 0 0 -6px; border: 2px solid rgba(255,255,255,0.5); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; }
 
-  /* Input area pinned to bottom of tab */
-  .tab-input-area { flex-shrink: 0; padding: 12px 16px; border-top: 1px solid #e0e0e0; background: #fff; }
-  .tab-input-wrap { display: flex; align-items: flex-end; gap: 8px; }
-  .tab-input-wrap textarea { flex: 1; padding: 10px 12px; border: 1px solid #ccc; border-radius: 8px; font-size: 13px; font-family: inherit; resize: none; line-height: 1.4; min-height: 40px; max-height: 120px; overflow-y: auto; }
-  .tab-input-wrap textarea:focus { outline: none; border-color: #2e7d32; }
-  .btn-send { width: 36px; height: 36px; border: none; background: #2e7d32; color: #fff; border-radius: 50%; font-size: 16px; cursor: pointer; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
-  .btn-send:hover { background: #1b5e20; }
-  .btn-send:disabled { background: #a5d6a7; cursor: not-allowed; }
+  /* ─── Input Area ──────────────────────────────────────────────────────────── */
+  .tab-input-area { flex-shrink: 0; padding: var(--space-md) var(--space-lg); border-top: 1px solid var(--color-border); background: var(--color-bg); }
+  .tab-input-wrap { display: flex; align-items: flex-end; gap: var(--space-sm); }
+  .tab-input-wrap textarea { flex: 1; padding: 10px 12px; border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: 13px; font-family: inherit; resize: none; line-height: 1.4; min-height: 40px; max-height: 120px; overflow-y: auto; }
+  .tab-input-wrap textarea:focus { outline: none; border-color: var(--color-primary); }
+  .btn-send { width: 36px; height: 36px; border: none; background: var(--color-primary); color: #fff; border-radius: 50%; font-size: 16px; cursor: pointer; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .btn-send:hover { background: var(--color-primary-hover); }
+  .btn-send:disabled { background: var(--color-primary); opacity: 0.4; cursor: not-allowed; }
 
-  /* Buttons */
-  .btn-primary { padding: 8px 16px; background: #2e7d32; color: #fff; border: none; border-radius: 4px; font-size: 13px; cursor: pointer; }
-  .btn-primary:hover { background: #1b5e20; }
-  .btn-primary:disabled { background: #a5d6a7; cursor: not-allowed; }
-  .btn-secondary { padding: 8px 16px; background: #f5f5f5; color: #333; border: 1px solid #ccc; border-radius: 4px; font-size: 13px; cursor: pointer; }
-  .btn-secondary:hover { background: #e8e8e8; }
+  /* ─── Buttons ─────────────────────────────────────────────────────────────── */
+  .btn-primary { padding: 8px var(--space-lg); background: var(--color-primary); color: #fff; border: none; border-radius: var(--radius-sm); font-size: 13px; cursor: pointer; }
+  .btn-primary:hover { background: var(--color-primary-hover); }
+  .btn-primary:disabled { background: var(--color-primary); opacity: 0.4; cursor: not-allowed; }
+  .btn-secondary { padding: 8px var(--space-lg); background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: var(--radius-sm); font-size: 13px; cursor: pointer; }
+  .btn-secondary:hover { background: var(--color-bg-hover); }
 
-  .btn-show-more { display: block; width: 100%; padding: 10px; margin-top: 4px; border: 1px dashed #ccc; border-radius: 4px; background: none; color: #2e7d32; font-size: 13px; cursor: pointer; text-align: center; }
-  .btn-show-more:hover { background: #f5f5f5; border-color: #2e7d32; }
+  .btn-show-more { display: block; width: 100%; padding: 10px; margin-top: var(--space-xs); border: 1px dashed var(--color-border); border-radius: var(--radius-sm); background: none; color: var(--color-primary); font-size: 13px; cursor: pointer; text-align: center; }
+  .btn-show-more:hover { background: var(--color-bg-secondary); border-color: var(--color-primary); }
 
-  .btn-icon { padding: 8px; border: none; background: none; cursor: pointer; color: #666; border-radius: 4px; font-size: 16px; }
-  .btn-icon:hover { background: #f0f0f0; color: #333; }
+  .btn-icon { padding: var(--space-sm); border: none; background: none; cursor: pointer; color: var(--color-text-secondary); border-radius: var(--radius-sm); font-size: 16px; }
+  .btn-icon:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
   .btn-icon svg { display: block; }
 
-  /* Settings overlay */
-  .settings-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); z-index: 100; display: flex; align-items: center; justify-content: center; padding: 20px; }
-  .settings-overlay.hidden { display: none; }
-  .settings-panel { background: #fff; border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.15); max-width: 320px; width: 100%; max-height: 90vh; overflow-y: auto; padding: 20px; }
-  .settings-panel-loading { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; min-height: 120px; padding: 8px 0 16px; }
+  /* ─── Settings Page ───────────────────────────────────────────────────────── */
+  .settings-page { display: flex; flex-direction: column; flex: 1; overflow-y: auto; }
+  .settings-page.hidden { display: none !important; }
+  .settings-header { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-md) var(--space-lg); border-bottom: 1px solid var(--color-border); flex-shrink: 0; }
+  .settings-title { margin: 0; font-size: 16px; font-weight: 600; color: var(--color-text-primary); }
+  .settings-body { padding: var(--space-xl); }
+  .settings-panel-loading { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-md); min-height: 120px; padding: var(--space-sm) 0 var(--space-lg); }
   .settings-panel-loading .startup-spinner { flex-shrink: 0; }
-  .settings-panel h2 { margin: 0 0 16px; font-size: 18px; display: flex; align-items: center; gap: 8px; }
-  .settings-panel .back-btn { padding: 4px; border: none; background: none; cursor: pointer; color: #666; }
-  .settings-panel .back-btn:hover { color: #333; }
-  .settings-section { margin-bottom: 20px; }
-  .settings-section label { display: block; font-weight: 500; margin-bottom: 8px; font-size: 13px; }
-  .settings-section .hint { font-size: 11px; color: #666; margin-top: 4px; }
-  .settings-section select, .settings-section input[type="text"] { width: 100%; padding: 8px 10px; border: 1px solid #ccc; border-radius: 4px; font-size: 13px; }
-  .settings-section input[type="text"][data-masked] { font-family: monospace; }
-  .settings-radio, .settings-check { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; cursor: pointer; }
-  .settings-radio input, .settings-check input { margin: 0; }
-  .settings-save-row { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
-  .settings-saved-msg { font-size: 12px; margin: 0; }
-  .settings-saved-msg.success { color: #2e7d32; }
-  .settings-saved-msg.error { color: #c62828; }
+  .settings-section { margin-bottom: var(--space-xl); }
+  .settings-section-title { margin: 0 0 var(--space-lg); font-size: 14px; font-weight: 600; color: var(--color-text-primary); }
+  .settings-row { display: flex; align-items: center; justify-content: space-between; padding: var(--space-md) 0; border-bottom: 1px solid var(--color-border); }
+  .settings-row--stacked { flex-direction: column; align-items: flex-start; gap: var(--space-sm); }
+  .settings-row-label { font-size: 13px; color: var(--color-text-primary); }
+  .settings-row .form-select { font-size: 13px; }
+
+  /* Toggle switch */
+  .toggle-switch { position: relative; display: inline-block; width: 40px; height: 22px; flex-shrink: 0; }
+  .toggle-switch input { opacity: 0; width: 0; height: 0; position: absolute; }
+  .toggle-slider {
+    position: absolute; inset: 0;
+    background: var(--color-border-hover);
+    border-radius: var(--radius-full);
+    transition: background var(--transition-fast);
+    cursor: pointer;
+  }
+  .toggle-slider::before {
+    content: '';
+    position: absolute;
+    width: 18px; height: 18px;
+    left: 2px; bottom: 2px;
+    background: white;
+    border-radius: 50%;
+    transition: transform var(--transition-fast);
+    box-shadow: var(--shadow-sm);
+  }
+  .toggle-switch input:checked + .toggle-slider { background: var(--color-primary); }
+  .toggle-switch input:checked + .toggle-slider::before { transform: translateX(18px); }
+
+  /* ─── Search Welcome ──────────────────────────────────────────────────────── */
+  .search-welcome {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    flex: 1; padding: var(--space-xl); text-align: center; gap: var(--space-md);
+  }
+  .search-welcome-icon { color: var(--color-text-muted); opacity: 0.5; }
+  .search-welcome-title { font-size: 15px; font-weight: 500; color: var(--color-text-primary); margin: 0; }
+  .search-welcome-hint { font-size: 13px; color: var(--color-text-muted); margin: 0; }
+
+  /* ─── AI Welcome ──────────────────────────────────────────────────────────── */
+  .ai-welcome {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    flex: 1; padding: var(--space-xl); text-align: center; gap: var(--space-xl);
+  }
+  .ai-welcome-greeting { font-size: 16px; font-weight: 600; color: var(--color-text-primary); margin: 0; }
+  .ai-welcome-hint { font-size: 13px; color: var(--color-text-muted); margin: var(--space-xs) 0 0; }
+  .ai-welcome-chips { display: flex; flex-direction: column; gap: var(--space-sm); width: 100%; max-width: 260px; }
+  .ai-chip {
+    padding: var(--space-sm) var(--space-lg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+    background: var(--color-bg);
+    font-size: 13px;
+    color: var(--color-text-primary);
+    cursor: pointer;
+    text-align: center;
+    transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  }
+  .ai-chip:hover { background: var(--color-primary-light); border-color: var(--color-primary); color: var(--color-primary); }
+
+  /* AI query header */
+  .ai-query-header { padding: 0 0 var(--space-sm); margin-bottom: var(--space-sm); }
+  .ai-query-label { font-size: 11px; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .ai-query-text { font-size: 13px; color: var(--color-text-primary); font-weight: 500; margin-left: var(--space-xs); }
+
+  /* AI disclaimer */
+  .ai-disclaimer {
+    display: flex; align-items: center; justify-content: center; gap: var(--space-xs);
+    padding: var(--space-xs) var(--space-lg);
+    font-size: 11px; color: var(--color-text-muted); text-align: center; flex-shrink: 0;
+  }
+
+  /* ─── Bottom Bar ──────────────────────────────────────────────────────────── */
+  .bottom-bar { flex-shrink: 0; border-top: 1px solid var(--color-border); padding: var(--space-sm) var(--space-lg); background: var(--color-bg-secondary); }
+  .bottom-bar-inner { display: flex; align-items: center; justify-content: space-between; }
+  .bottom-bar-logo { display: flex; align-items: center; gap: var(--space-xs); color: var(--color-text-muted); font-size: 12px; }
+  .bottom-bar-logo svg { flex-shrink: 0; }
+  .bottom-bar-name { font-weight: 500; }
+  .bottom-bar-link {
+    display: flex; align-items: center; gap: var(--space-xs);
+    font-size: 11px; color: var(--color-text-secondary); text-decoration: none;
+    padding: var(--space-xs) var(--space-sm);
+    border: 1px solid var(--color-border); border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+  }
+  .bottom-bar-link:hover { color: var(--color-primary); border-color: var(--color-primary); background: var(--color-primary-light); }
+  .bottom-bar-link svg { width: 14px; height: 14px; flex-shrink: 0; }
 
   .hidden { display: none !important; }
 </style>

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -86,8 +86,16 @@
   .format-bar .font-picker-trigger:hover { border-color: var(--color-border-hover); }
   .format-bar .font-picker-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
   .format-bar .font-picker-caret { flex-shrink: 0; color: var(--color-text-secondary); font-size: 10px; }
-  .format-bar .font-picker-dropdown { position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; width: max-content; max-width: min(318px, calc(100vw - 32px)); max-height: 240px; overflow-y: auto; overflow-x: hidden; background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-sm); z-index: 300; box-shadow: var(--shadow-lg); scrollbar-width: none; -ms-overflow-style: none; }
-  .format-bar .font-picker-dropdown::-webkit-scrollbar { display: none; }
+  .format-bar .font-picker-dropdown {
+    position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; width: max-content; max-width: min(318px, calc(100vw - 32px)); max-height: 240px;
+    overflow-y: auto; overflow-x: hidden; background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-sm); z-index: 300; box-shadow: var(--shadow-lg);
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border-hover) var(--color-bg-secondary);
+  }
+  .format-bar .font-picker-dropdown::-webkit-scrollbar { width: 6px; }
+  .format-bar .font-picker-dropdown::-webkit-scrollbar-track { background: var(--color-bg-secondary); border-radius: 3px; }
+  .format-bar .font-picker-dropdown::-webkit-scrollbar-thumb { background: var(--color-border-hover); border-radius: 3px; }
+  .format-bar .font-picker-dropdown::-webkit-scrollbar-thumb:hover { background: var(--color-text-muted); }
   .format-bar .font-picker-families { list-style: none; margin: 0; padding: var(--space-xs) 0; min-width: 100%; }
   .format-bar .font-picker-family-name { white-space: nowrap; min-width: 0; }
   .format-bar .font-picker-family-item { position: relative; padding: 6px 10px; cursor: pointer; display: flex; align-items: center; gap: 6px; font-size: 12px; }
@@ -96,13 +104,30 @@
   .format-bar .font-picker-family-item.is-selected:hover { background: var(--color-accent-light); }
   .format-bar .font-picker-empty { padding: 8px 10px; font-size: 11px; color: var(--color-text-muted); list-style: none; }
 
-  /* Size stepper */
+  /* Size stepper + preset dropdown from center control */
+  .size-stepper-wrap { position: relative; flex-shrink: 0; align-self: flex-start; }
   .size-stepper { display: flex; align-items: center; border: 1px solid var(--color-border); border-radius: var(--radius-sm); height: 30px; overflow: hidden; }
   .size-stepper-btn { display: flex; align-items: center; justify-content: center; width: 28px; height: 100%; border: none; background: none; cursor: pointer; color: var(--color-text-secondary); padding: 0; }
   .size-stepper-btn:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
   .size-stepper-btn:disabled { opacity: 0.3; cursor: not-allowed; }
   .size-stepper-btn:disabled:hover { background: none; }
-  .size-stepper-value { min-width: 28px; text-align: center; font-size: 12px; font-weight: 500; color: var(--color-text-primary); user-select: none; line-height: 30px; }
+  .size-stepper-value-btn {
+    min-width: 28px; height: 100%; padding: 0 4px; margin: 0; border: none; border-left: 1px solid var(--color-border); border-right: 1px solid var(--color-border);
+    background: var(--color-bg); cursor: pointer; text-align: center; font-size: 12px; font-weight: 500; font-family: inherit;
+    color: var(--color-text-primary); user-select: none; line-height: 1;
+  }
+  .size-stepper-value-btn:hover { background: var(--color-bg-hover); }
+  .font-size-presets-dropdown {
+    position: absolute; top: calc(100% + 2px); left: 0; min-width: 100%; z-index: 300;
+    margin: 0; padding: var(--space-xs) 0; list-style: none;
+    background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-sm); box-shadow: var(--shadow-lg);
+  }
+  .font-size-presets-dropdown .font-size-preset-item {
+    display: block; width: 100%; padding: 6px 12px; border: none; background: none; cursor: pointer;
+    font-size: 12px; font-family: inherit; text-align: left; color: var(--color-text-primary);
+  }
+  .font-size-presets-dropdown .font-size-preset-item:hover { background: var(--color-bg-hover); }
+  .font-size-presets-dropdown .font-size-preset-item.is-selected { background: var(--color-primary-light); box-shadow: inset 3px 0 0 var(--color-primary); }
 
   .format-bar .btn-format { padding: 6px 10px; border: 1px solid var(--color-border); background: var(--color-bg); border-radius: var(--radius-sm); font-size: 12px; font-weight: 700; cursor: pointer; height: 30px; }
   .format-bar .btn-format:hover { border-color: var(--color-border-hover); }
@@ -437,11 +462,11 @@
     color: inherit;
   }
   @keyframes sparkle-pulse {
-    0%, 100% { opacity: 1; transform: scale(1); }
-    50% { opacity: 0.6; transform: scale(0.85); }
+    0%, 100% { opacity: 1; transform: scale(1); filter: drop-shadow(0 0 2px rgba(13, 110, 79, 0.35)); }
+    50% { opacity: 0.55; transform: scale(0.82); filter: drop-shadow(0 0 5px rgba(13, 110, 79, 0.55)); }
   }
   .tab-btn--ai:hover .tab-btn-ai-icon {
-    animation: sparkle-pulse 1.5s ease-in-out infinite;
+    animation: sparkle-pulse 1.9s ease-in-out infinite;
   }
   .tab-btn--ai .tab-btn-ai-icon svg {
     width: 1em;
@@ -457,9 +482,9 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .tab-btn--ai .tab-btn-ai-icon,
     .tab-btn--ai:hover .tab-btn-ai-icon {
       animation: none;
+      filter: none;
     }
   }
 
@@ -528,9 +553,27 @@
   .sk-long { width: 100%; }
   @keyframes skeleton-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
-  /* ─── Insert Button Spinner ───────────────────────────────────────────────── */
-  .btn-insert-result.btn-loading { color: transparent; pointer-events: none; position: relative; }
-  .btn-insert-result.btn-loading::after { content: ''; position: absolute; top: 50%; left: 50%; width: 12px; height: 12px; margin: -6px 0 0 -6px; border: 2px solid rgba(255,255,255,0.5); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; }
+  /* ─── Insert Button Spinner (flex centers ::after; avoids padding/line-height offset) ─ */
+  .btn-insert-result.btn-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: transparent !important;
+    pointer-events: none;
+    position: relative;
+  }
+  .result-card .btn-insert-result.btn-loading { display: flex; }
+  .btn-insert-result.btn-loading::after {
+    content: '';
+    display: block;
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    border: 2px solid rgba(255,255,255,0.5);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
 
   /* ─── Input Area ──────────────────────────────────────────────────────────── */
   .tab-input-area { flex-shrink: 0; padding: var(--space-md) var(--space-lg); border-top: 1px solid var(--color-border); background: var(--color-bg); }
@@ -552,7 +595,8 @@
   .btn-show-more:hover { background: var(--color-bg-secondary); border-color: var(--color-primary); }
 
   .btn-icon { padding: var(--space-sm); border: none; background: none; cursor: pointer; color: var(--color-text-secondary); border-radius: var(--radius-sm); font-size: 16px; }
-  .btn-icon:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
+  .btn-icon:hover:not(:disabled) { background: var(--color-bg-hover); color: var(--color-text-primary); }
+  .btn-icon:disabled { opacity: 0.35; cursor: not-allowed; pointer-events: none; }
   .btn-icon svg { display: block; }
 
   /* ─── Settings Page ───────────────────────────────────────────────────────── */
@@ -638,9 +682,8 @@
   /* ─── Bottom Bar ──────────────────────────────────────────────────────────── */
   .bottom-bar { flex-shrink: 0; border-top: 1px solid var(--color-border); padding: var(--space-sm) var(--space-lg); background: var(--color-bg-secondary); }
   .bottom-bar-inner { display: flex; align-items: center; justify-content: space-between; }
-  .bottom-bar-logo { display: flex; align-items: center; gap: var(--space-xs); color: var(--color-text-muted); font-size: 12px; }
+  .bottom-bar-logo { display: flex; align-items: center; color: var(--color-text-muted); font-size: 12px; }
   .bottom-bar-logo svg { flex-shrink: 0; }
-  .bottom-bar-name { font-weight: 500; }
   .bottom-bar-link {
     display: flex; align-items: center; gap: var(--space-xs);
     font-size: 11px; color: var(--color-text-secondary); text-decoration: none;
@@ -652,4 +695,16 @@
   .bottom-bar-link svg { width: 14px; height: 14px; flex-shrink: 0; }
 
   .hidden { display: none !important; }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -12,30 +12,52 @@
       <span class="startup-text">Loading…</span>
     </div>
 
-    <header class="header">
+    <header class="header" id="sidebar-header">
       <div class="header-brand">
-        <?!= include_('sidebar/components/logo-img') ?>
-        <span class="title">Tasneef AI</span>
-      </div>
-      <div class="header-actions">
-        <button type="button" class="btn-icon" id="btn-new-ai-chat" title="New chat" aria-label="New chat">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <button type="button" class="btn-icon hidden" id="btn-new-ai-chat" title="New chat" aria-label="New chat">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
             <path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
             <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.506l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>
           </svg>
         </button>
-        <button type="button" class="btn-icon" id="btn-settings" title="Settings" aria-label="Settings">&#9881;</button>
+      </div>
+      <div class="header-actions">
+        <div class="header-menu" id="header-menu">
+          <button type="button" class="btn-icon" id="btn-header-menu" title="Menu" aria-label="Menu" aria-haspopup="true" aria-expanded="false">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true" focusable="false">
+              <circle cx="12" cy="5" r="1.5"/>
+              <circle cx="12" cy="12" r="1.5"/>
+              <circle cx="12" cy="19" r="1.5"/>
+            </svg>
+          </button>
+          <div class="header-menu-dropdown hidden" id="header-menu-dropdown">
+            <button type="button" class="header-menu-item" id="btn-menu-settings">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+                <circle cx="12" cy="12" r="3"/>
+              </svg>
+              <span>Settings</span>
+            </button>
+            <button type="button" class="header-menu-item" id="btn-menu-feedback">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+              </svg>
+              <span>Give us feedback</span>
+            </button>
+          </div>
+        </div>
       </div>
     </header>
 
-    <?!= include_('sidebar/components/format-bar') ?>
+    <div id="sidebar-format-bar">
+      <?!= include_('sidebar/components/format-bar') ?>
+    </div>
 
-    <nav class="tab-nav">
+    <nav class="tab-nav" id="sidebar-tab-nav">
       <button type="button" class="tab-btn active" data-tab="direct-insert">Browse</button>
       <button type="button" class="tab-btn" data-tab="exact-search">Search</button>
       <button type="button" class="tab-btn tab-btn--ai" data-tab="ai-search">
         <span class="tab-btn-ai-icon" aria-hidden="true">
-          <!-- Lucide sparkles (ISC) — stroke only, flat; color from tab via currentColor -->
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
             <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/>
             <path d="M20 3v4"/>
@@ -48,15 +70,19 @@
       </button>
     </nav>
 
-    <main class="tab-content">
+    <main class="tab-content" id="sidebar-tab-content">
       <?!= include_('sidebar/components/tab-direct-insert') ?>
       <?!= include_('sidebar/components/tab-exact-search') ?>
       <?!= include_('sidebar/components/tab-ai-search') ?>
     </main>
-  </div>
 
-  <div id="settings-overlay" class="settings-overlay hidden">
-    <?!= include_('sidebar/components/settings-panel') ?>
+    <div id="bottom-bar" class="bottom-bar">
+      <?!= include_('sidebar/components/bottom-bar') ?>
+    </div>
+
+    <div id="settings-page" class="settings-page hidden">
+      <?!= include_('sidebar/components/settings-panel') ?>
+    </div>
   </div>
 
   <?!= include_('client/makeClientCache') ?>

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -16,8 +16,8 @@
       <div class="header-brand">
         <button type="button" class="btn-icon hidden" id="btn-new-ai-chat" title="New chat" aria-label="New chat">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-            <path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
-            <path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.506l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/>
+            <rect x="4" y="5" width="12" height="14" rx="2.5" ry="2.5" fill="none"/>
+            <path d="M14.5 3.5L20 9l-7 7H10v-4l7-7z" fill="none"/>
           </svg>
         </button>
       </div>
@@ -42,7 +42,7 @@
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
                 <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
               </svg>
-              <span>Give us feedback</span>
+              <span>Send Feedback</span>
             </button>
           </div>
         </div>

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -302,7 +302,7 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[0]).toBe(fs);
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
     expect(applyFormatCalls[1].fontVariant).toBe('regular');
-    expect(applyFormatCalls[1].fontSize).toBe(11);
+    expect(applyFormatCalls[1].fontSize).toBe(12);
     expect(applyFormatCalls[1].bold).toBe(false);
     expect(applyFormatCalls[1].textColor).toBe('#112233');
   });

--- a/tests/FormatService.test.gs
+++ b/tests/FormatService.test.gs
@@ -59,12 +59,12 @@ function runFormatServiceTests() {
     expect(a.fontName).toBe('Figtree');
     expect(a.bold).toBe(false);
   });
-  it('copies fields; Figtree; regular variant (no Arabic weight); size 80% rounded; never bold', function () {
+  it('copies fields; Figtree; regular variant (no Arabic weight); size 85% of Arabic rounded up; never bold', function () {
     var fs = { fontName: 'Scheherazade New', fontVariant: '700', fontSize: 14, bold: true, textColor: '#000' };
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontName).toBe('Figtree');
     expect(b.fontVariant).toBe('regular');
-    expect(b.fontSize).toBe(11);
+    expect(b.fontSize).toBe(12);
     expect(b.bold).toBe(false);
     expect(b.textColor).toBe('#000');
   });
@@ -73,7 +73,7 @@ function runFormatServiceTests() {
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontVariant).toBe('regular');
   });
-  it('font size floors at 1 when 80% rounds below 1', function () {
+  it('font size floors at 1 when 85% ceil is below 1', function () {
     var fs = { fontName: 'X', fontSize: 1 };
     var b = formatStateForEnglishTranslation(fs);
     expect(b.fontSize).toBe(1);

--- a/tests/SettingsService.test.gs
+++ b/tests/SettingsService.test.gs
@@ -117,6 +117,22 @@ function runSettingsServiceTests() {
     PropertiesService.getUserProperties().deleteProperty('setting_customSwatchColors');
   });
 
+  // ─── getFeedbackFormUrl ───────────────────────────────────────────────────
+
+  results.push('\ngetFeedbackFormUrl()');
+
+  it('returns empty string when feedback_form_url is not set', function () {
+    PropertiesService.getScriptProperties().deleteProperty('feedback_form_url');
+    expect(getFeedbackFormUrl()).toBe('');
+  });
+
+  it('returns script property feedback_form_url when set', function () {
+    var url = 'https://example.com/form';
+    PropertiesService.getScriptProperties().setProperty('feedback_form_url', url);
+    expect(getFeedbackFormUrl()).toBe(url);
+    PropertiesService.getScriptProperties().deleteProperty('feedback_form_url');
+  });
+
   // ─── AI search daily limit ────────────────────────────────────────────────
 
   results.push('\nAI_SEARCH_DAILY_LIMIT');


### PR DESCRIPTION
Closes #97

## Summary
- Complete UI revamp with emerald green CSS design token system (`--color-primary`, spacing, radii, shadows)
- Header: removed logo/title, added 3-dot menu with Settings + Feedback items
- Settings: converted from modal overlay to in-sidebar page with auto-save toggle switch
- Format bar: unified look, font size stepper (+/- by 1) replacing fixed dropdown
- Search tab: inviting welcome state with magnifying glass icon
- AI Search tab: welcome greeting + suggestion chips, query header above results, AI disclaimer
- Bottom bar: Tasneef book logo + GitHub star link
- Browse tab: renamed "Ayah" label to "From"
- Sparkles animation: gentler pulse effect
- New-chat button: only visible on AI tab when conversation active

## Test plan
- [x] All 98 existing tests pass
- [ ] Open sidebar in Google Docs, verify all 3 tabs render correctly
- [ ] Test format bar: font picker, size stepper, bold, color picker
- [ ] Test 3-dot menu opens/closes, Settings page navigates correctly
- [ ] Test settings toggle auto-saves
- [ ] Test AI Search: welcome chips trigger search, query header shows, results render
- [ ] Test Search tab: welcome state shows/hides on typing
- [ ] Test Browse tab: "From" label, ayah selection + preview
- [ ] Verify bottom bar link opens GitHub in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)