### PR TITLE
Revamp settings Formatting section

### DIFF
--- a/sidebar/components/settings-panel.html
+++ b/sidebar/components/settings-panel.html
@@ -15,30 +15,19 @@
 
   <div id="settings-panel-body" class="settings-body">
     <section class="settings-section">
-      <h3 class="settings-section-title">Translation</h3>
+      <h3 class="settings-section-title">Formatting</h3>
 
       <div class="settings-row">
-        <span class="settings-row-label">Insert translation</span>
-        <label class="toggle-switch">
+        <label class="settings-row-label" for="insert-translation">Include English Translation</label>
+        <label class="toggle-switch" for="insert-translation">
           <input type="checkbox" id="insert-translation" checked>
           <span class="toggle-slider"></span>
         </label>
       </div>
 
-      <div class="settings-row settings-row--stacked">
-        <label class="settings-row-label" for="translation-edition">Choose edition</label>
-        <select id="translation-edition" class="form-select" disabled>
-          <option value="saheeh-international" selected>Saheeh International</option>
-        </select>
-      </div>
-    </section>
-
-    <section class="settings-section">
-      <h3 class="settings-section-title">Insertion</h3>
-
       <div class="settings-row">
-        <span class="settings-row-label">Blockquote style insertion</span>
-        <label class="toggle-switch">
+        <label class="settings-row-label" for="insert-blockquote">Format as Block-quote</label>
+        <label class="toggle-switch" for="insert-blockquote">
           <input type="checkbox" id="insert-blockquote" checked>
           <span class="toggle-slider"></span>
         </label>

--- a/sidebar/sidebar-css.html
+++ b/sidebar/sidebar-css.html
@@ -294,10 +294,22 @@
   .settings-panel-loading .startup-spinner { flex-shrink: 0; }
   .settings-section { margin-bottom: var(--space-xl); }
   .settings-section-title { margin: 0 0 var(--space-lg); font-size: 14px; font-weight: 600; color: var(--color-text-primary); }
-  .settings-row { display: flex; align-items: center; justify-content: space-between; padding: var(--space-md) 0; border-bottom: 1px solid var(--color-border); }
-  .settings-row--stacked { flex-direction: column; align-items: flex-start; gap: var(--space-sm); }
-  .settings-row-label { font-size: 13px; color: var(--color-text-primary); }
-  .settings-row .form-select { font-size: 13px; }
+  .settings-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-lg);
+    padding: var(--space-md) 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .settings-row-label {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--color-text-primary);
+    cursor: pointer;
+  }
+  .settings-row .toggle-switch { margin-inline-start: auto; }
 
   /* Toggle switch */
   .toggle-switch { position: relative; display: inline-block; width: 40px; height: 22px; flex-shrink: 0; }


### PR DESCRIPTION
Consolidates settings into one **Formatting** section with clearer labels and spacing. Removes the unused translation edition selector.

Closes #115

Made with [Cursor](https://cursor.com)