### PR TITLE
AI Search UI polish and range ayah NBSP

### DIFF
--- a/sidebar/components/tab-ai-search.html
+++ b/sidebar/components/tab-ai-search.html
@@ -10,14 +10,26 @@
       <button type="button" class="ai-chip" data-query="Duas for guidance">Duas for guidance</button>
     </div>
   </div>
+  <div id="ai-query-bar" class="ai-query-bar hidden" aria-live="polite">
+    <div class="ai-query-bar-main">
+      <span class="ai-query-label">Results for:</span>
+      <span class="ai-query-text" id="ai-query-text"></span>
+    </div>
+    <button type="button" class="btn-icon ai-query-bar-new-chat" id="btn-new-ai-chat-inline" title="New chat" aria-label="New chat">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <rect x="4" y="5" width="12" height="14" rx="2.5" ry="2.5" fill="none"/>
+        <path d="M14.5 3.5L20 9l-7 7H10v-4l7-7z" fill="none"/>
+      </svg>
+    </button>
+  </div>
   <div id="ai-search-results" class="results-list"></div>
   <div id="ai-search-clarify" class="clarify-message hidden"></div>
   <div id="ai-search-empty" class="empty-state hidden"></div>
   <div class="tab-input-area">
-    <div class="tab-input-wrap">
+    <div class="tab-input-wrap tab-input-wrap--composer">
       <textarea id="ai-search-query" rows="2" placeholder="Search themes (e.g., patience, charity)..."></textarea>
       <button type="button" class="btn-send" id="btn-ai-search" title="Send" aria-label="Send">&#10148;</button>
     </div>
-    <p class="ai-disclaimer">AI can make mistakes.</p>
+    <p class="ai-disclaimer">Tasneef uses AI and can make mistakes.</p>
   </div>
 </div>

--- a/sidebar/components/tab-ai-search.html
+++ b/sidebar/components/tab-ai-search.html
@@ -17,8 +17,8 @@
     </div>
     <button type="button" class="btn-icon ai-query-bar-new-chat" id="btn-new-ai-chat-inline" title="New chat" aria-label="New chat">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-        <rect x="4" y="5" width="12" height="14" rx="2.5" ry="2.5" fill="none"/>
-        <path d="M14.5 3.5L20 9l-7 7H10v-4l7-7z" fill="none"/>
+        <rect x="3" y="9" width="12" height="9" rx="2" ry="2"/>
+        <path d="M19 3v8M15 7h8"/>
       </svg>
     </button>
   </div>

--- a/sidebar/js/card-builder.html
+++ b/sidebar/js/card-builder.html
@@ -41,15 +41,16 @@ function isConsecutiveRange(results) {
 
 /**
  * Builds a range data object from an array of consecutive result objects.
- * Concatenates Arabic text with per-ayah markers for display and insert.
+ * Concatenates Arabic text with per-ayah markers for display and insert (U+00A0 before each (ayahNum)).
  * @param {Array<Object>} results - Ordered ayah result objects
  * @return {Object} Range data: { surah, ayahStart, ayahEnd, surahNameArabic, surahNameEnglish, arabicText, translationText }
  */
 function buildRangeData(results) {
   var first = results[0];
   var last  = results[results.length - 1];
+  var nb = '\u00A0';
   var concatenated = results.map(function(r) {
-    return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
+    return r.arabicText + nb + '(' + toArabicIndicClient(r.ayah) + ')';
   }).join(' ');
   return {
     surah:            first.surah,

--- a/sidebar/js/settings-panel-js.html
+++ b/sidebar/js/settings-panel-js.html
@@ -1,7 +1,6 @@
 <script>
 // Depends on globals: _settings, formatState (shared-state.html),
 //   applyFormatStateToUI (format-bar.html)
-// Header "New chat" calls clearAISearch (tab-ai-search-js.html)
 
 var settingsPanelLoadGen = 0;
 
@@ -113,15 +112,8 @@ function initHeaderMenu() {
 // ─── Init ──────────────────────────────────────────────────────────────────
 
 function initSettings() {
-  var btnNewAiChat = document.getElementById('btn-new-ai-chat');
   var btnBack = document.getElementById('btn-settings-back');
 
-  if (btnNewAiChat) {
-    btnNewAiChat.addEventListener('click', function () {
-      if (btnNewAiChat.disabled) return;
-      if (typeof clearAISearch === 'function') clearAISearch();
-    });
-  }
   if (btnBack) {
     btnBack.addEventListener('click', function () {
       hideSettingsPage();

--- a/sidebar/js/tab-ai-search-js.html
+++ b/sidebar/js/tab-ai-search-js.html
@@ -17,16 +17,30 @@ function aiSearchPanelIsDirty() {
   return false;
 }
 
+function showAIQueryBar(queryPlain) {
+  var bar = document.getElementById('ai-query-bar');
+  var textEl = document.getElementById('ai-query-text');
+  if (textEl) textEl.textContent = '\u201c' + (queryPlain || '') + '\u201d';
+  if (bar) bar.classList.remove('hidden');
+}
+
+function hideAIQueryBar() {
+  var bar = document.getElementById('ai-query-bar');
+  var textEl = document.getElementById('ai-query-text');
+  if (bar) bar.classList.add('hidden');
+  if (textEl) textEl.textContent = '';
+}
+
 function updateNewChatVisibility() {
-  var btn = document.getElementById('btn-new-ai-chat');
+  var btn = document.getElementById('btn-new-ai-chat-inline');
+  var queryEl = document.getElementById('ai-search-query');
   if (!btn) return;
   if (window._activeTab !== 'ai-search') {
-    btn.classList.add('hidden');
     btn.disabled = false;
     return;
   }
-  btn.classList.remove('hidden');
-  btn.disabled = !aiSearchPanelIsDirty();
+  var loading = queryEl && queryEl.disabled;
+  btn.disabled = loading || !aiSearchPanelIsDirty();
 }
 
 function showAIWelcome() {
@@ -42,12 +56,14 @@ function hideAIWelcome() {
 function initAISearchTab() {
   var queryEl = document.getElementById('ai-search-query');
   var btnSend = document.getElementById('btn-ai-search');
+  var btnNewInline = document.getElementById('btn-new-ai-chat-inline');
   var resultsEl = document.getElementById('ai-search-results');
   var clarifyEl = document.getElementById('ai-search-clarify');
   var emptyEl = document.getElementById('ai-search-empty');
   function setEnabled(enabled) {
     if (btnSend) btnSend.disabled = !enabled;
     if (queryEl) queryEl.disabled = !enabled;
+    updateNewChatVisibility();
   }
 
   function clearAIResults() {
@@ -76,12 +92,8 @@ function initAISearchTab() {
 
     hideAIWelcome();
     clearAIResults();
-
-    // Show query header + skeleton
-    var headerDiv = document.createElement('div');
-    headerDiv.className = 'ai-query-header';
-    headerDiv.innerHTML = '<span class="ai-query-label">Results for</span> <span class="ai-query-text">\u201c' + query.replace(/[<>&"]/g, function (c) { return '&#' + c.charCodeAt(0) + ';'; }) + '\u201d</span>';
-    resultsEl.appendChild(headerDiv);
+    showAIQueryBar(query);
+    updateNewChatVisibility();
 
     var skeletonDiv = document.createElement('div');
     skeletonDiv.id = 'ai-skeleton';
@@ -194,6 +206,13 @@ function initAISearchTab() {
     });
   }
 
+  if (btnNewInline) {
+    btnNewInline.addEventListener('click', function () {
+      if (btnNewInline.disabled) return;
+      if (typeof clearAISearch === 'function') clearAISearch();
+    });
+  }
+
   window.setupTextarea(queryEl, doAISearch);
   if (btnSend) btnSend.addEventListener('click', doAISearch);
   if (resultsEl) resultsEl.addEventListener('click', onInsertClick);
@@ -211,6 +230,7 @@ function clearAISearch() {
   if (resultsEl) resultsEl.innerHTML = '';
   if (clarifyEl) { clarifyEl.classList.add('hidden'); clarifyEl.textContent = ''; }
   if (emptyEl) { emptyEl.classList.add('hidden'); emptyEl.textContent = ''; }
+  hideAIQueryBar();
   showAIWelcome();
   updateNewChatVisibility();
 }

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -580,6 +580,38 @@
   .tab-input-wrap { display: flex; align-items: flex-end; gap: var(--space-sm); }
   .tab-input-wrap textarea { flex: 1; padding: 10px 12px; border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: 13px; font-family: inherit; resize: none; line-height: 1.4; min-height: 40px; max-height: 120px; overflow-y: auto; }
   .tab-input-wrap textarea:focus { outline: none; border-color: var(--color-primary); }
+  /* AI Search: send inside bordered composer */
+  #panel-ai-search .tab-input-wrap--composer {
+    position: relative;
+    align-items: stretch;
+    gap: 0;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-bg);
+    transition: border-color var(--transition-fast);
+  }
+  #panel-ai-search .tab-input-wrap--composer:focus-within {
+    border-color: var(--color-primary);
+  }
+  #panel-ai-search .tab-input-wrap--composer textarea {
+    flex: 1;
+    min-height: 44px;
+    max-height: 120px;
+    padding: 10px 44px 10px 12px;
+    border: none;
+    border-radius: var(--radius-lg);
+    background: transparent;
+    resize: none;
+  }
+  #panel-ai-search .tab-input-wrap--composer textarea:focus { outline: none; border-color: transparent; }
+  #panel-ai-search .tab-input-wrap--composer .btn-send {
+    position: absolute;
+    right: 6px;
+    bottom: 6px;
+    width: 32px;
+    height: 32px;
+    font-size: 14px;
+  }
   .btn-send { width: 36px; height: 36px; border: none; background: var(--color-primary); color: #fff; border-radius: 50%; font-size: 16px; cursor: pointer; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
   .btn-send:hover { background: var(--color-primary-hover); }
   .btn-send:disabled { background: var(--color-primary); opacity: 0.4; cursor: not-allowed; }
@@ -667,10 +699,21 @@
   }
   .ai-chip:hover { background: var(--color-primary-light); border-color: var(--color-primary); color: var(--color-primary); }
 
-  /* AI query header */
-  .ai-query-header { padding: 0 0 var(--space-sm); margin-bottom: var(--space-sm); }
+  /* AI query bar (above results; not cleared by pagination) */
+  .ai-query-bar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    flex-shrink: 0;
+    padding: var(--space-sm) var(--space-lg) 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .ai-query-bar-main { min-width: 0; flex: 1; }
   .ai-query-label { font-size: 11px; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-  .ai-query-text { font-size: 13px; color: var(--color-text-primary); font-weight: 500; margin-left: var(--space-xs); }
+  .ai-query-text { display: block; font-size: 13px; color: var(--color-text-primary); font-weight: 500; margin-top: 2px; word-break: break-word; }
+  .ai-query-bar-new-chat { flex-shrink: 0; margin-top: -2px; color: var(--color-text-secondary); }
+  .ai-query-bar-new-chat:hover:not(:disabled) { color: var(--color-primary); }
 
   /* AI disclaimer */
   .ai-disclaimer {

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -439,8 +439,8 @@
   }
 
   /* ─── Tab Navigation ──────────────────────────────────────────────────────── */
-  .tab-nav { display: flex; border-bottom: 2px solid var(--color-border); flex-shrink: 0; padding: 0 var(--space-sm); }
-  .tab-btn { flex: 1 1 0; min-width: 0; padding: 10px var(--space-xs); border: none; background: none; font-size: 13px; font-weight: 500; color: var(--color-text-secondary); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -2px; transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast); border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
+  .tab-nav { display: flex; gap: 3px; border-bottom: 2px solid var(--color-border); flex-shrink: 0; padding: 0 var(--space-md); }
+  .tab-btn { flex: 1 1 0; min-width: 0; padding: 12px var(--space-sm); border: none; background: none; font-size: 13px; font-weight: 500; color: var(--color-text-secondary); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -2px; transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast); border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
   .tab-btn:hover { color: var(--color-primary); background: var(--color-primary-lighter); }
   .tab-btn.active { color: var(--color-primary); border-bottom-color: var(--color-primary); background: var(--color-primary-light); }
 
@@ -450,7 +450,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    gap: 3px;
+    gap: 7px;
     white-space: nowrap;
   }
   .tab-btn--ai .tab-btn-ai-icon {

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -13,14 +13,7 @@
     </div>
 
     <header class="header" id="sidebar-header">
-      <div class="header-brand">
-        <button type="button" class="btn-icon hidden" id="btn-new-ai-chat" title="New chat" aria-label="New chat">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-            <rect x="4" y="5" width="12" height="14" rx="2.5" ry="2.5" fill="none"/>
-            <path d="M14.5 3.5L20 9l-7 7H10v-4l7-7z" fill="none"/>
-          </svg>
-        </button>
-      </div>
+      <div class="header-brand"></div>
       <div class="header-actions">
         <div class="header-menu" id="header-menu">
           <button type="button" class="btn-icon" id="btn-header-menu" title="Menu" aria-label="Menu" aria-haspopup="true" aria-expanded="false">

--- a/tests/buildResultCardHtml.test.js
+++ b/tests/buildResultCardHtml.test.js
@@ -95,8 +95,9 @@ function isConsecutiveRange(results) {
 function buildRangeData(results) {
   var first = results[0];
   var last  = results[results.length - 1];
+  var nb = '\u00A0';
   var concatenated = results.map(function(r) {
-    return r.arabicText + ' (' + toArabicIndicClient(r.ayah) + ')';
+    return r.arabicText + nb + '(' + toArabicIndicClient(r.ayah) + ')';
   }).join(' ');
   return {
     surah:            first.surah,
@@ -361,6 +362,7 @@ function runTests() {
     assert.ok(data.arabicText.indexOf('الحمد لله') >= 0, 'second ayah text present');
     assert.ok(data.arabicText.indexOf(toArabicIndicClient(1)) >= 0, 'ayah 1 marker present');
     assert.ok(data.arabicText.indexOf(toArabicIndicClient(2)) >= 0, 'ayah 2 marker present');
+    assert.ok(data.arabicText.indexOf('\u00A0(') >= 0, 'NBSP before each ayah-number parenthesis');
   });
 
   it('joins translationText for all ayahs', function () {


### PR DESCRIPTION
Closes #99

- AI Search: send control inside bordered composer; disclaimer copy; persistent **Results for:** row above paginated results with inline New chat (header duplicate removed).
- Range cards / insert: U+00A0 immediately before each parenthesized ayah number in `buildRangeData`.

Tests: `npm test`