### PR TITLE
Paragraph spacing and beautified Quran inserts

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -24,7 +24,7 @@ var INSERT_SPACING_INNER_PT = 6;
  *
  * @param {Body} body - The document body
  * @param {Document} doc - The active document
- * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, useEnglishTranslationFont?, spacingBefore?, spacingAfter? } (spacing in pt; optional)
+ * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, useEnglishTranslationFont?, spacingBefore?, spacingAfter?, fontSizeAdjustPt? } (spacing in pt; fontSizeAdjustPt e.g. -1 for citation one pt smaller)
  * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @return {Object} { fontWarning: string|null }
  */
@@ -86,6 +86,9 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
     var fs = item.useEnglishTranslationFont
       ? formatStateForEnglishTranslation(formatState)
       : formatState;
+    if (item.fontSizeAdjustPt != null && item.fontSizeAdjustPt !== 0) {
+      fs = formatStateWithFontSizeAdjustment(fs, item.fontSizeAdjustPt);
+    }
     fontWarning = applyFormat(p.editAsText(), fs) || fontWarning;
     if (item.spacingBefore != null) {
       p.setSpacingBefore(item.spacingBefore);
@@ -167,7 +170,8 @@ function insertAyah(ayahData, formatState, settings) {
       text: '(' + surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true,
-      spacingAfter: INSERT_SPACING_OUTER_PT
+      spacingAfter: INSERT_SPACING_OUTER_PT,
+      fontSizeAdjustPt: -1
     });
   } else {
     paragraphsToInsert.push({
@@ -181,7 +185,8 @@ function insertAyah(ayahData, formatState, settings) {
       text: '[' + surahNameAr + ':' + qNbsp + ayahNumAr + ']',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true,
-      spacingAfter: INSERT_SPACING_OUTER_PT
+      spacingAfter: INSERT_SPACING_OUTER_PT,
+      fontSizeAdjustPt: -1
     });
   }
 
@@ -235,7 +240,8 @@ function insertAyahRange(rangeData, formatState, settings) {
             rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
       useEnglishTranslationFont: true,
-      spacingAfter: INSERT_SPACING_OUTER_PT
+      spacingAfter: INSERT_SPACING_OUTER_PT,
+      fontSizeAdjustPt: -1
     });
   } else {
     paragraphsToInsert.push({
@@ -249,7 +255,8 @@ function insertAyahRange(rangeData, formatState, settings) {
       text: '[' + surahNameAr + ':' + qNbsp + ayahStartAr + qNbsp + '-' + qNbsp + ayahEndAr + ']',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true,
-      spacingAfter: INSERT_SPACING_OUTER_PT
+      spacingAfter: INSERT_SPACING_OUTER_PT,
+      fontSizeAdjustPt: -1
     });
   }
 

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -3,6 +3,10 @@
  * Inserts Quranic ayat into Google Docs with formatting.
  */
 
+/** Paragraph spacing (points) for beautified insert blocks: outer margin, gap between inner paragraphs. */
+var INSERT_SPACING_OUTER_PT = 12;
+var INSERT_SPACING_INNER_PT = 6;
+
 /**
  * Determines the insertion index and inserts paragraphs at the correct position.
  * Shared by insertAyah and insertAyahRange.
@@ -20,7 +24,7 @@
  *
  * @param {Body} body - The document body
  * @param {Document} doc - The active document
- * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, useEnglishTranslationFont? }
+ * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, useEnglishTranslationFont?, spacingBefore?, spacingAfter? } (spacing in pt; optional)
  * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @return {Object} { fontWarning: string|null }
  */
@@ -83,6 +87,12 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
       ? formatStateForEnglishTranslation(formatState)
       : formatState;
     fontWarning = applyFormat(p.editAsText(), fs) || fontWarning;
+    if (item.spacingBefore != null) {
+      p.setSpacingBefore(item.spacingBefore);
+    }
+    if (item.spacingAfter != null) {
+      p.setSpacingAfter(item.spacingAfter);
+    }
   }
 
   var lastInsertedIndex = insertIndex + paragraphsToInsert.length - 1;
@@ -93,6 +103,8 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
     var cleanup = body.insertParagraph(lastInsertedIndex + 1, '');
     cleanup.setHeading(DocumentApp.ParagraphHeading.NORMAL);
     cleanup.setLeftToRight(true);
+    cleanup.setSpacingBefore(0);
+    cleanup.setSpacingAfter(0);
     cursorTarget = cleanup;
   } else {
     cursorTarget = body.getChild(lastInsertedIndex).asParagraph();
@@ -141,18 +153,35 @@ function insertAyah(ayahData, formatState, settings) {
     paragraphsToInsert.push({
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      rtl: true
+      rtl: true,
+      spacingBefore: INSERT_SPACING_OUTER_PT,
+      spacingAfter: INSERT_SPACING_INNER_PT
     });
     paragraphsToInsert.push({
-      text: '\u201C' + translationText + '\u201D (' + surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah + ')',
+      text: '\u201C' + translationText + '\u201D',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      useEnglishTranslationFont: true
+      useEnglishTranslationFont: true,
+      spacingAfter: INSERT_SPACING_INNER_PT
+    });
+    paragraphsToInsert.push({
+      text: '(' + surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah + ')',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      useEnglishTranslationFont: true,
+      spacingAfter: INSERT_SPACING_OUTER_PT
     });
   } else {
     paragraphsToInsert.push({
-      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' + surahNameAr + ':' + qNbsp + ayahNumAr + ']',
+      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      rtl: true
+      rtl: true,
+      spacingBefore: INSERT_SPACING_OUTER_PT,
+      spacingAfter: INSERT_SPACING_INNER_PT
+    });
+    paragraphsToInsert.push({
+      text: '[' + surahNameAr + ':' + qNbsp + ayahNumAr + ']',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true,
+      spacingAfter: INSERT_SPACING_OUTER_PT
     });
   }
 
@@ -191,21 +220,36 @@ function insertAyahRange(rangeData, formatState, settings) {
     paragraphsToInsert.push({
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      rtl: true
+      rtl: true,
+      spacingBefore: INSERT_SPACING_OUTER_PT,
+      spacingAfter: INSERT_SPACING_INNER_PT
     });
     paragraphsToInsert.push({
-      text: '\u201C' + translationText + '\u201D (' +
-            surahNameEn + qNbsp + rangeData.surah + ':' +
+      text: '\u201C' + translationText + '\u201D',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      useEnglishTranslationFont: true,
+      spacingAfter: INSERT_SPACING_INNER_PT
+    });
+    paragraphsToInsert.push({
+      text: '(' + surahNameEn + qNbsp + rangeData.surah + ':' +
             rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      useEnglishTranslationFont: true
+      useEnglishTranslationFont: true,
+      spacingAfter: INSERT_SPACING_OUTER_PT
     });
   } else {
     paragraphsToInsert.push({
-      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E [' +
-            surahNameAr + ':' + qNbsp + ayahStartAr + qNbsp + '-' + qNbsp + ayahEndAr + ']',
+      text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
-      rtl: true
+      rtl: true,
+      spacingBefore: INSERT_SPACING_OUTER_PT,
+      spacingAfter: INSERT_SPACING_INNER_PT
+    });
+    paragraphsToInsert.push({
+      text: '[' + surahNameAr + ':' + qNbsp + ayahStartAr + qNbsp + '-' + qNbsp + ayahEndAr + ']',
+      align: DocumentApp.HorizontalAlignment.CENTER,
+      rtl: true,
+      spacingAfter: INSERT_SPACING_OUTER_PT
     });
   }
 

--- a/FormatService.js
+++ b/FormatService.js
@@ -40,6 +40,29 @@ function formatStateForEnglishTranslation(formatState) {
 }
 
 /**
+ * Shallow copy of formatState with fontSize shifted by deltaPt (points), floored at 1.
+ * If fontSize is missing or not a finite number, returns a copy without changing fontSize.
+ * @param {Object|null|undefined} formatState
+ * @param {number} deltaPt e.g. -1 for one point smaller
+ * @return {Object}
+ */
+function formatStateWithFontSizeAdjustment(formatState, deltaPt) {
+  if (!formatState || deltaPt == null || deltaPt === 0) {
+    return formatState;
+  }
+  var out = {};
+  for (var k in formatState) {
+    if (Object.prototype.hasOwnProperty.call(formatState, k)) {
+      out[k] = formatState[k];
+    }
+  }
+  if (out.fontSize != null && !isNaN(Number(out.fontSize))) {
+    out.fontSize = Math.max(1, Number(out.fontSize) + deltaPt);
+  }
+  return out;
+}
+
+/**
  * Builds the font family string Google Docs accepts for weighted Google Fonts.
  * @param {string} family
  * @param {number} weight

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -141,7 +141,8 @@ function runDocumentServiceTests() {
         text: '(Al-Fatiha\u00A01:1)',
         align: DocumentApp.HorizontalAlignment.CENTER,
         useEnglishTranslationFont: true,
-        spacingAfter: INSERT_SPACING_OUTER_PT
+        spacingAfter: INSERT_SPACING_OUTER_PT,
+        fontSizeAdjustPt: -1
       }
     ];
   }
@@ -159,7 +160,8 @@ function runDocumentServiceTests() {
         text: '[\u0633\u0648\u0631\u0629:\u0661]',
         align: DocumentApp.HorizontalAlignment.CENTER,
         rtl: true,
-        spacingAfter: INSERT_SPACING_OUTER_PT
+        spacingAfter: INSERT_SPACING_OUTER_PT,
+        fontSizeAdjustPt: -1
       }
     ];
   }
@@ -362,9 +364,27 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[1].textColor).toBe('#112233');
     expect(applyFormatCalls[2].fontName).toBe('Figtree');
     expect(applyFormatCalls[2].fontVariant).toBe('regular');
-    expect(applyFormatCalls[2].fontSize).toBe(12);
+    expect(applyFormatCalls[2].fontSize).toBe(11);
     expect(applyFormatCalls[2].bold).toBe(false);
     expect(applyFormatCalls[2].textColor).toBe('#112233');
+  });
+
+  it('Arabic citation paragraph is one point smaller than ayah', function () {
+    applyFormatCalls = [];
+    applyFormatReturnValue = null;
+    var fs = {
+      fontName: 'Amiri',
+      fontVariant: 'regular',
+      fontSize: 16,
+      bold: false,
+      textColor: '#000000'
+    };
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, arabicOnlyAyahAndCitation(), fs);
+    expect(applyFormatCalls.length).toBe(2);
+    expect(applyFormatCalls[0].fontSize).toBe(16);
+    expect(applyFormatCalls[1].fontSize).toBe(15);
   });
 
   it('three content paragraphs at end — all inserted, cleanup follows', function () {

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -44,11 +44,15 @@ function runDocumentServiceTests() {
       _align: null,
       _ltr: null,
       _heading: null,
+      _spacingBefore: null,
+      _spacingAfter: null,
       getText: function () { return this._text; },
       setText: function (t) { this._text = t; },
       setAlignment: function (a) { this._align = a; },
       setLeftToRight: function (v) { this._ltr = v; },
       setHeading: function (h) { this._heading = h; },
+      setSpacingBefore: function (pt) { this._spacingBefore = pt; },
+      setSpacingAfter: function (pt) { this._spacingAfter = pt; },
       getType: function () { return DocumentApp.ElementType.PARAGRAPH; },
       asParagraph: function () { return this; },
       getParent: function () { return null; },
@@ -123,12 +127,39 @@ function runDocumentServiceTests() {
       {
         text: '\uFD3F\u00A0arabic\u00A0\uFD3E',
         align: DocumentApp.HorizontalAlignment.CENTER,
-        rtl: true
+        rtl: true,
+        spacingBefore: INSERT_SPACING_OUTER_PT,
+        spacingAfter: INSERT_SPACING_INNER_PT
       },
       {
-        text: '"translation" (Al-Fatiha\u00A01:1)',
+        text: '"translation"',
         align: DocumentApp.HorizontalAlignment.CENTER,
-        useEnglishTranslationFont: true
+        useEnglishTranslationFont: true,
+        spacingAfter: INSERT_SPACING_INNER_PT
+      },
+      {
+        text: '(Al-Fatiha\u00A01:1)',
+        align: DocumentApp.HorizontalAlignment.CENTER,
+        useEnglishTranslationFont: true,
+        spacingAfter: INSERT_SPACING_OUTER_PT
+      }
+    ];
+  }
+
+  function arabicOnlyAyahAndCitation() {
+    return [
+      {
+        text: '\uFD3F\u00A0ayah\u00A0\uFD3E',
+        align: DocumentApp.HorizontalAlignment.CENTER,
+        rtl: true,
+        spacingBefore: INSERT_SPACING_OUTER_PT,
+        spacingAfter: INSERT_SPACING_INNER_PT
+      },
+      {
+        text: '[\u0633\u0648\u0631\u0629:\u0661]',
+        align: DocumentApp.HorizontalAlignment.CENTER,
+        rtl: true,
+        spacingAfter: INSERT_SPACING_OUTER_PT
       }
     ];
   }
@@ -269,6 +300,30 @@ function runDocumentServiceTests() {
     expect(body._children[2]._heading).toBe(null);
   });
 
+  results.push('\ninsertParagraphsAtPosition_() — paragraph spacing (insert beautify)');
+
+  it('Arabic-only two-paragraph block applies 12/6/12 pt spacing', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, arabicOnlyAyahAndCitation(), {});
+    expect(body._children[0]._spacingBefore).toBe(INSERT_SPACING_OUTER_PT);
+    expect(body._children[0]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
+    expect(body._children[1]._spacingBefore).toBe(null);
+    expect(body._children[1]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
+  });
+
+  it('Arabic + translation three-paragraph block applies outer and inner spacing', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
+    expect(body._children[0]._spacingBefore).toBe(INSERT_SPACING_OUTER_PT);
+    expect(body._children[0]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
+    expect(body._children[1]._spacingBefore).toBe(null);
+    expect(body._children[1]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
+    expect(body._children[2]._spacingBefore).toBe(null);
+    expect(body._children[2]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
+  });
+
   results.push('\ninsertParagraphsAtPosition_() — multi-paragraph & font warning');
 
   it('font warning is propagated from applyFormat', function () {
@@ -298,75 +353,87 @@ function runDocumentServiceTests() {
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), fs);
 
-    expect(applyFormatCalls.length).toBe(2);
+    expect(applyFormatCalls.length).toBe(3);
     expect(applyFormatCalls[0]).toBe(fs);
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
     expect(applyFormatCalls[1].fontVariant).toBe('regular');
     expect(applyFormatCalls[1].fontSize).toBe(12);
     expect(applyFormatCalls[1].bold).toBe(false);
     expect(applyFormatCalls[1].textColor).toBe('#112233');
+    expect(applyFormatCalls[2].fontName).toBe('Figtree');
+    expect(applyFormatCalls[2].fontVariant).toBe('regular');
+    expect(applyFormatCalls[2].fontSize).toBe(12);
+    expect(applyFormatCalls[2].bold).toBe(false);
+    expect(applyFormatCalls[2].textColor).toBe('#112233');
   });
 
-  it('two content paragraphs at end — both inserted, cleanup follows', function () {
+  it('three content paragraphs at end — all inserted, cleanup follows', function () {
     var body = createMockBody(['existing']);
     var cursorPara = body._children[0];
     var doc = createMockDoc(body, cursorPara);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, arabic, translation, cleanup]
-    expect(body._children.length).toBe(4);
+    // [existing, arabic, translation, citation, cleanup]
+    expect(body._children.length).toBe(5);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[1]._ltr).toBe(false);
-    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
+    expect(body._children[2]._text).toBe('"translation"');
     expect(body._children[2]._ltr).toBe(true);
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
     expect(body._children[3]._ltr).toBe(true);
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._ltr).toBe(true);
+    expect(body._children[4]._spacingBefore).toBe(0);
+    expect(body._children[4]._spacingAfter).toBe(0);
   });
 
-  it('two content paragraphs with content after — NO cleanup', function () {
+  it('three content paragraphs with content after — NO cleanup', function () {
     var body = createMockBody(['existing', 'after']);
     var cursorPara = body._children[0];
     var doc = createMockDoc(body, cursorPara);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, arabic, translation, after] — no cleanup
-    expect(body._children.length).toBe(4);
+    // [existing, arabic, translation, citation, after] — no cleanup
+    expect(body._children.length).toBe(5);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
-    expect(body._children[3]._text).toBe('after');
-    expect(body._children[3]._heading).toBe(null);
+    expect(body._children[2]._text).toBe('"translation"');
+    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[4]._text).toBe('after');
+    expect(body._children[4]._heading).toBe(null);
   });
 
   results.push('\ninsertParagraphsAtPosition_() — regression: sequential insertion & removeChild');
 
-  it('sequential insert: second insertion goes AFTER translation, not between', function () {
+  it('sequential insert: second insertion goes AFTER citation, not between', function () {
     var body = createMockBody(['']);
     var emptyPara = body._children[0];
     var doc = createMockDoc(body, emptyPara);
 
-    // First insert: Arabic + translation into empty doc
+    // First insert: Arabic + translation + citation into empty doc
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // After first insert: [arabic, translation, cleanup]
-    expect(body._children.length).toBe(3);
+    // After first insert: [arabic, translation, citation, cleanup]
+    expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[1]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
-    expect(body._children[2]._text).toBe('');
+    expect(body._children[1]._text).toBe('"translation"');
+    expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[3]._text).toBe('');
 
     // Second insert: cursor on cleanup (empty paragraph at end)
-    var cleanup = body._children[2];
+    var cleanup = body._children[3];
     var doc2 = createMockDoc(body, cleanup);
     insertParagraphsAtPosition_(body, doc2, singleArabicParagraph(), {});
 
-    // [arabic1, translation1, arabic2, cleanup2]
-    expect(body._children.length).toBe(4);
+    // [arabic1, translation1, citation1, arabic2, cleanup2]
+    expect(body._children.length).toBe(5);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[1]._text).toBe('"translation" (Al-Fatiha\u00A01:1)');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('');
+    expect(body._children[1]._text).toBe('"translation"');
+    expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('');
   });
 
   it('empty paragraph reuse avoids removeChild entirely', function () {


### PR DESCRIPTION
Closes #107

## Summary
- Split Arabic-only inserts into two paragraphs (ayah in ornate parens; citation on its own line).
- Split Arabic + English inserts into three paragraphs (ayah; quoted translation; parenthetical English citation).
- Apply paragraph spacing: 12pt before the ayah, 6pt between inner paragraphs (via `spacingAfter` only), 12pt after the final citation paragraph.
- Reset spacing on the trailing cleanup empty paragraph to 0.

## Testing
- `npm test`
- Run `runDocumentServiceTests` in the Apps Script editor (GAS-native mocks).

Made with [Cursor](https://cursor.com)