### PR TITLE
Fix insert-at-cursor regression caused by blockquote saveAndClose

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -84,7 +84,14 @@ function normalizeToContainerOffset_(element, offsetInElement) {
     return { container: container, offset: acc + offsetInElement };
   }
   if (element === container) {
-    return { container: container, offset: offsetInElement };
+    var charOff = 0;
+    for (var ci = 0; ci < offsetInElement && ci < container.getNumChildren(); ci++) {
+      var cch = container.getChild(ci);
+      if (cch.getType() === DocumentApp.ElementType.TEXT) {
+        charOff += cch.asText().getText().length;
+      }
+    }
+    return { container: container, offset: charOff };
   }
   return { container: container, offset: container.getText().length };
 }
@@ -167,19 +174,37 @@ function findListItemBlockBounds_(body, listItem) {
 
 /**
  * Splits a body-level paragraph at a character offset; second half becomes a new paragraph below.
- * May lose inline formatting at the split (DocumentApp limitation).
+ * Preserves inline (character-level) formatting on both halves by using deleteText (which keeps
+ * attributes on remaining text) and reapplying captured attributes to the new paragraph.
  * @param {Body} body
  * @param {GoogleAppsScript.Document.Paragraph} paragraph
  * @param {number} offset
  */
 function splitParagraphAt_(body, paragraph, offset) {
   var text = paragraph.getText();
-  var before = text.substring(0, offset);
+  var len = text.length;
+  if (offset <= 0 || offset >= len) return;
+
   var after = text.substring(offset);
   var idx = body.getChildIndex(paragraph);
-  paragraph.setText(before);
-  body.insertParagraph(idx + 1, after);
-  var np = body.getChild(idx + 1).asParagraph();
+
+  var srcText = paragraph.editAsText();
+  var afterAttrs = [];
+  for (var i = offset; i < len; i++) {
+    afterAttrs.push(srcText.getAttributes(i));
+  }
+
+  srcText.deleteText(offset, len - 1);
+
+  var np = body.insertParagraph(idx + 1, after);
+
+  var npText = np.editAsText();
+  for (var j = 0; j < afterAttrs.length; j++) {
+    if (afterAttrs[j]) {
+      npText.setAttributes(j, j, afterAttrs[j]);
+    }
+  }
+
   try {
     np.setHeading(paragraph.getHeading());
     np.setAlignment(paragraph.getAlignment());
@@ -217,12 +242,18 @@ function resolveFallbackInsertAnchor_(body) {
 function resolveIsolatedInsertAnchor_(body, doc) {
   var pos = getActivePositionNormalized_(doc);
   if (!pos) {
+    Logger.log('resolveIsolatedInsertAnchor_: no cursor/selection — using fallback');
     return resolveFallbackInsertAnchor_(body);
   }
+  Logger.log('resolveIsolatedInsertAnchor_: element type=' + pos.element.getType() +
+             ', offset=' + pos.offset);
   var norm = normalizeToContainerOffset_(pos.element, pos.offset);
   if (!norm) {
+    Logger.log('resolveIsolatedInsertAnchor_: normalizeToContainerOffset_ returned null — using fallback');
     return resolveFallbackInsertAnchor_(body);
   }
+  Logger.log('resolveIsolatedInsertAnchor_: normalized offset=' + norm.offset +
+             ', container text length=' + norm.container.getText().length);
   var container = norm.container;
   var off = norm.offset;
   if (off < 0) {

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -35,104 +35,22 @@ function resolveBodyLevelAncestor_(body, element) {
 }
 
 /**
- * Nearest paragraph-like block (body paragraph or list item) containing an element.
- * @param {GoogleAppsScript.Document.Element} element
- * @return {GoogleAppsScript.Document.Paragraph|null}
- */
-function findBlockContainer_(element) {
-  var el = element;
-  while (el) {
-    var t = el.getType();
-    if (t === DocumentApp.ElementType.PARAGRAPH || t === DocumentApp.ElementType.LIST_ITEM) {
-      return el.asParagraph();
-    }
-    el = el.getParent();
-  }
-  return null;
-}
-
-/**
- * Maps a position (element + offset) to offset within findBlockContainer_ text.
- * @param {GoogleAppsScript.Document.Element} element
- * @param {number} offsetInElement
- * @return {{ container: GoogleAppsScript.Document.Paragraph, offset: number }|null}
- */
-function normalizeToContainerOffset_(element, offsetInElement) {
-  var container = findBlockContainer_(element);
-  if (!container) {
-    return null;
-  }
-  var t = element.getType();
-  if (t === DocumentApp.ElementType.TEXT) {
-    var parent = element.getParent();
-    if (!parent) {
-      return { container: container, offset: offsetInElement };
-    }
-    var elementIndex;
-    try {
-      elementIndex = parent.getChildIndex(element);
-    } catch (e) {
-      return { container: container, offset: offsetInElement };
-    }
-    var acc = 0;
-    for (var i = 0; i < elementIndex; i++) {
-      var ch = parent.getChild(i);
-      if (ch.getType() === DocumentApp.ElementType.TEXT) {
-        acc += ch.asText().getText().length;
-      }
-    }
-    return { container: container, offset: acc + offsetInElement };
-  }
-  if (element === container) {
-    var charOff = 0;
-    for (var ci = 0; ci < offsetInElement && ci < container.getNumChildren(); ci++) {
-      var cch = container.getChild(ci);
-      if (cch.getType() === DocumentApp.ElementType.TEXT) {
-        charOff += cch.asText().getText().length;
-      }
-    }
-    return { container: container, offset: charOff };
-  }
-  return { container: container, offset: container.getText().length };
-}
-
-/**
- * Collapses a document selection to the end offset (insertion point after selection).
- * @param {GoogleAppsScript.Document.RangeElement[]} ranges
- * @return {{ element: GoogleAppsScript.Document.Element, offset: number }}
- */
-function collapseSelectionEndToPosition_(ranges) {
-  var re = ranges[ranges.length - 1];
-  var el = re.getElement();
-  if (re.isPartial() && el.getType() === DocumentApp.ElementType.TEXT) {
-    return { element: el, offset: re.getEndOffsetInclusive() + 1 };
-  }
-  if (el.getType() === DocumentApp.ElementType.TEXT) {
-    return { element: el, offset: el.asText().getText().length };
-  }
-  var container = findBlockContainer_(el);
-  if (container) {
-    return { element: container, offset: container.getText().length };
-  }
-  return { element: el, offset: 0 };
-}
-
-/**
- * Active caret: selection end if a range exists, else cursor. Never deletes selection text.
+ * Returns the element at the active cursor or selection (last range element).
+ * Does not compute offsets — only identifies which element the user is in.
  * @param {Document} doc
- * @return {{ element: GoogleAppsScript.Document.Element, offset: number }|null}
+ * @return {GoogleAppsScript.Document.Element|null}
  */
-function getActivePositionNormalized_(doc) {
+function getActiveCursorElement_(doc) {
   var sel = doc.getSelection();
   if (sel) {
     var ranges = sel.getRangeElements();
     if (ranges && ranges.length > 0) {
-      return collapseSelectionEndToPosition_(ranges);
+      return ranges[ranges.length - 1].getElement();
     }
   }
   var cur = doc.getCursor();
   if (cur) {
-    return { element: cur.getElement(), offset: cur.getOffset() };
+    return cur.getElement();
   }
   return null;
 }
@@ -173,49 +91,6 @@ function findListItemBlockBounds_(body, listItem) {
 }
 
 /**
- * Splits a body-level paragraph at a character offset; second half becomes a new paragraph below.
- * Preserves inline (character-level) formatting on both halves by using deleteText (which keeps
- * attributes on remaining text) and reapplying captured attributes to the new paragraph.
- * @param {Body} body
- * @param {GoogleAppsScript.Document.Paragraph} paragraph
- * @param {number} offset
- */
-function splitParagraphAt_(body, paragraph, offset) {
-  var text = paragraph.getText();
-  var len = text.length;
-  if (offset <= 0 || offset >= len) return;
-
-  var after = text.substring(offset);
-  var idx = body.getChildIndex(paragraph);
-
-  var srcText = paragraph.editAsText();
-  var afterAttrs = [];
-  for (var i = offset; i < len; i++) {
-    afterAttrs.push(srcText.getAttributes(i));
-  }
-
-  srcText.deleteText(offset, len - 1);
-
-  var np = body.insertParagraph(idx + 1, after);
-
-  var npText = np.editAsText();
-  for (var j = 0; j < afterAttrs.length; j++) {
-    if (afterAttrs[j]) {
-      npText.setAttributes(j, j, afterAttrs[j]);
-    }
-  }
-
-  try {
-    np.setHeading(paragraph.getHeading());
-    np.setAlignment(paragraph.getAlignment());
-    np.setLeftToRight(paragraph.getLeftToRight());
-    np.setSpacingBefore(paragraph.getSpacingBefore());
-    np.setSpacingAfter(paragraph.getSpacingAfter());
-  } catch (ignore) {
-  }
-}
-
-/**
  * When no cursor/selection: append after the last body child with isolation buffers.
  * @param {Body} body
  * @return {{ baseIndex: number, topBuffer: boolean, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
@@ -234,40 +109,30 @@ function resolveFallbackInsertAnchor_(body) {
 
 /**
  * Resolves where to insert isolated content (blockquote table or plain paragraphs).
- * Selection collapses to end; list/table contexts insert after the whole structure.
+ * Strategy: find the body-level element containing the cursor, then insert after it.
+ * Empty paragraphs are reused (replaced). Never modifies existing text.
  * @param {Body} body
  * @param {Document} doc
  * @return {{ baseIndex: number, topBuffer: boolean, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
  */
 function resolveIsolatedInsertAnchor_(body, doc) {
-  var pos = getActivePositionNormalized_(doc);
-  if (!pos) {
+  var el = getActiveCursorElement_(doc);
+  if (!el) {
     Logger.log('resolveIsolatedInsertAnchor_: no cursor/selection — using fallback');
     return resolveFallbackInsertAnchor_(body);
   }
-  Logger.log('resolveIsolatedInsertAnchor_: element type=' + pos.element.getType() +
-             ', offset=' + pos.offset);
-  var norm = normalizeToContainerOffset_(pos.element, pos.offset);
-  if (!norm) {
-    Logger.log('resolveIsolatedInsertAnchor_: normalizeToContainerOffset_ returned null — using fallback');
-    return resolveFallbackInsertAnchor_(body);
-  }
-  Logger.log('resolveIsolatedInsertAnchor_: normalized offset=' + norm.offset +
-             ', container text length=' + norm.container.getText().length);
-  var container = norm.container;
-  var off = norm.offset;
-  if (off < 0) {
-    off = 0;
-  }
-  var bodyChild = resolveBodyLevelAncestor_(body, container);
+
+  var bodyChild = resolveBodyLevelAncestor_(body, el);
   if (!bodyChild) {
+    Logger.log('resolveIsolatedInsertAnchor_: could not resolve body-level ancestor — using fallback');
     return resolveFallbackInsertAnchor_(body);
   }
 
-  if (bodyChild.getType() === DocumentApp.ElementType.TABLE) {
-    var ti = body.getChildIndex(bodyChild);
-    var afterTable = ti + 1;
-    return { baseIndex: afterTable, topBuffer: afterTable > 0, removeTarget: null };
+  var childIdx = body.getChildIndex(bodyChild);
+
+  if (bodyChild.getType() === DocumentApp.ElementType.PARAGRAPH &&
+      bodyChild.asParagraph().getText() === '') {
+    return { baseIndex: childIdx, topBuffer: false, removeTarget: bodyChild.asParagraph() };
   }
 
   if (bodyChild.getType() === DocumentApp.ElementType.LIST_ITEM) {
@@ -276,30 +141,12 @@ function resolveIsolatedInsertAnchor_(body, doc) {
     return { baseIndex: afterList, topBuffer: afterList > 0, removeTarget: null };
   }
 
-  if (bodyChild.getType() !== DocumentApp.ElementType.PARAGRAPH) {
-    return resolveFallbackInsertAnchor_(body);
+  if (bodyChild.getType() === DocumentApp.ElementType.TABLE) {
+    var afterTable = childIdx + 1;
+    return { baseIndex: afterTable, topBuffer: afterTable > 0, removeTarget: null };
   }
 
-  var para = bodyChild.asParagraph();
-  var text = para.getText();
-  var len = text.length;
-  if (off > len) {
-    off = len;
-  }
-  var childIdx = body.getChildIndex(bodyChild);
-
-  if (text === '') {
-    return { baseIndex: childIdx, topBuffer: false, removeTarget: para };
-  }
-  if (off === 0) {
-    return { baseIndex: childIdx, topBuffer: childIdx > 0, removeTarget: null };
-  }
-  if (off >= len) {
-    return { baseIndex: childIdx + 1, topBuffer: false, removeTarget: null };
-  }
-
-  splitParagraphAt_(body, para, off);
-  return { baseIndex: childIdx + 1, topBuffer: true, removeTarget: null };
+  return { baseIndex: childIdx + 1, topBuffer: false, removeTarget: null };
 }
 
 /**

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -13,18 +13,51 @@ var BLOCKQUOTE_BORDER_LEFT_COLOR = '#3A8F7A';
 var BLOCKQUOTE_CELL_BACKGROUND = '#F5F5F5';
 
 /**
+ * Walks an element up to its nearest body-level ancestor (direct child of body).
+ * If the element is already a direct child, returns it unchanged.
+ * Returns null when the element cannot be traced to a body-level child.
+ * @param {Body} body
+ * @param {GoogleAppsScript.Document.Element} element
+ * @return {GoogleAppsScript.Document.Element|null}
+ */
+function resolveBodyLevelAncestor_(body, element) {
+  var el = element;
+  while (el) {
+    if (body.getChildIndex(el) !== -1) return el;
+    el = el.getParent();
+  }
+  return null;
+}
+
+/**
  * Resolves where to insert the next body-level block (paragraphs or table).
+ * Tries getCursor() first; falls back to getSelection() (handles text-selection edge case);
+ * final fallback inserts after the last non-empty paragraph.
+ * When the resolved paragraph is nested (e.g. inside a blockquote table cell), walks up
+ * to the body-level ancestor so getChildIndex always succeeds.
  * @param {Body} body
  * @param {Document} doc
  * @return {{ insertIndex: number, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
  */
 function resolveInsertAnchor_(body, doc) {
+  var cursorElement = null;
   var cursor = doc.getCursor();
+  if (cursor) {
+    cursorElement = cursor.getElement();
+  } else {
+    var selection = doc.getSelection();
+    if (selection) {
+      var ranges = selection.getRangeElements();
+      if (ranges && ranges.length > 0) {
+        cursorElement = ranges[0].getElement();
+      }
+    }
+  }
+
   var insertIndex;
   var removeTarget = null;
 
-  if (cursor) {
-    var cursorElement = cursor.getElement();
+  if (cursorElement) {
     var cursorParagraph;
 
     if (cursorElement.getType() === DocumentApp.ElementType.PARAGRAPH) {
@@ -34,14 +67,23 @@ function resolveInsertAnchor_(body, doc) {
       while (parent && parent.getType() !== DocumentApp.ElementType.PARAGRAPH) {
         parent = parent.getParent();
       }
-      cursorParagraph = parent ? parent.asParagraph() : body.getParagraphs()[0];
+      cursorParagraph = parent ? parent.asParagraph() : null;
     }
 
-    if (cursorParagraph.getText() === '') {
-      insertIndex = body.getChildIndex(cursorParagraph);
-      removeTarget = cursorParagraph;
+    var bodyChild = cursorParagraph
+      ? resolveBodyLevelAncestor_(body, cursorParagraph)
+      : resolveBodyLevelAncestor_(body, cursorElement);
+
+    if (bodyChild) {
+      if (bodyChild.getType() === DocumentApp.ElementType.PARAGRAPH &&
+          bodyChild.asParagraph().getText() === '') {
+        insertIndex = body.getChildIndex(bodyChild);
+        removeTarget = bodyChild.asParagraph();
+      } else {
+        insertIndex = body.getChildIndex(bodyChild) + 1;
+      }
     } else {
-      insertIndex = body.getChildIndex(cursorParagraph) + 1;
+      insertIndex = body.getNumChildren();
     }
   } else {
     var paragraphs = body.getParagraphs();
@@ -160,7 +202,7 @@ function resolveTableStartIndexForDocsApi_(docId, tableOrdinal) {
  * Per-side cell borders (left accent only) via Docs API; DocumentApp cannot set per side.
  * Advanced Docs (get/batchUpdate) needs https://www.googleapis.com/auth/documents in appsscript.json;
  * drive.file can yield 404 on documents.get for the active editor doc.
- * Call only after DocumentApp.flush (e.g. saveAndClose): otherwise documents.get may omit the new table.
+ * Call only after the document has been flushed (auto-flush on function return, or saveAndClose).
  * @param {string} docId
  * @param {number} tableOrdinal - 1-based ordinal position of the target table among all body tables
  */
@@ -224,11 +266,14 @@ function applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal) {
 
 /**
  * Inserts a 1×1 table at the anchor, places beautified paragraphs in the cell, styles the shell.
+ * Border styling is NOT applied here — the caller receives pendingBorders and must invoke
+ * applyBlockquoteBorders() in a separate server call so that the auto-flush between calls
+ * makes the table visible to the Docs REST API without needing saveAndClose().
  * @param {Body} body
  * @param {Document} doc
  * @param {Array<Object>} paragraphsToInsert
  * @param {Object} formatState
- * @return {Object} { fontWarning: string|null }
+ * @return {Object} { fontWarning: string|null, pendingBorders: {docId: string, tableOrdinal: number}|null }
  */
 function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState) {
   var anchor = resolveInsertAnchor_(body, doc);
@@ -307,15 +352,22 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
       tableOrdinal++;
     }
   }
-  try {
-    if (typeof doc.saveAndClose === 'function') {
-      doc.saveAndClose();
-    }
-  } catch (ignore) {
-  }
-  applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal);
 
-  return { fontWarning: fontWarning };
+  return {
+    fontWarning: fontWarning,
+    pendingBorders: { docId: docId, tableOrdinal: tableOrdinal }
+  };
+}
+
+/**
+ * Public entry point for the client to apply blockquote cell borders via a second RPC.
+ * Called after insertAyah/insertAyahRange returns pendingBorders; the auto-flush between
+ * the two server calls ensures the Docs REST API can see the newly inserted table.
+ * @param {string} docId
+ * @param {number} tableOrdinal - 1-based ordinal position of the target table
+ */
+function applyBlockquoteBorders(docId, tableOrdinal) {
+  applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal);
 }
 
 /**
@@ -454,7 +506,11 @@ function insertAyah(ayahData, formatState, settings) {
     ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
     : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
   var message = result.fontWarning ? 'Ayah inserted. ' + result.fontWarning : 'Ayah inserted.';
-  return { success: true, message: message };
+  var out = { success: true, message: message };
+  if (result.pendingBorders) {
+    out.pendingBorders = result.pendingBorders;
+  }
+  return out;
 }
 
 /**
@@ -526,5 +582,9 @@ function insertAyahRange(rangeData, formatState, settings) {
   var result = useBlockquote
     ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
     : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
-  return { success: true, message: result.fontWarning ? 'Range inserted. ' + result.fontWarning : 'Range inserted.' };
+  var out = { success: true, message: result.fontWarning ? 'Range inserted. ' + result.fontWarning : 'Range inserted.' };
+  if (result.pendingBorders) {
+    out.pendingBorders = result.pendingBorders;
+  }
+  return out;
 }

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -23,87 +23,263 @@ var BLOCKQUOTE_CELL_BACKGROUND = '#F5F5F5';
 function resolveBodyLevelAncestor_(body, element) {
   var el = element;
   while (el) {
-    if (body.getChildIndex(el) !== -1) return el;
+    try {
+      var idx = body.getChildIndex(el);
+      if (idx !== -1) return el;
+    } catch (e) {
+      // el is not a direct child of body — keep walking up
+    }
     el = el.getParent();
   }
   return null;
 }
 
 /**
- * Resolves where to insert the next body-level block (paragraphs or table).
- * Tries getCursor() first; falls back to getSelection() (handles text-selection edge case);
- * final fallback inserts after the last non-empty paragraph.
- * When the resolved paragraph is nested (e.g. inside a blockquote table cell), walks up
- * to the body-level ancestor so getChildIndex always succeeds.
+ * Nearest paragraph-like block (body paragraph or list item) containing an element.
+ * @param {GoogleAppsScript.Document.Element} element
+ * @return {GoogleAppsScript.Document.Paragraph|null}
+ */
+function findBlockContainer_(element) {
+  var el = element;
+  while (el) {
+    var t = el.getType();
+    if (t === DocumentApp.ElementType.PARAGRAPH || t === DocumentApp.ElementType.LIST_ITEM) {
+      return el.asParagraph();
+    }
+    el = el.getParent();
+  }
+  return null;
+}
+
+/**
+ * Maps a position (element + offset) to offset within findBlockContainer_ text.
+ * @param {GoogleAppsScript.Document.Element} element
+ * @param {number} offsetInElement
+ * @return {{ container: GoogleAppsScript.Document.Paragraph, offset: number }|null}
+ */
+function normalizeToContainerOffset_(element, offsetInElement) {
+  var container = findBlockContainer_(element);
+  if (!container) {
+    return null;
+  }
+  var t = element.getType();
+  if (t === DocumentApp.ElementType.TEXT) {
+    var parent = element.getParent();
+    if (!parent) {
+      return { container: container, offset: offsetInElement };
+    }
+    var elementIndex;
+    try {
+      elementIndex = parent.getChildIndex(element);
+    } catch (e) {
+      return { container: container, offset: offsetInElement };
+    }
+    var acc = 0;
+    for (var i = 0; i < elementIndex; i++) {
+      var ch = parent.getChild(i);
+      if (ch.getType() === DocumentApp.ElementType.TEXT) {
+        acc += ch.asText().getText().length;
+      }
+    }
+    return { container: container, offset: acc + offsetInElement };
+  }
+  if (element === container) {
+    return { container: container, offset: offsetInElement };
+  }
+  return { container: container, offset: container.getText().length };
+}
+
+/**
+ * Collapses a document selection to the end offset (insertion point after selection).
+ * @param {GoogleAppsScript.Document.RangeElement[]} ranges
+ * @return {{ element: GoogleAppsScript.Document.Element, offset: number }}
+ */
+function collapseSelectionEndToPosition_(ranges) {
+  var re = ranges[ranges.length - 1];
+  var el = re.getElement();
+  if (re.isPartial() && el.getType() === DocumentApp.ElementType.TEXT) {
+    return { element: el, offset: re.getEndOffsetInclusive() + 1 };
+  }
+  if (el.getType() === DocumentApp.ElementType.TEXT) {
+    return { element: el, offset: el.asText().getText().length };
+  }
+  var container = findBlockContainer_(el);
+  if (container) {
+    return { element: container, offset: container.getText().length };
+  }
+  return { element: el, offset: 0 };
+}
+
+/**
+ * Active caret: selection end if a range exists, else cursor. Never deletes selection text.
+ * @param {Document} doc
+ * @return {{ element: GoogleAppsScript.Document.Element, offset: number }|null}
+ */
+function getActivePositionNormalized_(doc) {
+  var sel = doc.getSelection();
+  if (sel) {
+    var ranges = sel.getRangeElements();
+    if (ranges && ranges.length > 0) {
+      return collapseSelectionEndToPosition_(ranges);
+    }
+  }
+  var cur = doc.getCursor();
+  if (cur) {
+    return { element: cur.getElement(), offset: cur.getOffset() };
+  }
+  return null;
+}
+
+/**
+ * Contiguous list-item indices in the body sharing the same list id.
+ * @param {Body} body
+ * @param {GoogleAppsScript.Document.ListItem} listItem
+ * @return {{ startIndex: number, endIndex: number }}
+ */
+function findListItemBlockBounds_(body, listItem) {
+  var idx = body.getChildIndex(listItem);
+  var id = listItem.getListId();
+  var start = idx;
+  var i;
+  for (i = idx - 1; i >= 0; i--) {
+    var ch = body.getChild(i);
+    if (ch.getType() !== DocumentApp.ElementType.LIST_ITEM) {
+      break;
+    }
+    if (ch.asListItem().getListId() !== id) {
+      break;
+    }
+    start = i;
+  }
+  var end = idx;
+  for (i = idx + 1; i < body.getNumChildren(); i++) {
+    var ch2 = body.getChild(i);
+    if (ch2.getType() !== DocumentApp.ElementType.LIST_ITEM) {
+      break;
+    }
+    if (ch2.asListItem().getListId() !== id) {
+      break;
+    }
+    end = i;
+  }
+  return { startIndex: start, endIndex: end };
+}
+
+/**
+ * Splits a body-level paragraph at a character offset; second half becomes a new paragraph below.
+ * May lose inline formatting at the split (DocumentApp limitation).
+ * @param {Body} body
+ * @param {GoogleAppsScript.Document.Paragraph} paragraph
+ * @param {number} offset
+ */
+function splitParagraphAt_(body, paragraph, offset) {
+  var text = paragraph.getText();
+  var before = text.substring(0, offset);
+  var after = text.substring(offset);
+  var idx = body.getChildIndex(paragraph);
+  paragraph.setText(before);
+  body.insertParagraph(idx + 1, after);
+  var np = body.getChild(idx + 1).asParagraph();
+  try {
+    np.setHeading(paragraph.getHeading());
+    np.setAlignment(paragraph.getAlignment());
+    np.setLeftToRight(paragraph.getLeftToRight());
+    np.setSpacingBefore(paragraph.getSpacingBefore());
+    np.setSpacingAfter(paragraph.getSpacingAfter());
+  } catch (ignore) {
+  }
+}
+
+/**
+ * When no cursor/selection: append after the last body child with isolation buffers.
+ * @param {Body} body
+ * @return {{ baseIndex: number, topBuffer: boolean, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
+ */
+function resolveFallbackInsertAnchor_(body) {
+  var n = body.getNumChildren();
+  if (n === 1) {
+    var only = body.getChild(0);
+    if (only.getType() === DocumentApp.ElementType.PARAGRAPH &&
+        only.asParagraph().getText() === '') {
+      return { baseIndex: 0, topBuffer: false, removeTarget: only.asParagraph() };
+    }
+  }
+  return { baseIndex: n, topBuffer: n > 0, removeTarget: null };
+}
+
+/**
+ * Resolves where to insert isolated content (blockquote table or plain paragraphs).
+ * Selection collapses to end; list/table contexts insert after the whole structure.
  * @param {Body} body
  * @param {Document} doc
- * @return {{ insertIndex: number, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
+ * @return {{ baseIndex: number, topBuffer: boolean, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
  */
-function resolveInsertAnchor_(body, doc) {
-  var cursorElement = null;
-  var cursor = doc.getCursor();
-  if (cursor) {
-    cursorElement = cursor.getElement();
-  } else {
-    var selection = doc.getSelection();
-    if (selection) {
-      var ranges = selection.getRangeElements();
-      if (ranges && ranges.length > 0) {
-        cursorElement = ranges[0].getElement();
-      }
-    }
+function resolveIsolatedInsertAnchor_(body, doc) {
+  var pos = getActivePositionNormalized_(doc);
+  if (!pos) {
+    return resolveFallbackInsertAnchor_(body);
+  }
+  var norm = normalizeToContainerOffset_(pos.element, pos.offset);
+  if (!norm) {
+    return resolveFallbackInsertAnchor_(body);
+  }
+  var container = norm.container;
+  var off = norm.offset;
+  if (off < 0) {
+    off = 0;
+  }
+  var bodyChild = resolveBodyLevelAncestor_(body, container);
+  if (!bodyChild) {
+    return resolveFallbackInsertAnchor_(body);
   }
 
-  var insertIndex;
-  var removeTarget = null;
-
-  if (cursorElement) {
-    var cursorParagraph;
-
-    if (cursorElement.getType() === DocumentApp.ElementType.PARAGRAPH) {
-      cursorParagraph = cursorElement.asParagraph();
-    } else {
-      var parent = cursorElement.getParent();
-      while (parent && parent.getType() !== DocumentApp.ElementType.PARAGRAPH) {
-        parent = parent.getParent();
-      }
-      cursorParagraph = parent ? parent.asParagraph() : null;
-    }
-
-    var bodyChild = cursorParagraph
-      ? resolveBodyLevelAncestor_(body, cursorParagraph)
-      : resolveBodyLevelAncestor_(body, cursorElement);
-
-    if (bodyChild) {
-      if (bodyChild.getType() === DocumentApp.ElementType.PARAGRAPH &&
-          bodyChild.asParagraph().getText() === '') {
-        insertIndex = body.getChildIndex(bodyChild);
-        removeTarget = bodyChild.asParagraph();
-      } else {
-        insertIndex = body.getChildIndex(bodyChild) + 1;
-      }
-    } else {
-      insertIndex = body.getNumChildren();
-    }
-  } else {
-    var paragraphs = body.getParagraphs();
-    var lastNonEmptyIdx = -1;
-    for (var j = paragraphs.length - 1; j >= 0; j--) {
-      if (paragraphs[j].getText() !== '') {
-        lastNonEmptyIdx = j;
-        break;
-      }
-    }
-
-    if (lastNonEmptyIdx === -1) {
-      insertIndex = 0;
-      removeTarget = paragraphs[0];
-    } else {
-      insertIndex = body.getChildIndex(paragraphs[lastNonEmptyIdx]) + 1;
-    }
+  if (bodyChild.getType() === DocumentApp.ElementType.TABLE) {
+    var ti = body.getChildIndex(bodyChild);
+    var afterTable = ti + 1;
+    return { baseIndex: afterTable, topBuffer: afterTable > 0, removeTarget: null };
   }
 
-  return { insertIndex: insertIndex, removeTarget: removeTarget };
+  if (bodyChild.getType() === DocumentApp.ElementType.LIST_ITEM) {
+    var bounds = findListItemBlockBounds_(body, bodyChild.asListItem());
+    var afterList = bounds.endIndex + 1;
+    return { baseIndex: afterList, topBuffer: afterList > 0, removeTarget: null };
+  }
+
+  if (bodyChild.getType() !== DocumentApp.ElementType.PARAGRAPH) {
+    return resolveFallbackInsertAnchor_(body);
+  }
+
+  var para = bodyChild.asParagraph();
+  var text = para.getText();
+  var len = text.length;
+  if (off > len) {
+    off = len;
+  }
+  var childIdx = body.getChildIndex(bodyChild);
+
+  if (text === '') {
+    return { baseIndex: childIdx, topBuffer: false, removeTarget: para };
+  }
+  if (off === 0) {
+    return { baseIndex: childIdx, topBuffer: childIdx > 0, removeTarget: null };
+  }
+  if (off >= len) {
+    return { baseIndex: childIdx + 1, topBuffer: false, removeTarget: null };
+  }
+
+  splitParagraphAt_(body, para, off);
+  return { baseIndex: childIdx + 1, topBuffer: true, removeTarget: null };
+}
+
+/**
+ * Normal empty paragraph after an insert block (typing / isolation).
+ * @param {GoogleAppsScript.Document.Paragraph} p
+ */
+function formatBottomTypingParagraph_(p) {
+  p.setHeading(DocumentApp.ParagraphHeading.NORMAL);
+  p.setLeftToRight(true);
+  p.setSpacingBefore(0);
+  p.setSpacingAfter(0);
 }
 
 /**
@@ -276,13 +452,12 @@ function applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal) {
  * @return {Object} { fontWarning: string|null, pendingBorders: {docId: string, tableOrdinal: number}|null }
  */
 function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState) {
-  var anchor = resolveInsertAnchor_(body, doc);
-  var insertIndex = anchor.insertIndex;
+  var anchor = resolveIsolatedInsertAnchor_(body, doc);
+  var insertIndex = anchor.baseIndex;
   var removeTarget = anchor.removeTarget;
 
-  // Top buffer paragraph (structural). Skip when inserting at position 0 (empty doc).
   var tableOffset = 0;
-  if (insertIndex > 0) {
+  if (anchor.topBuffer) {
     body.insertParagraph(insertIndex, '');
     tableOffset = 1;
   }
@@ -335,8 +510,7 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
   } else {
     typingParagraph = body.insertParagraph(tableIdx + 1, '');
   }
-  typingParagraph.setHeading(DocumentApp.ParagraphHeading.NORMAL);
-  typingParagraph.setLeftToRight(true);
+  formatBottomTypingParagraph_(typingParagraph);
 
   try {
     doc.setCursor(doc.newPosition(typingParagraph, 0));
@@ -371,19 +545,9 @@ function applyBlockquoteBorders(docId, tableOrdinal) {
 }
 
 /**
- * Determines the insertion index and inserts paragraphs at the correct position.
- * Shared by insertAyah and insertAyahRange.
- *
- * Insertion rules:
- *   - Cursor on empty paragraph: reuse it for the first item, insert remaining after it
- *   - Cursor on non-empty paragraph: insert in a new paragraph below it
- *   - No cursor: insert after the last non-empty paragraph; if all empty, reuse the first
- *
- * Cleanup (empty Normal/LTR paragraph) is only added when the inserted content
- * ends up as the last child in the document. If any child exists after it, skip cleanup.
- *
- * After insertion, the document cursor is moved to the cleanup paragraph (if added)
- * or to the last inserted paragraph (if in the middle of the document).
+ * Inserts beautified paragraphs with the same isolation rules as blockquote inserts
+ * (resolveIsolatedInsertAnchor_: selection end, list/table escapes, split/start/end).
+ * Always adds a bottom buffer paragraph; cursor moves there.
  *
  * @param {Body} body - The document body
  * @param {Document} doc - The active document
@@ -392,40 +556,38 @@ function applyBlockquoteBorders(docId, tableOrdinal) {
  * @return {Object} { fontWarning: string|null }
  */
 function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState) {
-  var anchor = resolveInsertAnchor_(body, doc);
-  var insertIndex = anchor.insertIndex;
+  var anchor = resolveIsolatedInsertAnchor_(body, doc);
+  var idx = anchor.baseIndex;
   var removeTarget = anchor.removeTarget;
 
+  if (anchor.topBuffer) {
+    body.insertParagraph(idx, '');
+    idx++;
+  }
+
+  var contentStart = idx;
   var fontWarning = null;
-  for (var i = 0; i < paragraphsToInsert.length; i++) {
-    var item = paragraphsToInsert[i];
-    var p;
-    if (i === 0 && removeTarget) {
+  var i;
+  var item;
+  var p;
+
+  for (i = 0; i < paragraphsToInsert.length; i++) {
+    item = paragraphsToInsert[i];
+    if (i === 0 && removeTarget && body.getChild(contentStart) === removeTarget) {
       p = removeTarget;
       p.setText(item.text);
     } else {
-      p = body.insertParagraph(insertIndex + i, item.text);
+      p = body.insertParagraph(contentStart + i, item.text);
     }
     fontWarning = applyBeautifiedInsertToParagraph_(p, item, formatState) || fontWarning;
   }
 
-  var lastInsertedIndex = insertIndex + paragraphsToInsert.length - 1;
-  var isLastInDoc = (lastInsertedIndex >= body.getNumChildren() - 1);
-
-  var cursorTarget;
-  if (isLastInDoc) {
-    var cleanup = body.insertParagraph(lastInsertedIndex + 1, '');
-    cleanup.setHeading(DocumentApp.ParagraphHeading.NORMAL);
-    cleanup.setLeftToRight(true);
-    cleanup.setSpacingBefore(0);
-    cleanup.setSpacingAfter(0);
-    cursorTarget = cleanup;
-  } else {
-    cursorTarget = body.getChild(lastInsertedIndex).asParagraph();
-  }
+  var bottomIdx = contentStart + paragraphsToInsert.length;
+  var bottom = body.insertParagraph(bottomIdx, '');
+  formatBottomTypingParagraph_(bottom);
 
   try {
-    doc.setCursor(doc.newPosition(cursorTarget, 0));
+    doc.setCursor(doc.newPosition(bottom, 0));
   } catch (e) {
     // setCursor is unavailable in non-UI contexts (e.g. triggers); fail silently
   }
@@ -434,8 +596,8 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
 }
 
 /**
- * Inserts an ayah into the document at the cursor position.
- * If no cursor, inserts after the last non-empty paragraph.
+ * Inserts an ayah into the document using resolveIsolatedInsertAnchor_
+ * (selection end, list/table escapes, paragraph split/start/end, doc-end fallback).
  * @param {Object} ayahData - { surah, ayah, surahNameArabic, surahNameEnglish, textUthmani, textSimple, translationText }
  * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @param {Object} settings - { showTranslation, arabicStyle, blockquoteInsertion }
@@ -514,8 +676,7 @@ function insertAyah(ayahData, formatState, settings) {
 }
 
 /**
- * Inserts a pre-assembled ayah range into the document.
- * If no cursor is set, inserts after the last non-empty paragraph.
+ * Inserts a pre-assembled ayah range using the same anchor rules as insertAyah.
  * @param {Object} rangeData - { surah, ayahStart, ayahEnd, arabicText, translationText, surahNameArabic, surahNameEnglish }
  * @param {Object} formatState - { fontName, fontVariant, fontSize, bold, textColor }
  * @param {Object} settings - { showTranslation, blockquoteInsertion }

--- a/DocumentService.js
+++ b/DocumentService.js
@@ -111,6 +111,9 @@ function resolveFallbackInsertAnchor_(body) {
  * Resolves where to insert isolated content (blockquote table or plain paragraphs).
  * Strategy: find the body-level element containing the cursor, then insert after it.
  * Empty paragraphs are reused (replaced). Never modifies existing text.
+ * topBuffer: insert an empty paragraph immediately before the block when the insert
+ * is not at body start (baseIndex > 0 after a non-empty paragraph), or when reusing
+ * an empty paragraph not at index 0 (childIdx > 0).
  * @param {Body} body
  * @param {Document} doc
  * @return {{ baseIndex: number, topBuffer: boolean, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
@@ -132,7 +135,11 @@ function resolveIsolatedInsertAnchor_(body, doc) {
 
   if (bodyChild.getType() === DocumentApp.ElementType.PARAGRAPH &&
       bodyChild.asParagraph().getText() === '') {
-    return { baseIndex: childIdx, topBuffer: false, removeTarget: bodyChild.asParagraph() };
+    return {
+      baseIndex: childIdx,
+      topBuffer: childIdx > 0,
+      removeTarget: bodyChild.asParagraph()
+    };
   }
 
   if (bodyChild.getType() === DocumentApp.ElementType.LIST_ITEM) {
@@ -146,7 +153,8 @@ function resolveIsolatedInsertAnchor_(body, doc) {
     return { baseIndex: afterTable, topBuffer: afterTable > 0, removeTarget: null };
   }
 
-  return { baseIndex: childIdx + 1, topBuffer: false, removeTarget: null };
+  var baseAfter = childIdx + 1;
+  return { baseIndex: baseAfter, topBuffer: baseAfter > 0, removeTarget: null };
 }
 
 /**
@@ -385,10 +393,17 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
   var typingParagraph;
   if (removeTargetStillExists) {
     typingParagraph = removeTarget;
+    formatBottomTypingParagraph_(typingParagraph);
   } else {
-    typingParagraph = body.insertParagraph(tableIdx + 1, '');
+    var nextIdxBq = tableIdx + 1;
+    var nextElBq = nextIdxBq < body.getNumChildren() ? body.getChild(nextIdxBq) : null;
+    if (nextElBq && nextElBq.getType() === DocumentApp.ElementType.PARAGRAPH) {
+      typingParagraph = nextElBq.asParagraph();
+    } else {
+      typingParagraph = body.insertParagraph(tableIdx + 1, '');
+      formatBottomTypingParagraph_(typingParagraph);
+    }
   }
-  formatBottomTypingParagraph_(typingParagraph);
 
   try {
     doc.setCursor(doc.newPosition(typingParagraph, 0));
@@ -425,7 +440,8 @@ function applyBlockquoteBorders(docId, tableOrdinal) {
 /**
  * Inserts beautified paragraphs with the same isolation rules as blockquote inserts
  * (resolveIsolatedInsertAnchor_: selection end, list/table escapes, split/start/end).
- * Always adds a bottom buffer paragraph; cursor moves there.
+ * Adds a bottom empty paragraph only when no body paragraph already follows; otherwise
+ * cursor moves to the start of the following paragraph.
  *
  * @param {Body} body - The document body
  * @param {Document} doc - The active document
@@ -461,8 +477,19 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
   }
 
   var bottomIdx = contentStart + paragraphsToInsert.length;
-  var bottom = body.insertParagraph(bottomIdx, '');
-  formatBottomTypingParagraph_(bottom);
+  var bottom;
+  if (bottomIdx < body.getNumChildren()) {
+    var nextElPlain = body.getChild(bottomIdx);
+    if (nextElPlain.getType() === DocumentApp.ElementType.PARAGRAPH) {
+      bottom = nextElPlain.asParagraph();
+    } else {
+      bottom = body.insertParagraph(bottomIdx, '');
+      formatBottomTypingParagraph_(bottom);
+    }
+  } else {
+    bottom = body.insertParagraph(bottomIdx, '');
+    formatBottomTypingParagraph_(bottom);
+  }
 
   try {
     doc.setCursor(doc.newPosition(bottom, 0));

--- a/sidebar/js/render-helpers.html
+++ b/sidebar/js/render-helpers.html
@@ -3,6 +3,21 @@
 //   buildCardHtml, buildRangeData (card-builder.html),
 //   _buildAyahDataForInsert (search-utils.html)
 
+/**
+ * Fire-and-forget: applies blockquote cell borders via a deferred second RPC.
+ * The auto-flush between the insert call and this call ensures the Docs REST API
+ * can see the newly inserted table without needing saveAndClose().
+ */
+function _applyPendingBorders(result) {
+  if (!result || !result.pendingBorders) return;
+  var pb = result.pendingBorders;
+  google.script.run
+    .withFailureHandler(function(err) {
+      console.error('Blockquote border styling failed:', err);
+    })
+    .applyBlockquoteBorders(pb.docId, pb.tableOrdinal);
+}
+
 function makeSkeleton(count) {
   var html = '';
   for (var i = 0; i < count; i++) {
@@ -91,6 +106,7 @@ function onInsertClick(e) {
         if (result && !result.success) {
           console.warn('Range insert warning:', result.message);
         }
+        _applyPendingBorders(result);
       })
       .withFailureHandler(function(err) {
         btn.disabled = false;
@@ -124,6 +140,7 @@ function onInsertClick(e) {
       if (result && !result.success) {
         console.warn('Insert warning:', result.message);
       }
+      _applyPendingBorders(result);
     })
     .withFailureHandler(function(err) {
       btn.disabled = false;

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -82,31 +82,7 @@ function runDocumentServiceTests() {
         return {
           _owner: para,
           setFontSize: function (s) { para._fontSize = s; return this; },
-          getFontSize: function () { return para._fontSize; },
-          getAttributes: function (charIndex) {
-            if (!para._charAttrs) return null;
-            return para._charAttrs[charIndex] || null;
-          },
-          setAttributes: function (startOffset, endOffset, attrs) {
-            if (!para._charAttrs) para._charAttrs = {};
-            for (var ai = startOffset; ai <= endOffset; ai++) {
-              para._charAttrs[ai] = attrs;
-            }
-            return this;
-          },
-          deleteText: function (startOffset, endOffset) {
-            var t = para._text;
-            para._text = t.substring(0, startOffset) + t.substring(endOffset + 1);
-            if (para._charAttrs) {
-              var newAttrs = {};
-              for (var ai = 0; ai < startOffset; ai++) {
-                if (para._charAttrs[ai]) newAttrs[ai] = para._charAttrs[ai];
-              }
-              para._charAttrs = newAttrs;
-            }
-            para._textChildren = [createMockText(para._text, para)];
-            return this;
-          }
+          getFontSize: function () { return para._fontSize; }
         };
       }
     };
@@ -200,23 +176,18 @@ function runDocumentServiceTests() {
 
   /**
    * @param {*} body
-   * @param {*} cursorParagraph - element for cursor (or null)
+   * @param {*} cursorElement - element for cursor (or null)
    * @param {Array} selectionElements - optional range elements (see mockRangeEl_)
-   * @param {number} [cursorOffset] - defaults to end of cursor paragraph text
    */
-  function createMockDoc(body, cursorParagraph, selectionElements, cursorOffset) {
+  function createMockDoc(body, cursorElement, selectionElements) {
     return {
       getBody: function () { return body; },
       getId: function () { return 'mock-doc-id'; },
       getCursor: function () {
-        if (!cursorParagraph) return null;
-        var co = cursorOffset;
-        if (co === undefined || co === null) {
-          co = cursorParagraph.getText ? cursorParagraph.getText().length : 0;
-        }
+        if (!cursorElement) return null;
         return {
-          getElement: function () { return cursorParagraph; },
-          getOffset: function () { return co; }
+          getElement: function () { return cursorElement; },
+          getOffset: function () { return 0; }
         };
       },
       getSelection: function () {
@@ -232,11 +203,11 @@ function runDocumentServiceTests() {
     };
   }
 
-  function mockRangeEl_(element, partial, endOffsetInclusive) {
+  function mockRangeEl_(element) {
     return {
       getElement: function () { return element; },
-      isPartial: function () { return !!partial; },
-      getEndOffsetInclusive: function () { return endOffsetInclusive; }
+      isPartial: function () { return false; },
+      getEndOffsetInclusive: function () { return 0; }
     };
   }
 
@@ -309,8 +280,7 @@ function runDocumentServiceTests() {
 
   it('cursor on empty paragraph (only child) — replaces empty, adds cleanup', function () {
     var body = createMockBody(['']);
-    var cursorPara = body._children[0];
-    var doc = createMockDoc(body, cursorPara);
+    var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
@@ -325,8 +295,7 @@ function runDocumentServiceTests() {
 
   it('cursor on non-empty paragraph (last child) — inserts below, adds cleanup', function () {
     var body = createMockBody(['existing text']);
-    var cursorPara = body._children[0];
-    var doc = createMockDoc(body, cursorPara);
+    var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
@@ -369,8 +338,7 @@ function runDocumentServiceTests() {
 
   it('cursor at last paragraph (non-empty) — content appended, cleanup is last', function () {
     var body = createMockBody(['first', 'last']);
-    var cursorPara = body._children[1];
-    var doc = createMockDoc(body, cursorPara);
+    var doc = createMockDoc(body, body._children[1]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
@@ -400,14 +368,13 @@ function runDocumentServiceTests() {
     expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
   });
 
-  it('cursor at end of first paragraph with paragraphs below — content, bottom, then rest', function () {
+  it('cursor at first paragraph with paragraphs below — content after first, then rest', function () {
     var body = createMockBody(['first', 'second', 'third']);
-    var cursorPara = body._children[0];
-    var doc = createMockDoc(body, cursorPara);
+    var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // End of "first" → no top buffer; [first, content, bottom, second, third]
+    // [first, content, bottom, second, third]
     expect(body._children.length).toBe(5);
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
@@ -417,10 +384,9 @@ function runDocumentServiceTests() {
     expect(body._children[4]._text).toBe('third');
   });
 
-  it('cursor at end of first with only spaces paragraph below — bottom buffer before spaces', function () {
+  it('cursor at first with only spaces paragraph below — bottom buffer before spaces', function () {
     var body = createMockBody(['first', '   ']);
-    var cursorPara = body._children[0];
-    var doc = createMockDoc(body, cursorPara);
+    var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
@@ -520,8 +486,7 @@ function runDocumentServiceTests() {
 
   it('three content paragraphs at end — all inserted, cleanup follows', function () {
     var body = createMockBody(['existing']);
-    var cursorPara = body._children[0];
-    var doc = createMockDoc(body, cursorPara);
+    var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
@@ -542,12 +507,11 @@ function runDocumentServiceTests() {
 
   it('three content paragraphs with content after — bottom buffer before following paragraph', function () {
     var body = createMockBody(['existing', 'after']);
-    var cursorPara = body._children[0];
-    var doc = createMockDoc(body, cursorPara);
+    var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // End of "existing" → [existing, arabic, translation, citation, bottom, after]
+    // [existing, arabic, translation, citation, bottom, after]
     expect(body._children.length).toBe(6);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[2]._text).toBe('"translation"');
@@ -564,7 +528,6 @@ function runDocumentServiceTests() {
     var emptyPara = body._children[0];
     var doc = createMockDoc(body, emptyPara);
 
-    // First insert: Arabic + translation + citation into empty doc
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
     // After first insert: [arabic, translation, citation, cleanup]
@@ -574,7 +537,6 @@ function runDocumentServiceTests() {
     expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
     expect(body._children[3]._text).toBe('');
 
-    // Second insert: cursor on cleanup (empty paragraph at end)
     var cleanup = body._children[3];
     var doc2 = createMockDoc(body, cleanup);
     insertParagraphsAtPosition_(body, doc2, singleArabicParagraph(), {});
@@ -613,7 +575,6 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, arabicOnlyAyahAndCitation(), {});
 
-    // insertIndex=0 → no top buffer; [TABLE, typingParagraph]
     expect(body._children.length).toBe(2);
     expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[1]._text).toBe('');
@@ -637,7 +598,6 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [TABLE, typingParagraph]
     expect(body._children.length).toBe(2);
     var cell = body._children[0]._cell;
     expect(cell._inner.length).toBe(3);
@@ -647,12 +607,12 @@ function runDocumentServiceTests() {
     expect(cell._inner[2]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
   });
 
-  it('blockquote: non-empty doc — cursor at end of paragraph: table, typing, no top buffer', function () {
+  it('blockquote: non-empty doc — cursor on paragraph: table after it, no top buffer', function () {
     var body = createMockBody(['existing', 'after']);
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // End of "existing" → [existing, TABLE, typingParagraph, after]
+    // [existing, TABLE, typingParagraph, after]
     expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('existing');
     expect(body._children[1].getType()).toBe(DocumentApp.ElementType.TABLE);
@@ -667,17 +627,15 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // insertIndex=0 → no top buffer; first child is the table
     expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[0]._cell._inner[0]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
   });
 
-  it('blockquote: typing paragraph has no explicit spacing (after end-of-para insert)', function () {
+  it('blockquote: typing paragraph has no explicit spacing', function () {
     var body = createMockBody(['content above', 'more content']);
     var doc = createMockDoc(body, body._children[1]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // End of last body paragraph → no top buffer; [ca, more, TABLE, typing]
     var typing = body._children[3];
     expect(typing._text).toBe('');
     expect(typing._fontSize).toBe(null);
@@ -708,7 +666,6 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, origPara);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [TABLE, reusedOrigPara]
     expect(body._children.length).toBe(2);
     expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
     var typing = body._children[1];
@@ -847,22 +804,50 @@ function runDocumentServiceTests() {
     applyBlockquoteCellBordersViaDocsApi_ = origBorders;
   });
 
-  // ── resolveIsolatedInsertAnchor_ — getSelection() fallback ─
+  // ── resolveIsolatedInsertAnchor_ — always-after-paragraph ──
 
-  results.push('\nresolveIsolatedInsertAnchor_() — getSelection() fallback');
+  results.push('\nresolveIsolatedInsertAnchor_() — simplified anchor (always after paragraph)');
 
-  it('selection on non-empty body paragraph inserts after it (end collapsed)', function () {
+  it('cursor on non-empty paragraph inserts after it', function () {
     var body = createMockBody(['first', 'second', 'third']);
-    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1], false)]);
+    var doc = createMockDoc(body, body._children[1]);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(2);
     expect(anchor.topBuffer).toBe(false);
     expect(anchor.removeTarget).toBe(null);
   });
 
-  it('selection on empty body paragraph reuses it', function () {
+  it('cursor on empty paragraph reuses it', function () {
     var body = createMockBody(['first', '', 'third']);
-    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1], false)]);
+    var doc = createMockDoc(body, body._children[1]);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.removeTarget).toBe(body._children[1]);
+  });
+
+  it('cursor on TEXT child of paragraph inserts after that paragraph', function () {
+    var body = createMockBody(['hello world']);
+    var textEl = body._children[0]._textChildren[0];
+    var doc = createMockDoc(body, textEl);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  it('selection on non-empty paragraph inserts after it', function () {
+    var body = createMockBody(['first', 'second', 'third']);
+    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1])]);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(2);
+    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  it('selection on empty paragraph reuses it', function () {
+    var body = createMockBody(['first', '', 'third']);
+    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1])]);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(1);
     expect(anchor.topBuffer).toBe(false);
@@ -894,14 +879,16 @@ function runDocumentServiceTests() {
     body._children.push(createMockParagraph('after'));
     var cellPara = tbl._cell._inner[0];
     cellPara.getParent = function () { return tbl; };
-    var doc = createMockDoc(body, null, [mockRangeEl_(cellPara, false)]);
+    var doc = createMockDoc(body, null, [mockRangeEl_(cellPara)]);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(2);
     expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(null);
   });
 
-  results.push('\nresolveIsolatedInsertAnchor_() — start / split / list');
+  // ── resolveIsolatedInsertAnchor_ — list ──
+
+  results.push('\nresolveIsolatedInsertAnchor_() — list items');
 
   function createMockListItem(text, listId) {
     var li = createMockParagraph(text);
@@ -911,27 +898,6 @@ function runDocumentServiceTests() {
     return li;
   }
 
-  it('cursor at start of second paragraph — top buffer then insert before it', function () {
-    var body = createMockBody(['first', 'second']);
-    var doc = createMockDoc(body, body._children[1], null, 0);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  it('cursor in middle of paragraph — splits then insert region has top buffer', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 6);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(body._children[0]._text).toBe('hello ');
-    expect(body._children[1]._text).toBe('world');
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-  });
-
   it('cursor in list — anchor after contiguous same-listId block', function () {
     var body = createMockBody(['intro']);
     body._children.push(createMockListItem('one', 'L9'));
@@ -940,86 +906,6 @@ function runDocumentServiceTests() {
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(3);
     expect(anchor.topBuffer).toBe(true);
-  });
-
-  // ── normalizeToContainerOffset_ — Text cursor element ───────
-
-  results.push('\nnormalizeToContainerOffset_() — Text element cursor');
-
-  it('Text cursor at offset 6 in "hello world" returns container offset 6', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var result = normalizeToContainerOffset_(textEl, 6);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(6);
-  });
-
-  it('Text cursor at offset 0 returns container offset 0', function () {
-    var body = createMockBody(['some text']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var result = normalizeToContainerOffset_(textEl, 0);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(0);
-  });
-
-  it('Text cursor at end of text returns container offset equal to length', function () {
-    var body = createMockBody(['hello']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var result = normalizeToContainerOffset_(textEl, 5);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(5);
-  });
-
-  it('Text cursor in second text child accounts for first child length', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var text1 = createMockText('hello ', para);
-    var text2 = createMockText('world', para);
-    para._textChildren = [text1, text2];
-    var result = normalizeToContainerOffset_(text2, 3);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(9);
-  });
-
-  // ── resolveIsolatedInsertAnchor_ — Text cursor split / start ──
-
-  results.push('\nresolveIsolatedInsertAnchor_() — Text cursor split / start');
-
-  it('Text cursor at middle of paragraph triggers split', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 6);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(body._children[0]._text).toBe('hello ');
-    expect(body._children[1]._text).toBe('world');
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-  });
-
-  it('Text cursor at beginning of paragraph inserts before it', function () {
-    var body = createMockBody(['first', 'second']);
-    var para = body._children[1];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 0);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  it('Text cursor at end of paragraph inserts after it', function () {
-    var body = createMockBody(['hello']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 5);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(false);
-    expect(anchor.removeTarget).toBe(null);
   });
 
   // ── End-to-end: blockquote insert with cursor in table cell ──
@@ -1047,232 +933,62 @@ function runDocumentServiceTests() {
     expect(result.pendingBorders.tableOrdinal).toBe(2);
   });
 
-  // ── End-to-end: blockquote + plain insert with mid-paragraph cursor ──
+  // ── End-to-end: cursor in middle or beginning of paragraph (no split) ──
 
-  results.push('\ninsertBlockquoteTableAtPosition_() — mid-paragraph split (Text cursor)');
+  results.push('\ninsertBlockquoteTableAtPosition_() — cursor in paragraph (no split)');
 
-  it('blockquote: Text cursor mid-paragraph splits and inserts table between halves', function () {
+  it('blockquote: cursor on paragraph inserts table after it', function () {
     var body = createMockBody(['hello world', 'after']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 6);
+    var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["hello ", topBuffer, TABLE, typingPara, "world", "after"]
-    expect(body._children[0]._text).toBe('hello ');
-    expect(body._children[1]._text).toBe('');
+    // ["hello world", TABLE, typingPara, "after"]
+    expect(body._children[0]._text).toBe('hello world');
+    expect(body._children[1].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[3]._text).toBe('after');
+  });
+
+  it('plain: cursor on paragraph inserts content after it', function () {
+    var body = createMockBody(['hello world', 'after']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    // ["hello world", content, bottom, "after"]
+    expect(body._children[0]._text).toBe('hello world');
+    expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[3]._text).toBe('after');
+  });
+
+  it('blockquote: cursor on second of three paragraphs inserts after it', function () {
+    var body = createMockBody(['first', 'second', 'third']);
+    var doc = createMockDoc(body, body._children[1]);
+    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    // ["first", "second", TABLE, typingPara, "third"]
+    expect(body._children[0]._text).toBe('first');
+    expect(body._children[1]._text).toBe('second');
     expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[3]._text).toBe('');
     expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[4]._text).toBe('world');
-    expect(body._children[5]._text).toBe('after');
+    expect(body._children[4]._text).toBe('third');
   });
 
-  it('plain: Text cursor mid-paragraph splits and inserts content between halves', function () {
-    var body = createMockBody(['hello world', 'after']);
-    var para = body._children[0];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 6);
+  it('plain: cursor on second of three paragraphs inserts after it', function () {
+    var body = createMockBody(['first', 'second', 'third']);
+    var doc = createMockDoc(body, body._children[1]);
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["hello ", topBuffer, content, bottom, "world", "after"]
-    expect(body._children[0]._text).toBe('hello ');
-    expect(body._children[1]._text).toBe('');
+    // ["first", "second", content, bottom, "third"]
+    expect(body._children[0]._text).toBe('first');
+    expect(body._children[1]._text).toBe('second');
     expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
     expect(body._children[3]._text).toBe('');
     expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[4]._text).toBe('world');
-    expect(body._children[5]._text).toBe('after');
-  });
-
-  // ── End-to-end: blockquote + plain insert with cursor at beginning ──
-
-  results.push('\ninsertBlockquoteTableAtPosition_() — beginning of paragraph (Text cursor)');
-
-  it('blockquote: Text cursor at beginning inserts table before paragraph', function () {
-    var body = createMockBody(['first', 'second', 'third']);
-    var para = body._children[1];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 0);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-
-    // ["first", topBuffer, TABLE, typingPara, "second", "third"]
-    expect(body._children[0]._text).toBe('first');
-    expect(body._children[1]._text).toBe('');
-    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[4]._text).toBe('second');
-    expect(body._children[5]._text).toBe('third');
-  });
-
-  it('plain: Text cursor at beginning inserts content before paragraph', function () {
-    var body = createMockBody(['first', 'second', 'third']);
-    var para = body._children[1];
-    var textEl = para._textChildren[0];
-    var doc = createMockDoc(body, textEl, null, 0);
-    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
-
-    // ["first", topBuffer, content, bottom, "second", "third"]
-    expect(body._children[0]._text).toBe('first');
-    expect(body._children[1]._text).toBe('');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[4]._text).toBe('second');
-    expect(body._children[5]._text).toBe('third');
-  });
-
-  // ── normalizeToContainerOffset_ — Paragraph element with child-index offset ──
-
-  results.push('\nnormalizeToContainerOffset_() — Paragraph element child-index to char-offset');
-
-  it('Paragraph cursor offset 0 (before all children) returns char offset 0', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var result = normalizeToContainerOffset_(para, 0);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(0);
-  });
-
-  it('Paragraph cursor offset 1 (after 1 TEXT child) returns char offset = child text length', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var result = normalizeToContainerOffset_(para, 1);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(11);
-  });
-
-  it('Paragraph cursor offset 2 with two TEXT children sums both lengths', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var text1 = createMockText('hello ', para);
-    var text2 = createMockText('world', para);
-    para._textChildren = [text1, text2];
-    var result = normalizeToContainerOffset_(para, 2);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(11);
-  });
-
-  it('Paragraph cursor offset 1 with two TEXT children returns first child length only', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    var text1 = createMockText('hello ', para);
-    var text2 = createMockText('world', para);
-    para._textChildren = [text1, text2];
-    var result = normalizeToContainerOffset_(para, 1);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(6);
-  });
-
-  it('Paragraph cursor offset exceeding child count clamps to total text length', function () {
-    var body = createMockBody(['abc']);
-    var para = body._children[0];
-    var result = normalizeToContainerOffset_(para, 5);
-    expect(result.container).toBe(para);
-    expect(result.offset).toBe(3);
-  });
-
-  // ── splitParagraphAt_ — formatting preservation ──
-
-  results.push('\nsplitParagraphAt_() — formatting preservation');
-
-  it('split preserves "before" text via deleteText (not setText)', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    para._charAttrs = {};
-    para._charAttrs[0] = { BOLD: true };
-    para._charAttrs[1] = { BOLD: true };
-    para._charAttrs[2] = { BOLD: true };
-    para._charAttrs[3] = { BOLD: true };
-    para._charAttrs[4] = { BOLD: true };
-
-    splitParagraphAt_(body, para, 6);
-
-    expect(para._text).toBe('hello ');
-    expect(body._children[1]._text).toBe('world');
-    expect(para._charAttrs[0]).toEqual({ BOLD: true });
-    expect(para._charAttrs[4]).toEqual({ BOLD: true });
-    expect(para._charAttrs[6]).toBe(undefined);
-  });
-
-  it('split reapplies character attributes to "after" paragraph', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    para._charAttrs = {};
-    for (var ci = 6; ci < 11; ci++) {
-      para._charAttrs[ci] = { ITALIC: true, FONT_FAMILY: 'Arial' };
-    }
-
-    splitParagraphAt_(body, para, 6);
-
-    var np = body._children[1];
-    expect(np._text).toBe('world');
-    expect(np._charAttrs[0]).toEqual({ ITALIC: true, FONT_FAMILY: 'Arial' });
-    expect(np._charAttrs[4]).toEqual({ ITALIC: true, FONT_FAMILY: 'Arial' });
-  });
-
-  it('split copies paragraph-level attributes to new paragraph', function () {
-    var body = createMockBody(['hello world']);
-    var para = body._children[0];
-    para._heading = DocumentApp.ParagraphHeading.HEADING1;
-    para._align = DocumentApp.HorizontalAlignment.CENTER;
-    para._ltr = false;
-    para._spacingBefore = 10;
-    para._spacingAfter = 5;
-    para.getHeading = function () { return this._heading; };
-    para.getAlignment = function () { return this._align; };
-    para.getLeftToRight = function () { return this._ltr; };
-    para.getSpacingBefore = function () { return this._spacingBefore; };
-    para.getSpacingAfter = function () { return this._spacingAfter; };
-
-    splitParagraphAt_(body, para, 6);
-
-    var np = body._children[1];
-    expect(np._heading).toBe(DocumentApp.ParagraphHeading.HEADING1);
-    expect(np._align).toBe(DocumentApp.HorizontalAlignment.CENTER);
-    expect(np._ltr).toBe(false);
-    expect(np._spacingBefore).toBe(10);
-    expect(np._spacingAfter).toBe(5);
-  });
-
-  it('split at offset 0 or offset >= len is a no-op', function () {
-    var body = createMockBody(['hello']);
-    splitParagraphAt_(body, body._children[0], 0);
-    expect(body._children.length).toBe(1);
-    expect(body._children[0]._text).toBe('hello');
-
-    splitParagraphAt_(body, body._children[0], 5);
-    expect(body._children.length).toBe(1);
-    expect(body._children[0]._text).toBe('hello');
-
-    splitParagraphAt_(body, body._children[0], 10);
-    expect(body._children.length).toBe(1);
-    expect(body._children[0]._text).toBe('hello');
-  });
-
-  // ── resolveIsolatedInsertAnchor_ — Paragraph cursor element ──
-
-  results.push('\nresolveIsolatedInsertAnchor_() — Paragraph cursor element (child-index offset)');
-
-  it('Paragraph cursor at child-index 0 inserts before paragraph', function () {
-    var body = createMockBody(['first', 'second']);
-    var para = body._children[1];
-    var doc = createMockDoc(body, para, null, 0);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  it('Paragraph cursor at child-index 1 (after all children) inserts after paragraph', function () {
-    var body = createMockBody(['hello']);
-    var para = body._children[0];
-    var doc = createMockDoc(body, para, null, 1);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(false);
-    expect(anchor.removeTarget).toBe(null);
+    expect(body._children[4]._text).toBe('third');
   });
 
   // ── Restore ─────────────────────────────────────────────────

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -1,6 +1,6 @@
 /**
- * GAS-native tests for DocumentService.gs — insertParagraphsAtPosition_(),
- * insertBlockquoteTableAtPosition_(), and helpers.
+ * GAS-native tests for DocumentService.gs — resolveIsolatedInsertAnchor_(),
+ * insertParagraphsAtPosition_(), insertBlockquoteTableAtPosition_(), and helpers.
  * Run from Apps Script editor: select runDocumentServiceTests, click Run.
  */
 
@@ -39,9 +39,21 @@ function runDocumentServiceTests() {
 
   // ── Mock factories ──────────────────────────────────────────
 
+  function createMockText(textContent, parentEl) {
+    return {
+      _text: textContent,
+      _parent: parentEl,
+      getText: function () { return this._text; },
+      getType: function () { return DocumentApp.ElementType.TEXT; },
+      asText: function () { return this; },
+      getParent: function () { return this._parent; }
+    };
+  }
+
   function createMockParagraph(text) {
     var para = {
       _text: text,
+      _textChildren: [],
       _align: null,
       _ltr: null,
       _heading: null,
@@ -58,6 +70,14 @@ function runDocumentServiceTests() {
       getType: function () { return DocumentApp.ElementType.PARAGRAPH; },
       asParagraph: function () { return this; },
       getParent: function () { return null; },
+      getChild: function (i) { return this._textChildren[i]; },
+      getNumChildren: function () { return this._textChildren.length; },
+      getChildIndex: function (child) {
+        for (var j = 0; j < this._textChildren.length; j++) {
+          if (this._textChildren[j] === child) return j;
+        }
+        throw new Error('Element does not contain the specified child element.');
+      },
       editAsText: function () {
         return {
           _owner: para,
@@ -66,6 +86,7 @@ function runDocumentServiceTests() {
         };
       }
     };
+    para._textChildren = [createMockText(text, para)];
     return para;
   }
 
@@ -130,7 +151,7 @@ function runDocumentServiceTests() {
         for (var i = 0; i < this._children.length; i++) {
           if (this._children[i] === child) return i;
         }
-        return -1;
+        throw new Error('Element does not contain the specified child element.');
       },
       insertParagraph: function (index, text) {
         var p = createMockParagraph(text);
@@ -153,28 +174,45 @@ function runDocumentServiceTests() {
     };
   }
 
-  function createMockDoc(body, cursorParagraph, selectionElements) {
+  /**
+   * @param {*} body
+   * @param {*} cursorParagraph - element for cursor (or null)
+   * @param {Array} selectionElements - optional range elements (see mockRangeEl_)
+   * @param {number} [cursorOffset] - defaults to end of cursor paragraph text
+   */
+  function createMockDoc(body, cursorParagraph, selectionElements, cursorOffset) {
     return {
       getBody: function () { return body; },
       getId: function () { return 'mock-doc-id'; },
       getCursor: function () {
         if (!cursorParagraph) return null;
+        var co = cursorOffset;
+        if (co === undefined || co === null) {
+          co = cursorParagraph.getText ? cursorParagraph.getText().length : 0;
+        }
         return {
-          getElement: function () { return cursorParagraph; }
+          getElement: function () { return cursorParagraph; },
+          getOffset: function () { return co; }
         };
       },
       getSelection: function () {
         if (!selectionElements || selectionElements.length === 0) return null;
         return {
           getRangeElements: function () {
-            return selectionElements.map(function (el) {
-              return { getElement: function () { return el; } };
-            });
+            return selectionElements;
           }
         };
       },
       setCursor: function () {},
       newPosition: function () { return {}; }
+    };
+  }
+
+  function mockRangeEl_(element, partial, endOffsetInclusive) {
+    return {
+      getElement: function () { return element; },
+      isPartial: function () { return !!partial; },
+      getEndOffsetInclusive: function () { return endOffsetInclusive; }
     };
   }
 
@@ -277,19 +315,18 @@ function runDocumentServiceTests() {
     expect(body._children[2]._ltr).toBe(true);
   });
 
-  it('no cursor, all paragraphs empty — replaces first, NO cleanup (empties remain after)', function () {
+  it('no cursor, all paragraphs empty — appends top buffer, content, bottom after empties', function () {
     var body = createMockBody(['', '', '']);
     var doc = createMockDoc(body, null);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // Reuse first empty for content → [content, '', '']
-    // Content is NOT last child → no cleanup
-    expect(body._children.length).toBe(3);
-    expect(body._children[0]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[1]._text).toBe('');
-    expect(body._children[1]._heading).toBe(null);
-    expect(body._children[2]._text).toBe('');
+    // Fallback baseIndex=3, topBuffer → [e0,e1,e2, top, content, bottom]
+    expect(body._children.length).toBe(6);
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
   });
 
   it('new doc (single empty paragraph, no cursor) — content + cleanup', function () {
@@ -321,51 +358,53 @@ function runDocumentServiceTests() {
     expect(body._children[3]._ltr).toBe(true);
   });
 
-  results.push('\ninsertParagraphsAtPosition_() — conditional cleanup');
+  results.push('\ninsertParagraphsAtPosition_() — bottom buffer when not at doc end');
 
-  it('no cursor, trailing empties after last non-empty — NO cleanup', function () {
+  it('no cursor, trailing empties after last non-empty — top buffer, content, bottom after trailing empty', function () {
     var body = createMockBody(['first', 'second', '']);
     var doc = createMockDoc(body, null);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // Insert after 'second' (index 2), trailing '' pushed to index 3
-    // [first, second, content, ''] — content is NOT last → no cleanup
-    expect(body._children.length).toBe(4);
+    // [first, second, '', top, content, bottom]
+    expect(body._children.length).toBe(6);
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('second');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[2]._text).toBe('');
     expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(null);
+    expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
   });
 
-  it('cursor on non-empty paragraph with paragraphs below — NO cleanup', function () {
+  it('cursor at end of first paragraph with paragraphs below — content, bottom, then rest', function () {
     var body = createMockBody(['first', 'second', 'third']);
     var cursorPara = body._children[0];
     var doc = createMockDoc(body, cursorPara);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [first, content, second, third] — content is NOT last → no cleanup
-    expect(body._children.length).toBe(4);
+    // End of "first" → no top buffer; [first, content, bottom, second, third]
+    expect(body._children.length).toBe(5);
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('second');
-    expect(body._children[3]._text).toBe('third');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[3]._text).toBe('second');
+    expect(body._children[4]._text).toBe('third');
   });
 
-  it('cursor on non-empty paragraph with only spaces paragraph below — NO cleanup', function () {
+  it('cursor at end of first with only spaces paragraph below — bottom buffer before spaces', function () {
     var body = createMockBody(['first', '   ']);
     var cursorPara = body._children[0];
     var doc = createMockDoc(body, cursorPara);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [first, content, '   '] — spaces paragraph after → no cleanup
-    expect(body._children.length).toBe(3);
+    expect(body._children.length).toBe(4);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('   ');
-    expect(body._children[2]._heading).toBe(null);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[3]._text).toBe('   ');
   });
 
   results.push('\ninsertParagraphsAtPosition_() — paragraph spacing (insert beautify)');
@@ -378,6 +417,7 @@ function runDocumentServiceTests() {
     expect(body._children[0]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
     expect(body._children[1]._spacingBefore).toBe(null);
     expect(body._children[1]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
+    expect(body._children[2]._text).toBe('');
   });
 
   it('Arabic + translation three-paragraph block applies outer and inner spacing', function () {
@@ -390,6 +430,7 @@ function runDocumentServiceTests() {
     expect(body._children[1]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
     expect(body._children[2]._spacingBefore).toBe(null);
     expect(body._children[2]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
+    expect(body._children[3]._text).toBe('');
   });
 
   results.push('\ninsertParagraphsAtPosition_() — multi-paragraph & font warning');
@@ -475,20 +516,21 @@ function runDocumentServiceTests() {
     expect(body._children[4]._spacingAfter).toBe(0);
   });
 
-  it('three content paragraphs with content after — NO cleanup', function () {
+  it('three content paragraphs with content after — bottom buffer before following paragraph', function () {
     var body = createMockBody(['existing', 'after']);
     var cursorPara = body._children[0];
     var doc = createMockDoc(body, cursorPara);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, arabic, translation, citation, after] — no cleanup
-    expect(body._children.length).toBe(5);
+    // End of "existing" → [existing, arabic, translation, citation, bottom, after]
+    expect(body._children.length).toBe(6);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[2]._text).toBe('"translation"');
     expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
-    expect(body._children[4]._text).toBe('after');
-    expect(body._children[4]._heading).toBe(null);
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[5]._text).toBe('after');
   });
 
   results.push('\ninsertParagraphsAtPosition_() — regression: sequential insertion & removeChild');
@@ -581,21 +623,19 @@ function runDocumentServiceTests() {
     expect(cell._inner[2]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
   });
 
-  it('blockquote: non-empty doc — top buffer, table, typing paragraph', function () {
+  it('blockquote: non-empty doc — cursor at end of paragraph: table, typing, no top buffer', function () {
     var body = createMockBody(['existing', 'after']);
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // cursor on 'existing' (non-empty) → insertIndex 1 → top buffer at 1, table at 2
-    // [existing, topBuffer, TABLE, typingParagraph, after]
-    expect(body._children.length).toBe(5);
+    // End of "existing" → [existing, TABLE, typingParagraph, after]
+    expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('existing');
-    expect(body._children[1]._text).toBe('');
-    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[3]._ltr).toBe(true);
-    expect(body._children[4]._text).toBe('after');
+    expect(body._children[1].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[2]._ltr).toBe(true);
+    expect(body._children[3]._text).toBe('after');
   });
 
   it('blockquote: empty doc skips top buffer paragraph', function () {
@@ -608,20 +648,13 @@ function runDocumentServiceTests() {
     expect(body._children[0]._cell._inner[0]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
   });
 
-  it('blockquote: top buffer and typing paragraph have no explicit spacing set', function () {
+  it('blockquote: typing paragraph has no explicit spacing (after end-of-para insert)', function () {
     var body = createMockBody(['content above', 'more content']);
     var doc = createMockDoc(body, body._children[1]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // cursor on 'more content' (non-empty, last) → insertIndex 2, top buffer at 2, table at 3
-    // [content above, more content, topBuffer, TABLE, typingParagraph]
-    var topBuf = body._children[2];
-    expect(topBuf._text).toBe('');
-    expect(topBuf._fontSize).toBe(null);
-    expect(topBuf._spacingBefore).toBe(null);
-    expect(topBuf._spacingAfter).toBe(null);
-
-    var typing = body._children[4];
+    // End of last body paragraph → no top buffer; [ca, more, TABLE, typing]
+    var typing = body._children[3];
     expect(typing._text).toBe('');
     expect(typing._fontSize).toBe(null);
     expect(typing._spacingBefore).toBe(null);
@@ -633,8 +666,8 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [text, topBuffer, TABLE, typingParagraph]
-    var typing = body._children[3];
+    // [text, TABLE, typingParagraph]
+    var typing = body._children[2];
     expect(typing._text).toBe('');
     expect(typing._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
     expect(typing._ltr).toBe(true);
@@ -790,56 +823,278 @@ function runDocumentServiceTests() {
     applyBlockquoteCellBordersViaDocsApi_ = origBorders;
   });
 
-  // ── resolveInsertAnchor_ — getSelection() fallback ──────────
+  // ── resolveIsolatedInsertAnchor_ — getSelection() fallback ─
 
-  results.push('\nresolveInsertAnchor_() — getSelection() fallback');
+  results.push('\nresolveIsolatedInsertAnchor_() — getSelection() fallback');
 
-  it('selection on non-empty body paragraph inserts after it', function () {
+  it('selection on non-empty body paragraph inserts after it (end collapsed)', function () {
     var body = createMockBody(['first', 'second', 'third']);
-    var doc = createMockDoc(body, null, [body._children[1]]);
-    var anchor = resolveInsertAnchor_(body, doc);
-    expect(anchor.insertIndex).toBe(2);
+    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1], false)]);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(2);
+    expect(anchor.topBuffer).toBe(false);
     expect(anchor.removeTarget).toBe(null);
   });
 
   it('selection on empty body paragraph reuses it', function () {
     var body = createMockBody(['first', '', 'third']);
-    var doc = createMockDoc(body, null, [body._children[1]]);
-    var anchor = resolveInsertAnchor_(body, doc);
-    expect(anchor.insertIndex).toBe(1);
+    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1], false)]);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(false);
     expect(anchor.removeTarget).toBe(body._children[1]);
   });
 
-  // ── resolveInsertAnchor_ — nested cursor (inside table cell) ──
+  // ── resolveIsolatedInsertAnchor_ — nested cursor (inside table cell) ──
 
-  results.push('\nresolveInsertAnchor_() — nested cursor inside table');
+  results.push('\nresolveIsolatedInsertAnchor_() — nested cursor inside table');
 
-  it('cursor inside table cell paragraph resolves to body-level table index + 1', function () {
+  it('cursor inside table cell paragraph resolves after table with top buffer', function () {
     var body = createMockBody(['before']);
     var tbl = createMockTable();
     body._children.push(tbl);
     body._children.push(createMockParagraph('after'));
-    // Cursor is on the paragraph inside the table cell
     var cellPara = tbl._cell._inner[0];
     cellPara.getParent = function () { return tbl; };
     var doc = createMockDoc(body, cellPara);
-    var anchor = resolveInsertAnchor_(body, doc);
-    // Table is at body index 1 → insert after it at index 2
-    expect(anchor.insertIndex).toBe(2);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(2);
+    expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(null);
   });
 
-  it('selection inside table cell resolves to body-level table index + 1', function () {
+  it('selection inside table cell resolves after table with top buffer', function () {
     var body = createMockBody(['before']);
     var tbl = createMockTable();
     body._children.push(tbl);
     body._children.push(createMockParagraph('after'));
     var cellPara = tbl._cell._inner[0];
     cellPara.getParent = function () { return tbl; };
-    var doc = createMockDoc(body, null, [cellPara]);
-    var anchor = resolveInsertAnchor_(body, doc);
-    expect(anchor.insertIndex).toBe(2);
+    var doc = createMockDoc(body, null, [mockRangeEl_(cellPara, false)]);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(2);
+    expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(null);
+  });
+
+  results.push('\nresolveIsolatedInsertAnchor_() — start / split / list');
+
+  function createMockListItem(text, listId) {
+    var li = createMockParagraph(text);
+    li.getType = function () { return DocumentApp.ElementType.LIST_ITEM; };
+    li.asListItem = function () { return this; };
+    li.getListId = function () { return listId; };
+    return li;
+  }
+
+  it('cursor at start of second paragraph — top buffer then insert before it', function () {
+    var body = createMockBody(['first', 'second']);
+    var doc = createMockDoc(body, body._children[1], null, 0);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(true);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  it('cursor in middle of paragraph — splits then insert region has top buffer', function () {
+    var body = createMockBody(['hello world']);
+    var doc = createMockDoc(body, body._children[0], null, 6);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(body._children[0]._text).toBe('hello ');
+    expect(body._children[1]._text).toBe('world');
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(true);
+  });
+
+  it('cursor in list — anchor after contiguous same-listId block', function () {
+    var body = createMockBody(['intro']);
+    body._children.push(createMockListItem('one', 'L9'));
+    body._children.push(createMockListItem('two', 'L9'));
+    var doc = createMockDoc(body, body._children[1]);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(3);
+    expect(anchor.topBuffer).toBe(true);
+  });
+
+  // ── normalizeToContainerOffset_ — Text cursor element ───────
+
+  results.push('\nnormalizeToContainerOffset_() — Text element cursor');
+
+  it('Text cursor at offset 6 in "hello world" returns container offset 6', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var result = normalizeToContainerOffset_(textEl, 6);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(6);
+  });
+
+  it('Text cursor at offset 0 returns container offset 0', function () {
+    var body = createMockBody(['some text']);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var result = normalizeToContainerOffset_(textEl, 0);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(0);
+  });
+
+  it('Text cursor at end of text returns container offset equal to length', function () {
+    var body = createMockBody(['hello']);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var result = normalizeToContainerOffset_(textEl, 5);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(5);
+  });
+
+  it('Text cursor in second text child accounts for first child length', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    var text1 = createMockText('hello ', para);
+    var text2 = createMockText('world', para);
+    para._textChildren = [text1, text2];
+    var result = normalizeToContainerOffset_(text2, 3);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(9);
+  });
+
+  // ── resolveIsolatedInsertAnchor_ — Text cursor split / start ──
+
+  results.push('\nresolveIsolatedInsertAnchor_() — Text cursor split / start');
+
+  it('Text cursor at middle of paragraph triggers split', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 6);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(body._children[0]._text).toBe('hello ');
+    expect(body._children[1]._text).toBe('world');
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(true);
+  });
+
+  it('Text cursor at beginning of paragraph inserts before it', function () {
+    var body = createMockBody(['first', 'second']);
+    var para = body._children[1];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 0);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(true);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  it('Text cursor at end of paragraph inserts after it', function () {
+    var body = createMockBody(['hello']);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 5);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  // ── End-to-end: blockquote insert with cursor in table cell ──
+
+  results.push('\ninsertBlockquoteTableAtPosition_() — cursor in table cell');
+
+  it('blockquote: cursor in table cell inserts table after the existing table', function () {
+    var body = createMockBody(['before']);
+    var tbl = createMockTable();
+    body._children.push(tbl);
+    body._children.push(createMockParagraph('after'));
+    var cellPara = tbl._cell._inner[0];
+    cellPara.getParent = function () { return tbl; };
+    var doc = createMockDoc(body, cellPara);
+    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    // [before, existingTable, topBuffer, NEW TABLE, typingPara, after]
+    expect(body._children[0]._text).toBe('before');
+    expect(body._children[1]).toBe(tbl);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[5]._text).toBe('after');
+    expect(result.pendingBorders.tableOrdinal).toBe(2);
+  });
+
+  // ── End-to-end: blockquote + plain insert with mid-paragraph cursor ──
+
+  results.push('\ninsertBlockquoteTableAtPosition_() — mid-paragraph split (Text cursor)');
+
+  it('blockquote: Text cursor mid-paragraph splits and inserts table between halves', function () {
+    var body = createMockBody(['hello world', 'after']);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 6);
+    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    // ["hello ", topBuffer, TABLE, typingPara, "world", "after"]
+    expect(body._children[0]._text).toBe('hello ');
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._text).toBe('world');
+    expect(body._children[5]._text).toBe('after');
+  });
+
+  it('plain: Text cursor mid-paragraph splits and inserts content between halves', function () {
+    var body = createMockBody(['hello world', 'after']);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 6);
+    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    // ["hello ", topBuffer, content, bottom, "world", "after"]
+    expect(body._children[0]._text).toBe('hello ');
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._text).toBe('world');
+    expect(body._children[5]._text).toBe('after');
+  });
+
+  // ── End-to-end: blockquote + plain insert with cursor at beginning ──
+
+  results.push('\ninsertBlockquoteTableAtPosition_() — beginning of paragraph (Text cursor)');
+
+  it('blockquote: Text cursor at beginning inserts table before paragraph', function () {
+    var body = createMockBody(['first', 'second', 'third']);
+    var para = body._children[1];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 0);
+    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    // ["first", topBuffer, TABLE, typingPara, "second", "third"]
+    expect(body._children[0]._text).toBe('first');
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._text).toBe('second');
+    expect(body._children[5]._text).toBe('third');
+  });
+
+  it('plain: Text cursor at beginning inserts content before paragraph', function () {
+    var body = createMockBody(['first', 'second', 'third']);
+    var para = body._children[1];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 0);
+    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    // ["first", topBuffer, content, bottom, "second", "third"]
+    expect(body._children[0]._text).toBe('first');
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._text).toBe('second');
+    expect(body._children[5]._text).toBe('third');
   });
 
   // ── Restore ─────────────────────────────────────────────────

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -293,19 +293,20 @@ function runDocumentServiceTests() {
     expect(body._children[1]._ltr).toBe(true);
   });
 
-  it('cursor on non-empty paragraph (last child) — inserts below, adds cleanup', function () {
+  it('cursor on non-empty paragraph (last child) — top buffer, content, cleanup', function () {
     var body = createMockBody(['existing text']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [existing, content, cleanup]
-    expect(body._children.length).toBe(3);
+    // [existing, topBuffer, content, cleanup]
+    expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('existing text');
-    expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('');
-    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[2]._ltr).toBe(true);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[3]._ltr).toBe(true);
   });
 
   it('no cursor, all paragraphs empty — appends top buffer, content, bottom after empties', function () {
@@ -336,18 +337,19 @@ function runDocumentServiceTests() {
     expect(body._children[1]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
   });
 
-  it('cursor at last paragraph (non-empty) — content appended, cleanup is last', function () {
+  it('cursor at last paragraph (non-empty) — top buffer, content, cleanup is last', function () {
     var body = createMockBody(['first', 'last']);
     var doc = createMockDoc(body, body._children[1]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [first, last, content, cleanup]
-    expect(body._children.length).toBe(4);
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[3]._ltr).toBe(true);
+    // [first, last, topBuffer, content, cleanup]
+    expect(body._children.length).toBe(5);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._ltr).toBe(true);
   });
 
   results.push('\ninsertParagraphsAtPosition_() — bottom buffer when not at doc end');
@@ -368,32 +370,30 @@ function runDocumentServiceTests() {
     expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
   });
 
-  it('cursor at first paragraph with paragraphs below — content after first, then rest', function () {
+  it('cursor at first paragraph with paragraphs below — top buffer, content, then rest (no extra bottom)', function () {
     var body = createMockBody(['first', 'second', 'third']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [first, content, bottom, second, third]
+    // [first, topBuffer, content, second, third]
     expect(body._children.length).toBe(5);
     expect(body._children[0]._text).toBe('first');
-    expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('');
-    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
     expect(body._children[3]._text).toBe('second');
     expect(body._children[4]._text).toBe('third');
   });
 
-  it('cursor at first with only spaces paragraph below — bottom buffer before spaces', function () {
+  it('cursor at first with only spaces paragraph below — top buffer, content, cursor in spaces paragraph', function () {
     var body = createMockBody(['first', '   ']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
     expect(body._children.length).toBe(4);
-    expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('');
-    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
     expect(body._children[3]._text).toBe('   ');
   });
 
@@ -452,6 +452,8 @@ function runDocumentServiceTests() {
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), fs);
 
+    // [existing, topBuffer, arabic, translation, citation, bottom]
+    expect(body._children.length).toBe(6);
     expect(applyFormatCalls.length).toBe(3);
     expect(applyFormatCalls[0]).toBe(fs);
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
@@ -484,40 +486,40 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[1].fontSize).toBe(15);
   });
 
-  it('three content paragraphs at end — all inserted, cleanup follows', function () {
+  it('three content paragraphs at end — top buffer, all inserted, cleanup follows', function () {
     var body = createMockBody(['existing']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, arabic, translation, citation, cleanup]
-    expect(body._children.length).toBe(5);
-    expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[1]._ltr).toBe(false);
-    expect(body._children[2]._text).toBe('"translation"');
-    expect(body._children[2]._ltr).toBe(true);
-    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
+    // [existing, topBuffer, arabic, translation, citation, cleanup]
+    expect(body._children.length).toBe(6);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
+    expect(body._children[2]._ltr).toBe(false);
+    expect(body._children[3]._text).toBe('"translation"');
     expect(body._children[3]._ltr).toBe(true);
-    expect(body._children[4]._text).toBe('');
-    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[4]._text).toBe('(Al-Fatiha\u00A01:1)');
     expect(body._children[4]._ltr).toBe(true);
-    expect(body._children[4]._spacingBefore).toBe(0);
-    expect(body._children[4]._spacingAfter).toBe(0);
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[5]._ltr).toBe(true);
+    expect(body._children[5]._spacingBefore).toBe(0);
+    expect(body._children[5]._spacingAfter).toBe(0);
   });
 
-  it('three content paragraphs with content after — bottom buffer before following paragraph', function () {
+  it('three content paragraphs with content after — top buffer, no extra bottom before following paragraph', function () {
     var body = createMockBody(['existing', 'after']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, arabic, translation, citation, bottom, after]
+    // [existing, topBuffer, arabic, translation, citation, after]
     expect(body._children.length).toBe(6);
-    expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('"translation"');
-    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
-    expect(body._children[4]._text).toBe('');
-    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
+    expect(body._children[3]._text).toBe('"translation"');
+    expect(body._children[4]._text).toBe('(Al-Fatiha\u00A01:1)');
     expect(body._children[5]._text).toBe('after');
   });
 
@@ -541,13 +543,14 @@ function runDocumentServiceTests() {
     var doc2 = createMockDoc(body, cleanup);
     insertParagraphsAtPosition_(body, doc2, singleArabicParagraph(), {});
 
-    // [arabic1, translation1, citation1, arabic2, cleanup2]
-    expect(body._children.length).toBe(5);
+    // [arabic1, translation1, citation1, topBuffer, arabic2, cleanup2]
+    expect(body._children.length).toBe(6);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[1]._text).toBe('"translation"');
     expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
-    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[4]._text).toBe('');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[5]._text).toBe('');
   });
 
   it('empty paragraph reuse avoids removeChild entirely', function () {
@@ -607,18 +610,16 @@ function runDocumentServiceTests() {
     expect(cell._inner[2]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
   });
 
-  it('blockquote: non-empty doc — cursor on paragraph: table after it, no top buffer', function () {
+  it('blockquote: non-empty doc — top buffer, table, cursor in following paragraph (no extra typing para)', function () {
     var body = createMockBody(['existing', 'after']);
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [existing, TABLE, typingParagraph, after]
+    // [existing, topBuffer, TABLE, after]
     expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('existing');
-    expect(body._children[1].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[2]._text).toBe('');
-    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[2]._ltr).toBe(true);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[3]._text).toBe('after');
   });
 
@@ -636,7 +637,8 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[1]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    var typing = body._children[3];
+    // [above, more, topBuffer, TABLE, typing]
+    var typing = body._children[4];
     expect(typing._text).toBe('');
     expect(typing._fontSize).toBe(null);
     expect(typing._spacingBefore).toBe(null);
@@ -648,8 +650,8 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [text, TABLE, typingParagraph]
-    var typing = body._children[2];
+    // [text, topBuffer, TABLE, typingParagraph]
+    var typing = body._children[3];
     expect(typing._text).toBe('');
     expect(typing._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
     expect(typing._ltr).toBe(true);
@@ -813,7 +815,7 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[1]);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(2);
-    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(null);
   });
 
@@ -822,7 +824,7 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[1]);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(body._children[1]);
   });
 
@@ -832,7 +834,7 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, textEl);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(null);
   });
 
@@ -841,7 +843,7 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1])]);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(2);
-    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(null);
   });
 
@@ -850,7 +852,7 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1])]);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.topBuffer).toBe(true);
     expect(anchor.removeTarget).toBe(body._children[1]);
   });
 
@@ -922,14 +924,12 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, cellPara);
     var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [before, existingTable, topBuffer, NEW TABLE, typingPara, after]
+    // [before, existingTable, topBuffer, NEW TABLE, after]
     expect(body._children[0]._text).toBe('before');
     expect(body._children[1]).toBe(tbl);
     expect(body._children[2]._text).toBe('');
     expect(body._children[3].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[4]._text).toBe('');
-    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[5]._text).toBe('after');
+    expect(body._children[4]._text).toBe('after');
     expect(result.pendingBorders.tableOrdinal).toBe(2);
   });
 
@@ -942,11 +942,10 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["hello world", TABLE, typingPara, "after"]
+    // ["hello world", topBuffer, TABLE, "after"]
     expect(body._children[0]._text).toBe('hello world');
-    expect(body._children[1].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[2]._text).toBe('');
-    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[3]._text).toBe('after');
   });
 
@@ -955,11 +954,10 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[0]);
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["hello world", content, bottom, "after"]
+    // ["hello world", topBuffer, content, "after"]
     expect(body._children[0]._text).toBe('hello world');
-    expect(body._children[1]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[2]._text).toBe('');
-    expect(body._children[2]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
     expect(body._children[3]._text).toBe('after');
   });
 
@@ -968,12 +966,11 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[1]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["first", "second", TABLE, typingPara, "third"]
+    // ["first", "second", topBuffer, TABLE, "third"]
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('second');
-    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[4]._text).toBe('third');
   });
 
@@ -982,12 +979,11 @@ function runDocumentServiceTests() {
     var doc = createMockDoc(body, body._children[1]);
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["first", "second", content, bottom, "third"]
+    // ["first", "second", topBuffer, content, "third"]
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('second');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
     expect(body._children[4]._text).toBe('third');
   });
 

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -82,7 +82,31 @@ function runDocumentServiceTests() {
         return {
           _owner: para,
           setFontSize: function (s) { para._fontSize = s; return this; },
-          getFontSize: function () { return para._fontSize; }
+          getFontSize: function () { return para._fontSize; },
+          getAttributes: function (charIndex) {
+            if (!para._charAttrs) return null;
+            return para._charAttrs[charIndex] || null;
+          },
+          setAttributes: function (startOffset, endOffset, attrs) {
+            if (!para._charAttrs) para._charAttrs = {};
+            for (var ai = startOffset; ai <= endOffset; ai++) {
+              para._charAttrs[ai] = attrs;
+            }
+            return this;
+          },
+          deleteText: function (startOffset, endOffset) {
+            var t = para._text;
+            para._text = t.substring(0, startOffset) + t.substring(endOffset + 1);
+            if (para._charAttrs) {
+              var newAttrs = {};
+              for (var ai = 0; ai < startOffset; ai++) {
+                if (para._charAttrs[ai]) newAttrs[ai] = para._charAttrs[ai];
+              }
+              para._charAttrs = newAttrs;
+            }
+            para._textChildren = [createMockText(para._text, para)];
+            return this;
+          }
         };
       }
     };
@@ -898,7 +922,9 @@ function runDocumentServiceTests() {
 
   it('cursor in middle of paragraph — splits then insert region has top buffer', function () {
     var body = createMockBody(['hello world']);
-    var doc = createMockDoc(body, body._children[0], null, 6);
+    var para = body._children[0];
+    var textEl = para._textChildren[0];
+    var doc = createMockDoc(body, textEl, null, 6);
     var anchor = resolveIsolatedInsertAnchor_(body, doc);
     expect(body._children[0]._text).toBe('hello ');
     expect(body._children[1]._text).toBe('world');
@@ -1095,6 +1121,158 @@ function runDocumentServiceTests() {
     expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
     expect(body._children[4]._text).toBe('second');
     expect(body._children[5]._text).toBe('third');
+  });
+
+  // ── normalizeToContainerOffset_ — Paragraph element with child-index offset ──
+
+  results.push('\nnormalizeToContainerOffset_() — Paragraph element child-index to char-offset');
+
+  it('Paragraph cursor offset 0 (before all children) returns char offset 0', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    var result = normalizeToContainerOffset_(para, 0);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(0);
+  });
+
+  it('Paragraph cursor offset 1 (after 1 TEXT child) returns char offset = child text length', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    var result = normalizeToContainerOffset_(para, 1);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(11);
+  });
+
+  it('Paragraph cursor offset 2 with two TEXT children sums both lengths', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    var text1 = createMockText('hello ', para);
+    var text2 = createMockText('world', para);
+    para._textChildren = [text1, text2];
+    var result = normalizeToContainerOffset_(para, 2);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(11);
+  });
+
+  it('Paragraph cursor offset 1 with two TEXT children returns first child length only', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    var text1 = createMockText('hello ', para);
+    var text2 = createMockText('world', para);
+    para._textChildren = [text1, text2];
+    var result = normalizeToContainerOffset_(para, 1);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(6);
+  });
+
+  it('Paragraph cursor offset exceeding child count clamps to total text length', function () {
+    var body = createMockBody(['abc']);
+    var para = body._children[0];
+    var result = normalizeToContainerOffset_(para, 5);
+    expect(result.container).toBe(para);
+    expect(result.offset).toBe(3);
+  });
+
+  // ── splitParagraphAt_ — formatting preservation ──
+
+  results.push('\nsplitParagraphAt_() — formatting preservation');
+
+  it('split preserves "before" text via deleteText (not setText)', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    para._charAttrs = {};
+    para._charAttrs[0] = { BOLD: true };
+    para._charAttrs[1] = { BOLD: true };
+    para._charAttrs[2] = { BOLD: true };
+    para._charAttrs[3] = { BOLD: true };
+    para._charAttrs[4] = { BOLD: true };
+
+    splitParagraphAt_(body, para, 6);
+
+    expect(para._text).toBe('hello ');
+    expect(body._children[1]._text).toBe('world');
+    expect(para._charAttrs[0]).toEqual({ BOLD: true });
+    expect(para._charAttrs[4]).toEqual({ BOLD: true });
+    expect(para._charAttrs[6]).toBe(undefined);
+  });
+
+  it('split reapplies character attributes to "after" paragraph', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    para._charAttrs = {};
+    for (var ci = 6; ci < 11; ci++) {
+      para._charAttrs[ci] = { ITALIC: true, FONT_FAMILY: 'Arial' };
+    }
+
+    splitParagraphAt_(body, para, 6);
+
+    var np = body._children[1];
+    expect(np._text).toBe('world');
+    expect(np._charAttrs[0]).toEqual({ ITALIC: true, FONT_FAMILY: 'Arial' });
+    expect(np._charAttrs[4]).toEqual({ ITALIC: true, FONT_FAMILY: 'Arial' });
+  });
+
+  it('split copies paragraph-level attributes to new paragraph', function () {
+    var body = createMockBody(['hello world']);
+    var para = body._children[0];
+    para._heading = DocumentApp.ParagraphHeading.HEADING1;
+    para._align = DocumentApp.HorizontalAlignment.CENTER;
+    para._ltr = false;
+    para._spacingBefore = 10;
+    para._spacingAfter = 5;
+    para.getHeading = function () { return this._heading; };
+    para.getAlignment = function () { return this._align; };
+    para.getLeftToRight = function () { return this._ltr; };
+    para.getSpacingBefore = function () { return this._spacingBefore; };
+    para.getSpacingAfter = function () { return this._spacingAfter; };
+
+    splitParagraphAt_(body, para, 6);
+
+    var np = body._children[1];
+    expect(np._heading).toBe(DocumentApp.ParagraphHeading.HEADING1);
+    expect(np._align).toBe(DocumentApp.HorizontalAlignment.CENTER);
+    expect(np._ltr).toBe(false);
+    expect(np._spacingBefore).toBe(10);
+    expect(np._spacingAfter).toBe(5);
+  });
+
+  it('split at offset 0 or offset >= len is a no-op', function () {
+    var body = createMockBody(['hello']);
+    splitParagraphAt_(body, body._children[0], 0);
+    expect(body._children.length).toBe(1);
+    expect(body._children[0]._text).toBe('hello');
+
+    splitParagraphAt_(body, body._children[0], 5);
+    expect(body._children.length).toBe(1);
+    expect(body._children[0]._text).toBe('hello');
+
+    splitParagraphAt_(body, body._children[0], 10);
+    expect(body._children.length).toBe(1);
+    expect(body._children[0]._text).toBe('hello');
+  });
+
+  // ── resolveIsolatedInsertAnchor_ — Paragraph cursor element ──
+
+  results.push('\nresolveIsolatedInsertAnchor_() — Paragraph cursor element (child-index offset)');
+
+  it('Paragraph cursor at child-index 0 inserts before paragraph', function () {
+    var body = createMockBody(['first', 'second']);
+    var para = body._children[1];
+    var doc = createMockDoc(body, para, null, 0);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(true);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  it('Paragraph cursor at child-index 1 (after all children) inserts after paragraph', function () {
+    var body = createMockBody(['hello']);
+    var para = body._children[0];
+    var doc = createMockDoc(body, para, null, 1);
+    var anchor = resolveIsolatedInsertAnchor_(body, doc);
+    expect(anchor.baseIndex).toBe(1);
+    expect(anchor.topBuffer).toBe(false);
+    expect(anchor.removeTarget).toBe(null);
   });
 
   // ── Restore ─────────────────────────────────────────────────

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -153,7 +153,7 @@ function runDocumentServiceTests() {
     };
   }
 
-  function createMockDoc(body, cursorParagraph) {
+  function createMockDoc(body, cursorParagraph, selectionElements) {
     return {
       getBody: function () { return body; },
       getId: function () { return 'mock-doc-id'; },
@@ -161,6 +161,16 @@ function runDocumentServiceTests() {
         if (!cursorParagraph) return null;
         return {
           getElement: function () { return cursorParagraph; }
+        };
+      },
+      getSelection: function () {
+        if (!selectionElements || selectionElements.length === 0) return null;
+        return {
+          getRangeElements: function () {
+            return selectionElements.map(function (el) {
+              return { getElement: function () { return el; } };
+            });
+          }
         };
       },
       setCursor: function () {},
@@ -737,50 +747,100 @@ function runDocumentServiceTests() {
 
   // ── tableOrdinal computation in insertBlockquoteTableAtPosition_ ──
 
-  results.push('\ninsertBlockquoteTableAtPosition_() — ordinal targeting');
+  results.push('\ninsertBlockquoteTableAtPosition_() — ordinal targeting (pendingBorders)');
 
-  var capturedTableOrdinal = null;
-  var originalApplyBorders = applyBlockquoteCellBordersViaDocsApi_;
-  applyBlockquoteCellBordersViaDocsApi_ = function (docId, tableOrdinal) {
-    capturedTableOrdinal = tableOrdinal;
-  };
-
-  it('single table in empty doc gets tableOrdinal 1', function () {
-    capturedTableOrdinal = null;
+  it('single table in empty doc returns pendingBorders with tableOrdinal 1', function () {
     var body = createMockBody(['']);
     var doc = createMockDoc(body, body._children[0]);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(capturedTableOrdinal).toBe(1);
+    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+    expect(result.pendingBorders.docId).toBe('mock-doc-id');
+    expect(result.pendingBorders.tableOrdinal).toBe(1);
   });
 
-  it('new table after one pre-existing table gets tableOrdinal 2', function () {
-    capturedTableOrdinal = null;
+  it('new table after one pre-existing table returns tableOrdinal 2', function () {
     var body = createMockBody(['text before', 'cursor here']);
     var existingTable = createMockTable();
     body._children.splice(1, 0, existingTable);
     var cursorPara = body._children[2];
     var doc = createMockDoc(body, cursorPara);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(capturedTableOrdinal).toBe(2);
+    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+    expect(result.pendingBorders.tableOrdinal).toBe(2);
   });
 
-  it('new table between two pre-existing tables gets tableOrdinal 2', function () {
-    capturedTableOrdinal = null;
+  it('new table between two pre-existing tables returns tableOrdinal 2', function () {
     var body = createMockBody(['before', 'middle', 'after']);
     var table1 = createMockTable();
     body._children.splice(1, 0, table1);
     var table2 = createMockTable();
     body._children.splice(3, 0, table2);
-    // body: [para"before", table1, para"middle", table2, para"after"]
-    var cursorPara = body._children[2]; // para "middle"
+    var cursorPara = body._children[2];
     var doc = createMockDoc(body, cursorPara);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    // inserted after "middle" at index 3, pushing table2 to 4
-    // body: [para"before", table1, para"middle", newTable, table2, para"after"]
-    expect(capturedTableOrdinal).toBe(2);
+    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+    expect(result.pendingBorders.tableOrdinal).toBe(2);
   });
 
-  applyBlockquoteCellBordersViaDocsApi_ = originalApplyBorders;
+  it('blockquote does NOT call applyBlockquoteCellBordersViaDocsApi_ inline', function () {
+    var called = false;
+    var origBorders = applyBlockquoteCellBordersViaDocsApi_;
+    applyBlockquoteCellBordersViaDocsApi_ = function () { called = true; };
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+    expect(called).toBe(false);
+    applyBlockquoteCellBordersViaDocsApi_ = origBorders;
+  });
+
+  // ── resolveInsertAnchor_ — getSelection() fallback ──────────
+
+  results.push('\nresolveInsertAnchor_() — getSelection() fallback');
+
+  it('selection on non-empty body paragraph inserts after it', function () {
+    var body = createMockBody(['first', 'second', 'third']);
+    var doc = createMockDoc(body, null, [body._children[1]]);
+    var anchor = resolveInsertAnchor_(body, doc);
+    expect(anchor.insertIndex).toBe(2);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  it('selection on empty body paragraph reuses it', function () {
+    var body = createMockBody(['first', '', 'third']);
+    var doc = createMockDoc(body, null, [body._children[1]]);
+    var anchor = resolveInsertAnchor_(body, doc);
+    expect(anchor.insertIndex).toBe(1);
+    expect(anchor.removeTarget).toBe(body._children[1]);
+  });
+
+  // ── resolveInsertAnchor_ — nested cursor (inside table cell) ──
+
+  results.push('\nresolveInsertAnchor_() — nested cursor inside table');
+
+  it('cursor inside table cell paragraph resolves to body-level table index + 1', function () {
+    var body = createMockBody(['before']);
+    var tbl = createMockTable();
+    body._children.push(tbl);
+    body._children.push(createMockParagraph('after'));
+    // Cursor is on the paragraph inside the table cell
+    var cellPara = tbl._cell._inner[0];
+    cellPara.getParent = function () { return tbl; };
+    var doc = createMockDoc(body, cellPara);
+    var anchor = resolveInsertAnchor_(body, doc);
+    // Table is at body index 1 → insert after it at index 2
+    expect(anchor.insertIndex).toBe(2);
+    expect(anchor.removeTarget).toBe(null);
+  });
+
+  it('selection inside table cell resolves to body-level table index + 1', function () {
+    var body = createMockBody(['before']);
+    var tbl = createMockTable();
+    body._children.push(tbl);
+    body._children.push(createMockParagraph('after'));
+    var cellPara = tbl._cell._inner[0];
+    cellPara.getParent = function () { return tbl; };
+    var doc = createMockDoc(body, null, [cellPara]);
+    var anchor = resolveInsertAnchor_(body, doc);
+    expect(anchor.insertIndex).toBe(2);
+    expect(anchor.removeTarget).toBe(null);
+  });
 
   // ── Restore ─────────────────────────────────────────────────
   applyFormat = originalApplyFormat;


### PR DESCRIPTION
Closes #111

## Summary
- Remove `saveAndClose()` from blockquote insertion to preserve cursor state
- Split border styling into a deferred second RPC call from the client
- Add `getSelection()` fallback and nested-element handling in `resolveInsertAnchor_`

## Test plan
- [ ] Verify ayah inserts at cursor position in the middle of a document
- [ ] Verify ayah inserts at cursor on an empty line
- [ ] Verify blockquote borders still render correctly (deferred call)
- [ ] Verify insertion works when user has text selected
- [ ] Run `runDocumentServiceTests` in Apps Script editor

Made with [Cursor](https://cursor.com)