### PR TITLE
Paragraph spacing and split citation paragraphs on doc insert

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -3,6 +3,11 @@
  * Inserts Quranic ayat into Google Docs with formatting.
  */
 
+/** Space (pt) before the Arabic ayah paragraph on insert. */
+var INSERT_SPACE_BEFORE_ARABIC_PT = 12;
+/** Space (pt) between Arabic ayah and English translation when both are inserted. */
+var INSERT_SPACE_ARABIC_TO_TRANSLATION_PT = 6;
+
 /**
  * Determines the insertion index and inserts paragraphs at the correct position.
  * Shared by insertAyah and insertAyahRange.
@@ -20,7 +25,7 @@
  *
  * @param {Body} body - The document body
  * @param {Document} doc - The active document
- * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, useEnglishTranslationFont? }
+ * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, useEnglishTranslationFont?, spacingBefore?, spacingAfter? } (spacing in pt; omit keys to leave Doc defaults)
  * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @return {Object} { fontWarning: string|null }
  */
@@ -79,6 +84,12 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
     }
     p.setAlignment(item.align);
     p.setLeftToRight(item.rtl ? false : true);
+    if (typeof item.spacingBefore === 'number') {
+      p.setSpacingBefore(item.spacingBefore);
+    }
+    if (typeof item.spacingAfter === 'number') {
+      p.setSpacingAfter(item.spacingAfter);
+    }
     var fs = item.useEnglishTranslationFont
       ? formatStateForEnglishTranslation(formatState)
       : formatState;
@@ -141,16 +152,29 @@ function insertAyah(ayahData, formatState, settings) {
     paragraphsToInsert.push({
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      rtl: true
+      rtl: true,
+      spacingBefore: INSERT_SPACE_BEFORE_ARABIC_PT,
+      spacingAfter: INSERT_SPACE_ARABIC_TO_TRANSLATION_PT
     });
     paragraphsToInsert.push({
-      text: '\u201C' + translationText + '\u201D (' + surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah + ')',
+      text: '\u201C' + translationText + '\u201D',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      useEnglishTranslationFont: true
+    });
+    paragraphsToInsert.push({
+      text: '(' + surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true
     });
   } else {
     paragraphsToInsert.push({
-      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' + surahNameAr + ':' + qNbsp + ayahNumAr + ']',
+      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true,
+      spacingBefore: INSERT_SPACE_BEFORE_ARABIC_PT
+    });
+    paragraphsToInsert.push({
+      text: '[' + surahNameAr + ':' + qNbsp + ayahNumAr + ']',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true
     });
@@ -191,19 +215,30 @@ function insertAyahRange(rangeData, formatState, settings) {
     paragraphsToInsert.push({
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      rtl: true
+      rtl: true,
+      spacingBefore: INSERT_SPACE_BEFORE_ARABIC_PT,
+      spacingAfter: INSERT_SPACE_ARABIC_TO_TRANSLATION_PT
     });
     paragraphsToInsert.push({
-      text: '\u201C' + translationText + '\u201D (' +
-            surahNameEn + qNbsp + rangeData.surah + ':' +
+      text: '\u201C' + translationText + '\u201D',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      useEnglishTranslationFont: true
+    });
+    paragraphsToInsert.push({
+      text: '(' + surahNameEn + qNbsp + rangeData.surah + ':' +
             rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true
     });
   } else {
     paragraphsToInsert.push({
-      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' +
-            surahNameAr + ':' + qNbsp + ayahStartAr + qNbsp + '-' + qNbsp + ayahEndAr + ']',
+      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true,
+      spacingBefore: INSERT_SPACE_BEFORE_ARABIC_PT
+    });
+    paragraphsToInsert.push({
+      text: '[' + surahNameAr + ':' + qNbsp + ayahStartAr + qNbsp + '-' + qNbsp + ayahEndAr + ']',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true
     });

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -166,6 +166,12 @@ function insertAyah(ayahData, formatState, settings) {
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true
     });
+  } else if (showTranslation) {
+    paragraphsToInsert.push({
+      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' + surahNameAr + ':' + qNbsp + ayahNumAr + ']',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true
+    });
   } else {
     paragraphsToInsert.push({
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
@@ -229,6 +235,13 @@ function insertAyahRange(rangeData, formatState, settings) {
             rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true
+    });
+  } else if (showTranslation) {
+    paragraphsToInsert.push({
+      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' +
+            surahNameAr + ':' + qNbsp + ayahStartAr + qNbsp + '-' + qNbsp + ayahEndAr + ']',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true
     });
   } else {
     paragraphsToInsert.push({

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -44,11 +44,15 @@ function runDocumentServiceTests() {
       _align: null,
       _ltr: null,
       _heading: null,
+      _spacingBefore: null,
+      _spacingAfter: null,
       getText: function () { return this._text; },
       setText: function (t) { this._text = t; },
       setAlignment: function (a) { this._align = a; },
       setLeftToRight: function (v) { this._ltr = v; },
       setHeading: function (h) { this._heading = h; },
+      setSpacingBefore: function (pt) { this._spacingBefore = pt; },
+      setSpacingAfter: function (pt) { this._spacingAfter = pt; },
       getType: function () { return DocumentApp.ElementType.PARAGRAPH; },
       asParagraph: function () { return this; },
       getParent: function () { return null; },
@@ -123,12 +127,35 @@ function runDocumentServiceTests() {
       {
         text: '\uFD3F\u00A0arabic\u00A0\uFD3E',
         align: DocumentApp.HorizontalAlignment.CENTER,
-        rtl: true
+        rtl: true,
+        spacingBefore: INSERT_SPACE_BEFORE_ARABIC_PT,
+        spacingAfter: INSERT_SPACE_ARABIC_TO_TRANSLATION_PT
       },
       {
-        text: '"translation" (Al-Fatiha\u00A01:1)',
+        text: '"translation"',
         align: DocumentApp.HorizontalAlignment.CENTER,
         useEnglishTranslationFont: true
+      },
+      {
+        text: '(Al-Fatiha\u00A01:1)',
+        align: DocumentApp.HorizontalAlignment.CENTER,
+        useEnglishTranslationFont: true
+      }
+    ];
+  }
+
+  function arabicOnlyTwoParagraphs() {
+    return [
+      {
+        text: '\uFD3F\u00A0ayah\u00A0\uFD3E',
+        align: DocumentApp.HorizontalAlignment.CENTER,
+        rtl: true,
+        spacingBefore: INSERT_SPACE_BEFORE_ARABIC_PT
+      },
+      {
+        text: '[\u0627\u0644\u0641\u0627\u062a\u062d\u0629:\u0661]',
+        align: DocumentApp.HorizontalAlignment.CENTER,
+        rtl: true
       }
     ];
   }
@@ -298,46 +325,80 @@ function runDocumentServiceTests() {
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), fs);
 
-    expect(applyFormatCalls.length).toBe(2);
+    expect(applyFormatCalls.length).toBe(3);
     expect(applyFormatCalls[0]).toBe(fs);
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
     expect(applyFormatCalls[1].fontVariant).toBe('regular');
     expect(applyFormatCalls[1].fontSize).toBe(12);
     expect(applyFormatCalls[1].bold).toBe(false);
     expect(applyFormatCalls[1].textColor).toBe('#112233');
+    expect(applyFormatCalls[2].fontName).toBe('Figtree');
+    expect(applyFormatCalls[2].fontVariant).toBe('regular');
+    expect(applyFormatCalls[2].fontSize).toBe(12);
+    expect(applyFormatCalls[2].bold).toBe(false);
+    expect(applyFormatCalls[2].textColor).toBe('#112233');
   });
 
-  it('two content paragraphs at end — both inserted, cleanup follows', function () {
+  it('three content paragraphs at end — all inserted, cleanup follows', function () {
     var body = createMockBody(['existing']);
     var cursorPara = body._children[0];
     var doc = createMockDoc(body, cursorPara);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, arabic, translation, cleanup]
-    expect(body._children.length).toBe(4);
+    // [existing, arabic, translation, citation, cleanup]
+    expect(body._children.length).toBe(5);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[1]._ltr).toBe(false);
-    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
+    expect(body._children[2]._text).toBe('"translation"');
     expect(body._children[2]._ltr).toBe(true);
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
     expect(body._children[3]._ltr).toBe(true);
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._ltr).toBe(true);
   });
 
-  it('two content paragraphs with content after — NO cleanup', function () {
+  it('three content paragraphs with content after — NO cleanup', function () {
     var body = createMockBody(['existing', 'after']);
     var cursorPara = body._children[0];
     var doc = createMockDoc(body, cursorPara);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, arabic, translation, after] — no cleanup
-    expect(body._children.length).toBe(4);
+    // [existing, arabic, translation, citation, after] — no cleanup
+    expect(body._children.length).toBe(5);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
-    expect(body._children[3]._text).toBe('after');
-    expect(body._children[3]._heading).toBe(null);
+    expect(body._children[2]._text).toBe('"translation"');
+    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[4]._text).toBe('after');
+    expect(body._children[4]._heading).toBe(null);
+  });
+
+  it('payload spacingBefore and spacingAfter are applied to paragraphs', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+
+    insertParagraphsAtPosition_(body, doc, arabicOnlyTwoParagraphs(), {});
+
+    expect(body._children[0]._spacingBefore).toBe(INSERT_SPACE_BEFORE_ARABIC_PT);
+    expect(body._children[0]._spacingAfter).toBe(null);
+    expect(body._children[1]._spacingBefore).toBe(null);
+    expect(body._children[1]._spacingAfter).toBe(null);
+  });
+
+  it('Arabic + translation: Arabic has before and after spacing; citation has no trailing spacing', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+
+    insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
+
+    expect(body._children[0]._spacingBefore).toBe(INSERT_SPACE_BEFORE_ARABIC_PT);
+    expect(body._children[0]._spacingAfter).toBe(INSERT_SPACE_ARABIC_TO_TRANSLATION_PT);
+    expect(body._children[1]._spacingBefore).toBe(null);
+    expect(body._children[1]._spacingAfter).toBe(null);
+    expect(body._children[2]._spacingBefore).toBe(null);
+    expect(body._children[2]._spacingAfter).toBe(null);
   });
 
   results.push('\ninsertParagraphsAtPosition_() — regression: sequential insertion & removeChild');
@@ -350,23 +411,25 @@ function runDocumentServiceTests() {
     // First insert: Arabic + translation into empty doc
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // After first insert: [arabic, translation, cleanup]
-    expect(body._children.length).toBe(3);
+    // After first insert: [arabic, translation, citation, cleanup]
+    expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[1]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
-    expect(body._children[2]._text).toBe('');
+    expect(body._children[1]._text).toBe('"translation"');
+    expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[3]._text).toBe('');
 
     // Second insert: cursor on cleanup (empty paragraph at end)
-    var cleanup = body._children[2];
+    var cleanup = body._children[3];
     var doc2 = createMockDoc(body, cleanup);
     insertParagraphsAtPosition_(body, doc2, singleArabicParagraph(), {});
 
-    // [arabic1, translation1, arabic2, cleanup2]
-    expect(body._children.length).toBe(4);
+    // [arabic1, translation1, citation1, arabic2, cleanup2]
+    expect(body._children.length).toBe(5);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[1]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('');
+    expect(body._children[1]._text).toBe('"translation"');
+    expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('');
   });
 
   it('empty paragraph reuse avoids removeChild entirely', function () {


### PR DESCRIPTION
Closes #105

Summary:
- `insertParagraphsAtPosition_` accepts optional `spacingBefore` / `spacingAfter` (pt).
- Arabic-only (translation off): two paragraphs, 12pt before ayah; citation on its own line; no spacing after citation.
- Translation on with text: three paragraphs; 12pt before Arabic, 6pt after Arabic; translation and English citation separate; no spacing after citation.
- Translation on but empty translation text: unchanged single-paragraph insert.

Made with [Cursor](https://cursor.com)