### PR TITLE
Revamp ayah insertion (buffers, split, list, cursor)

### DIFF
--- a/DocumentService.js
+++ b/DocumentService.js
@@ -14,8 +14,6 @@ var BLOCKQUOTE_CELL_BACKGROUND = '#F7F7F7';
 
 /**
  * Walks an element up to its nearest body-level ancestor (direct child of body).
- * If the element is already a direct child, returns it unchanged.
- * Returns null when the element cannot be traced to a body-level child.
  * @param {Body} body
  * @param {GoogleAppsScript.Document.Element} element
  * @return {GoogleAppsScript.Document.Element|null}
@@ -27,7 +25,6 @@ function resolveBodyLevelAncestor_(body, element) {
       var idx = body.getChildIndex(el);
       if (idx !== -1) return el;
     } catch (e) {
-      // el is not a direct child of body — keep walking up
     }
     el = el.getParent();
   }
@@ -35,145 +32,372 @@ function resolveBodyLevelAncestor_(body, element) {
 }
 
 /**
- * Returns the element at the active cursor or selection (last range element).
- * Does not compute offsets — only identifies which element the user is in.
- * @param {Document} doc
- * @return {GoogleAppsScript.Document.Element|null}
+ * @param {string} s
+ * @return {number}
  */
-function getActiveCursorElement_(doc) {
-  var sel = doc.getSelection();
-  if (sel) {
-    var ranges = sel.getRangeElements();
-    if (ranges && ranges.length > 0) {
-      return ranges[ranges.length - 1].getElement();
+function countTrailingNewlinesInString_(s) {
+  var c = 0;
+  var i;
+  for (i = s.length - 1; i >= 0; i--) {
+    if (s.charAt(i) === '\n') {
+      c++;
+    } else {
+      break;
     }
   }
-  var cur = doc.getCursor();
-  if (cur) {
-    return cur.getElement();
+  return c;
+}
+
+/**
+ * Counts empty body-level paragraphs/list items and trailing newlines on the first non-empty
+ * encountered when walking backward from gapIdx (exclusive).
+ * @param {Body} body
+ * @param {number} gapIdx
+ * @return {number}
+ */
+function countPrecedingBlankEquivalence_(body, gapIdx) {
+  var total = 0;
+  var i = gapIdx - 1;
+  while (i >= 0) {
+    var ch = body.getChild(i);
+    var t = ch.getType();
+    if (t === DocumentApp.ElementType.PARAGRAPH || t === DocumentApp.ElementType.LIST_ITEM) {
+      var text = ch.asParagraph().getText();
+      if (text === '') {
+        total++;
+        i--;
+      } else {
+        total += countTrailingNewlinesInString_(text);
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+  return total;
+}
+
+/**
+ * @param {Body} body
+ * @param {number} gapIdx
+ * @param {boolean} absoluteDocStart
+ * @return {number} how many empty paragraphs to insert at gapIdx
+ */
+function computeTopBufferParagraphsToAdd_(body, gapIdx, absoluteDocStart) {
+  if (absoluteDocStart) {
+    return 0;
+  }
+  var n = countPrecedingBlankEquivalence_(body, gapIdx);
+  if (n >= 2) {
+    return 0;
+  }
+  if (n === 1) {
+    return 1;
+  }
+  return 2;
+}
+
+/**
+ * @param {GoogleAppsScript.Document.Element} el
+ * @param {number} offset
+ * @return {{ host: GoogleAppsScript.Document.Paragraph, charOffset: number }|null}
+ */
+function resolveHostParagraphAndCharOffset_(el, offset) {
+  var type = el.getType();
+  if (type === DocumentApp.ElementType.TEXT) {
+    var textEl = el.asText();
+    var host = textEl.getParent();
+    var ht = host.getType();
+    if (ht !== DocumentApp.ElementType.PARAGRAPH && ht !== DocumentApp.ElementType.LIST_ITEM) {
+      return null;
+    }
+    var local = offset;
+    var acc = 0;
+    var j;
+    for (j = 0; j < host.getNumChildren(); j++) {
+      var ch = host.getChild(j);
+      if (ch.getType() === DocumentApp.ElementType.TEXT) {
+        var len = ch.asText().getText().length;
+        if (ch === textEl) {
+          return { host: /** @type {GoogleAppsScript.Document.Paragraph} */ (host), charOffset: acc + local };
+        }
+        acc += len;
+      }
+    }
+    return null;
+  }
+  if (type === DocumentApp.ElementType.PARAGRAPH || type === DocumentApp.ElementType.LIST_ITEM) {
+    return { host: /** @type {GoogleAppsScript.Document.Paragraph} */ (el), charOffset: offset };
   }
   return null;
 }
 
 /**
- * Contiguous list-item indices in the body sharing the same list id.
- * @param {Body} body
- * @param {GoogleAppsScript.Document.ListItem} listItem
- * @return {{ startIndex: number, endIndex: number }}
+ * @param {GoogleAppsScript.Document.RangeElement} re
+ * @return {number}
  */
-function findListItemBlockBounds_(body, listItem) {
-  var idx = body.getChildIndex(listItem);
-  var id = listItem.getListId();
-  var start = idx;
-  var i;
-  for (i = idx - 1; i >= 0; i--) {
-    var ch = body.getChild(i);
-    if (ch.getType() !== DocumentApp.ElementType.LIST_ITEM) {
-      break;
-    }
-    if (ch.asListItem().getListId() !== id) {
-      break;
-    }
-    start = i;
+function rangeElementInsertCharOffset_(re) {
+  var el = re.getElement();
+  if (re.isPartial()) {
+    return re.getEndOffsetInclusive() + 1;
   }
-  var end = idx;
-  for (i = idx + 1; i < body.getNumChildren(); i++) {
-    var ch2 = body.getChild(i);
-    if (ch2.getType() !== DocumentApp.ElementType.LIST_ITEM) {
-      break;
-    }
-    if (ch2.asListItem().getListId() !== id) {
-      break;
-    }
-    end = i;
+  if (el.getType() === DocumentApp.ElementType.TEXT) {
+    return el.asText().getText().length;
   }
-  return { startIndex: start, endIndex: end };
+  if (el.getType() === DocumentApp.ElementType.PARAGRAPH || el.getType() === DocumentApp.ElementType.LIST_ITEM) {
+    return el.asParagraph().getText().length;
+  }
+  return 0;
 }
 
 /**
- * When no cursor/selection: append after the last body child with isolation buffers.
- * @param {Body} body
- * @return {{ baseIndex: number, topBuffer: boolean, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
+ * Resolves cursor/selection to host paragraph (or list item as paragraph) and character offset.
+ * @param {Document} doc
+ * @return {{ host: GoogleAppsScript.Document.Paragraph, charOffset: number }|null}
  */
-function resolveFallbackInsertAnchor_(body) {
-  var n = body.getNumChildren();
-  if (n === 1) {
-    var only = body.getChild(0);
-    if (only.getType() === DocumentApp.ElementType.PARAGRAPH &&
-        only.asParagraph().getText() === '') {
-      return { baseIndex: 0, topBuffer: false, removeTarget: only.asParagraph() };
+function resolveActiveHostAndOffset_(doc) {
+  var sel = doc.getSelection();
+  if (sel) {
+    var ranges = sel.getRangeElements();
+    if (ranges && ranges.length > 0) {
+      var last = ranges[ranges.length - 1];
+      return resolveHostParagraphAndCharOffset_(last.getElement(), rangeElementInsertCharOffset_(last));
     }
   }
-  return { baseIndex: n, topBuffer: n > 0, removeTarget: null };
+  var cur = doc.getCursor();
+  if (cur) {
+    return resolveHostParagraphAndCharOffset_(cur.getElement(), cur.getOffset());
+  }
+  return null;
 }
 
 /**
- * Resolves where to insert isolated content (blockquote table or plain paragraphs).
- * Strategy: find the body-level element containing the cursor, then insert after it.
- * Empty paragraphs are reused (replaced). Never modifies existing text.
- * topBuffer: insert an empty paragraph immediately before the block when the insert
- * is not at body start (baseIndex > 0 after a non-empty paragraph), or when reusing
- * an empty paragraph not at index 0 (childIdx > 0).
  * @param {Body} body
  * @param {Document} doc
- * @return {{ baseIndex: number, topBuffer: boolean, removeTarget: GoogleAppsScript.Document.Paragraph|null }}
+ * @return {{
+ *   gapBodyIndex: number,
+ *   reuseFirstParagraphForFirstAyah: boolean,
+ *   remainderText: string,
+ *   remainderIsListItem: boolean,
+ *   templateListItem: GoogleAppsScript.Document.ListItem|null,
+ *   absoluteDocStart: boolean,
+ *   hasFollowingStructural: boolean
+ * }}
  */
-function resolveIsolatedInsertAnchor_(body, doc) {
-  var el = getActiveCursorElement_(doc);
-  if (!el) {
-    Logger.log('resolveIsolatedInsertAnchor_: no cursor/selection — using fallback');
-    return resolveFallbackInsertAnchor_(body);
-  }
-
-  var bodyChild = resolveBodyLevelAncestor_(body, el);
-  if (!bodyChild) {
-    Logger.log('resolveIsolatedInsertAnchor_: could not resolve body-level ancestor — using fallback');
-    return resolveFallbackInsertAnchor_(body);
-  }
-
-  var childIdx = body.getChildIndex(bodyChild);
-
-  if (bodyChild.getType() === DocumentApp.ElementType.PARAGRAPH &&
-      bodyChild.asParagraph().getText() === '') {
+function buildInsertPlan_(body, doc) {
+  var n = body.getNumChildren();
+  var hostInfo = resolveActiveHostAndOffset_(doc);
+  if (!hostInfo) {
+    var absStart = n === 0;
     return {
-      baseIndex: childIdx,
-      topBuffer: childIdx > 0,
-      removeTarget: bodyChild.asParagraph()
+      gapBodyIndex: n,
+      reuseFirstParagraphForFirstAyah: false,
+      remainderText: '',
+      remainderIsListItem: false,
+      templateListItem: null,
+      absoluteDocStart: absStart,
+      hasFollowingStructural: false
     };
   }
 
-  if (bodyChild.getType() === DocumentApp.ElementType.LIST_ITEM) {
-    var bounds = findListItemBlockBounds_(body, bodyChild.asListItem());
-    var afterList = bounds.endIndex + 1;
-    return { baseIndex: afterList, topBuffer: afterList > 0, removeTarget: null };
+  var host = hostInfo.host;
+  var charOffset = hostInfo.charOffset;
+  var bodyChild = resolveBodyLevelAncestor_(body, host);
+  if (!bodyChild) {
+    return {
+      gapBodyIndex: n,
+      reuseFirstParagraphForFirstAyah: false,
+      remainderText: '',
+      remainderIsListItem: false,
+      templateListItem: null,
+      absoluteDocStart: n === 0,
+      hasFollowingStructural: false
+    };
   }
 
   if (bodyChild.getType() === DocumentApp.ElementType.TABLE) {
-    var afterTable = childIdx + 1;
-    return { baseIndex: afterTable, topBuffer: afterTable > 0, removeTarget: null };
+    var tIdx = body.getChildIndex(bodyChild);
+    var gapIdxTable = tIdx + 1;
+    return {
+      gapBodyIndex: gapIdxTable,
+      reuseFirstParagraphForFirstAyah: false,
+      remainderText: '',
+      remainderIsListItem: false,
+      templateListItem: null,
+      absoluteDocStart: gapIdxTable === 0,
+      hasFollowingStructural: gapIdxTable < n
+    };
   }
 
-  var baseAfter = childIdx + 1;
-  return { baseIndex: baseAfter, topBuffer: baseAfter > 0, removeTarget: null };
+  var childIdx = body.getChildIndex(bodyChild);
+  var fullText = host.getText();
+  var safeOffset = Math.max(0, Math.min(charOffset, fullText.length));
+  var before = fullText.substring(0, safeOffset);
+  var after = fullText.substring(safeOffset);
+
+  if (n === 1 && bodyChild.getType() === DocumentApp.ElementType.PARAGRAPH &&
+      fullText === '' && safeOffset === 0) {
+    return {
+      gapBodyIndex: 0,
+      reuseFirstParagraphForFirstAyah: true,
+      remainderText: '',
+      remainderIsListItem: false,
+      templateListItem: null,
+      absoluteDocStart: true,
+      hasFollowingStructural: false
+    };
+  }
+
+  host.setText(before);
+  var gapIdx = childIdx + 1;
+  var isList = bodyChild.getType() === DocumentApp.ElementType.LIST_ITEM;
+  var templateLi = isList ? bodyChild.asListItem() : null;
+
+  return {
+    gapBodyIndex: gapIdx,
+    reuseFirstParagraphForFirstAyah: false,
+    remainderText: after,
+    remainderIsListItem: isList,
+    templateListItem: templateLi,
+    absoluteDocStart: gapIdx === 0 && before === '',
+    hasFollowingStructural: (gapIdx < body.getNumChildren()) || (after.length > 0)
+  };
 }
 
 /**
- * Normal empty paragraph after an insert block (typing / isolation).
- * @param {GoogleAppsScript.Document.Paragraph} p
+ * @param {boolean} hasFollowingStructural
+ * @return {number} 1 or 2
  */
-function formatBottomTypingParagraph_(p) {
-  p.setHeading(DocumentApp.ParagraphHeading.NORMAL);
-  p.setLeftToRight(true);
-  p.setSpacingBefore(0);
-  p.setSpacingAfter(0);
+function computeBottomBufferParagraphCount_(hasFollowingStructural) {
+  return hasFollowingStructural ? 2 : 1;
+}
+
+/**
+ * Inserts n empty paragraphs at body index `atIndex` (each insert shifts; repeat at same index).
+ * @param {Body} body
+ * @param {number} atIndex
+ * @param {number} n
+ */
+function insertEmptyParagraphBuffersAt_(body, atIndex, n) {
+  var k;
+  for (k = 0; k < n; k++) {
+    body.insertParagraph(atIndex, '');
+  }
+}
+
+/**
+ * @param {Body} body
+ * @param {Document} doc
+ * @param {Array<Object>} paragraphsToInsert
+ * @param {Object} formatState
+ * @param {boolean} useBlockquote
+ * @return {Object}
+ */
+function insertAyahPayloadShared_(body, doc, paragraphsToInsert, formatState, useBlockquote) {
+  var plan = buildInsertPlan_(body, doc);
+  var gapIdx = plan.gapBodyIndex;
+  var topN = computeTopBufferParagraphsToAdd_(body, gapIdx, plan.absoluteDocStart);
+  insertEmptyParagraphBuffersAt_(body, gapIdx, topN);
+  gapIdx += topN;
+
+  var fontWarning = null;
+  var pendingBorders = null;
+  var table = null;
+  var i;
+  var item;
+  var p;
+  var curIdx;
+
+  if (useBlockquote) {
+    table = body.insertTable(gapIdx, [['']]);
+    if (plan.reuseFirstParagraphForFirstAyah) {
+      try {
+        var displaced = body.getChild(gapIdx + 1);
+        if (displaced.getType() === DocumentApp.ElementType.PARAGRAPH &&
+            displaced.asParagraph().getText() === '') {
+          body.removeChild(displaced);
+        }
+      } catch (ignoreRm) {
+      }
+    }
+    try {
+      if (typeof table.setBorderWidth === 'function') {
+        table.setBorderWidth(0);
+      }
+    } catch (ignore) {
+    }
+    var cell = table.getRow(0).getCell(0);
+    cell.setPaddingLeft(21);
+    cell.setPaddingTop(6);
+    cell.setPaddingRight(18);
+    cell.setPaddingBottom(6);
+
+    for (i = 0; i < paragraphsToInsert.length; i++) {
+      item = paragraphsToInsert[i];
+      if (i === 0) {
+        p = cell.getChild(0).asParagraph();
+        p.setText(item.text);
+      } else {
+        p = cell.insertParagraph(i, item.text);
+      }
+      fontWarning = applyBeautifiedInsertToParagraph_(p, item, formatState) || fontWarning;
+    }
+
+    gapIdx = body.getChildIndex(table) + 1;
+    var docId = doc.getId();
+    var bodyChildIndex = body.getChildIndex(table);
+    var tableOrdinal = 0;
+    for (var ci = 0; ci <= bodyChildIndex; ci++) {
+      if (body.getChild(ci).getType() === DocumentApp.ElementType.TABLE) {
+        tableOrdinal++;
+      }
+    }
+    pendingBorders = { docId: docId, tableOrdinal: tableOrdinal };
+  } else {
+    curIdx = gapIdx;
+    for (i = 0; i < paragraphsToInsert.length; i++) {
+      item = paragraphsToInsert[i];
+      if (i === 0 && plan.reuseFirstParagraphForFirstAyah) {
+        p = body.getChild(gapIdx).asParagraph();
+        p.setText(item.text);
+        curIdx = gapIdx + 1;
+      } else {
+        p = body.insertParagraph(curIdx, item.text);
+        curIdx++;
+      }
+      fontWarning = applyBeautifiedInsertToParagraph_(p, item, formatState) || fontWarning;
+    }
+    gapIdx = curIdx;
+  }
+
+  var bottomN = computeBottomBufferParagraphCount_(plan.hasFollowingStructural);
+  insertEmptyParagraphBuffersAt_(body, gapIdx, bottomN);
+  var cursorPara = body.getChild(gapIdx + bottomN - 1).asParagraph();
+
+  var remainderInsertIdx = gapIdx + bottomN;
+  if (plan.remainderText.length > 0) {
+    if (plan.remainderIsListItem && plan.templateListItem) {
+      var newLi = body.insertListItem(remainderInsertIdx, plan.templateListItem);
+      newLi.setText(plan.remainderText);
+    } else {
+      body.insertParagraph(remainderInsertIdx, plan.remainderText);
+    }
+  }
+
+  try {
+    doc.setCursor(doc.newPosition(cursorPara, 0));
+  } catch (e) {
+  }
+
+  return { fontWarning: fontWarning, pendingBorders: pendingBorders };
 }
 
 /**
  * Applies beautified insert formatting to a paragraph (body or table cell).
  * @param {GoogleAppsScript.Document.Paragraph} p
- * @param {Object} item - insert descriptor
+ * @param {Object} item
  * @param {Object} formatState
- * @return {string|null} fontWarning from applyFormat
+ * @return {string|null}
  */
 function applyBeautifiedInsertToParagraph_(p, item, formatState) {
   p.setAlignment(item.align);
@@ -191,7 +415,7 @@ function applyBeautifiedInsertToParagraph_(p, item, formatState) {
 
 /**
  * @param {string|null|undefined} hex
- * @return {{ red: number, green: number, blue: number }} RGB in 0–1 for Docs API
+ * @return {{ red: number, green: number, blue: number }}
  */
 function hexToDocsRgb01_(hex) {
   var h = normalizeHex6ForSettings_(hex);
@@ -209,8 +433,8 @@ function hexToDocsRgb01_(hex) {
 
 /**
  * @param {number} pt
- * @param {{ red: number, green: number, blue: number }} rgb01
- * @return {Object} Docs API TableCellBorder (OptionalColor nested per docs OptionalColor schema)
+ * @param {{ red: number, green: number, blue: number}} rgb01
+ * @return {Object}
  */
 function docsTableBorderPt_(pt, rgb01) {
   return {
@@ -221,11 +445,8 @@ function docsTableBorderPt_(pt, rgb01) {
 }
 
 /**
- * Resolves structural startIndex of a table for Docs API batchUpdate using
- * ordinal position (Nth table in the document) rather than array-index heuristics.
- * Returns null when the expected table is not yet visible (triggers caller retry).
  * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal: "this is the Nth table in the body"
+ * @param {number} tableOrdinal
  * @return {number|null}
  */
 function resolveTableStartIndexForDocsApi_(docId, tableOrdinal) {
@@ -256,12 +477,8 @@ function resolveTableStartIndexForDocsApi_(docId, tableOrdinal) {
 }
 
 /**
- * Per-side cell borders (left accent only) via Docs API; DocumentApp cannot set per side.
- * Advanced Docs (get/batchUpdate) needs https://www.googleapis.com/auth/documents in appsscript.json;
- * drive.file can yield 404 on documents.get for the active editor doc.
- * Call only after the document has been flushed (auto-flush on function return, or saveAndClose).
  * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal position of the target table among all body tables
+ * @param {number} tableOrdinal
  */
 function applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal) {
   if (typeof Docs === 'undefined' || !Docs.Documents || !Docs.Documents.batchUpdate) {
@@ -322,186 +539,40 @@ function applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal) {
 }
 
 /**
- * Inserts a 1×1 table at the anchor, places beautified paragraphs in the cell, styles the shell.
- * Border styling is NOT applied here — the caller receives pendingBorders and must invoke
- * applyBlockquoteBorders() in a separate server call so that the auto-flush between calls
- * makes the table visible to the Docs REST API without needing saveAndClose().
  * @param {Body} body
  * @param {Document} doc
  * @param {Array<Object>} paragraphsToInsert
  * @param {Object} formatState
- * @return {Object} { fontWarning: string|null, pendingBorders: {docId: string, tableOrdinal: number}|null }
+ * @return {Object}
  */
 function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState) {
-  var anchor = resolveIsolatedInsertAnchor_(body, doc);
-  var insertIndex = anchor.baseIndex;
-  var removeTarget = anchor.removeTarget;
-
-  var tableOffset = 0;
-  if (anchor.topBuffer) {
-    body.insertParagraph(insertIndex, '');
-    tableOffset = 1;
-  }
-
-  var table = body.insertTable(insertIndex + tableOffset, [['']]);
-
-  // Hide default table chrome immediately to minimize unstyled flash.
-  try {
-    if (typeof table.setBorderWidth === 'function') {
-      table.setBorderWidth(0);
-    }
-  } catch (ignore) {
-  }
-
-  var removeTargetStillExists = false;
-  if (removeTarget) {
-    var after = body.getChild(insertIndex + tableOffset + 1);
-    if (after === removeTarget) {
-      try {
-        body.removeChild(removeTarget);
-      } catch (ignore) {
-        removeTargetStillExists = true;
-      }
-    }
-  }
-
-  var cell = table.getRow(0).getCell(0);
-  cell.setPaddingLeft(21);
-  cell.setPaddingTop(6);
-  cell.setPaddingRight(18);
-  cell.setPaddingBottom(6);
-
-  var fontWarning = null;
-  for (var i = 0; i < paragraphsToInsert.length; i++) {
-    var item = paragraphsToInsert[i];
-    var p;
-    if (i === 0) {
-      p = cell.getChild(0).asParagraph();
-      p.setText(item.text);
-    } else {
-      p = cell.insertParagraph(i, item.text);
-    }
-    fontWarning = applyBeautifiedInsertToParagraph_(p, item, formatState) || fontWarning;
-  }
-
-  var tableIdx = body.getChildIndex(table);
-  var typingParagraph;
-  if (removeTargetStillExists) {
-    typingParagraph = removeTarget;
-    formatBottomTypingParagraph_(typingParagraph);
-  } else {
-    var nextIdxBq = tableIdx + 1;
-    var nextElBq = nextIdxBq < body.getNumChildren() ? body.getChild(nextIdxBq) : null;
-    if (nextElBq && nextElBq.getType() === DocumentApp.ElementType.PARAGRAPH) {
-      typingParagraph = nextElBq.asParagraph();
-    } else {
-      typingParagraph = body.insertParagraph(tableIdx + 1, '');
-      formatBottomTypingParagraph_(typingParagraph);
-    }
-  }
-
-  try {
-    doc.setCursor(doc.newPosition(typingParagraph, 0));
-  } catch (e) {
-    // setCursor is unavailable in non-UI contexts (e.g. triggers); fail silently
-  }
-
-  var docId = doc.getId();
-  var bodyChildIndex = body.getChildIndex(table);
-  var tableOrdinal = 0;
-  for (var ci = 0; ci <= bodyChildIndex; ci++) {
-    if (body.getChild(ci).getType() === DocumentApp.ElementType.TABLE) {
-      tableOrdinal++;
-    }
-  }
-
-  return {
-    fontWarning: fontWarning,
-    pendingBorders: { docId: docId, tableOrdinal: tableOrdinal }
-  };
+  return insertAyahPayloadShared_(body, doc, paragraphsToInsert, formatState, true);
 }
 
 /**
- * Public entry point for the client to apply blockquote cell borders via a second RPC.
- * Called after insertAyah/insertAyahRange returns pendingBorders; the auto-flush between
- * the two server calls ensures the Docs REST API can see the newly inserted table.
  * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal position of the target table
+ * @param {number} tableOrdinal
  */
 function applyBlockquoteBorders(docId, tableOrdinal) {
   applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal);
 }
 
 /**
- * Inserts beautified paragraphs with the same isolation rules as blockquote inserts
- * (resolveIsolatedInsertAnchor_: selection end, list/table escapes, split/start/end).
- * Adds a bottom empty paragraph only when no body paragraph already follows; otherwise
- * cursor moves to the start of the following paragraph.
- *
- * @param {Body} body - The document body
- * @param {Document} doc - The active document
- * @param {Array<Object>} paragraphsToInsert - Array of { text, align, rtl?, insertTextRole, spacingBefore?, spacingAfter? } (spacing in pt)
- * @param {Object} formatState - legacy payload; Quran Arabic forced to Amiri regular in FormatService
- * @return {Object} { fontWarning: string|null }
+ * @param {Body} body
+ * @param {Document} doc
+ * @param {Array<Object>} paragraphsToInsert
+ * @param {Object} formatState
+ * @return {Object}
  */
 function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState) {
-  var anchor = resolveIsolatedInsertAnchor_(body, doc);
-  var idx = anchor.baseIndex;
-  var removeTarget = anchor.removeTarget;
-
-  if (anchor.topBuffer) {
-    body.insertParagraph(idx, '');
-    idx++;
-  }
-
-  var contentStart = idx;
-  var fontWarning = null;
-  var i;
-  var item;
-  var p;
-
-  for (i = 0; i < paragraphsToInsert.length; i++) {
-    item = paragraphsToInsert[i];
-    if (i === 0 && removeTarget && body.getChild(contentStart) === removeTarget) {
-      p = removeTarget;
-      p.setText(item.text);
-    } else {
-      p = body.insertParagraph(contentStart + i, item.text);
-    }
-    fontWarning = applyBeautifiedInsertToParagraph_(p, item, formatState) || fontWarning;
-  }
-
-  var bottomIdx = contentStart + paragraphsToInsert.length;
-  var bottom;
-  if (bottomIdx < body.getNumChildren()) {
-    var nextElPlain = body.getChild(bottomIdx);
-    if (nextElPlain.getType() === DocumentApp.ElementType.PARAGRAPH) {
-      bottom = nextElPlain.asParagraph();
-    } else {
-      bottom = body.insertParagraph(bottomIdx, '');
-      formatBottomTypingParagraph_(bottom);
-    }
-  } else {
-    bottom = body.insertParagraph(bottomIdx, '');
-    formatBottomTypingParagraph_(bottom);
-  }
-
-  try {
-    doc.setCursor(doc.newPosition(bottom, 0));
-  } catch (e) {
-    // setCursor is unavailable in non-UI contexts (e.g. triggers); fail silently
-  }
-
-  return { fontWarning: fontWarning };
+  return insertAyahPayloadShared_(body, doc, paragraphsToInsert, formatState, false);
 }
 
 /**
- * Inserts an ayah into the document using resolveIsolatedInsertAnchor_
- * (selection end, list/table escapes, paragraph split/start/end, doc-end fallback).
- * @param {Object} ayahData - { surah, ayah, surahNameArabic, surahNameEnglish, textUthmani, textSimple, translationText }
- * @param {Object} formatState - legacy payload; Quran Arabic forced to Amiri regular in FormatService
- * @param {Object} settings - { showTranslation, arabicStyle, blockquoteInsertion }
- * @return {Object} { success: boolean, message?: string }
+ * @param {Object} ayahData
+ * @param {Object} formatState
+ * @param {Object} settings
+ * @return {Object}
  */
 function insertAyah(ayahData, formatState, settings) {
   if (!ayahData || !ayahData.surah || !ayahData.ayah) {
@@ -509,6 +580,9 @@ function insertAyah(ayahData, formatState, settings) {
   }
 
   var doc = DocumentApp.getActiveDocument();
+  if (!doc) {
+    return { success: false, message: 'No active document' };
+  }
   var body = doc.getBody();
 
   var arabicStyle = (settings && settings.arabicStyle) || 'uthmani';
@@ -520,7 +594,6 @@ function insertAyah(ayahData, formatState, settings) {
   var translationText = ayahData.translationText || '';
   var surahNameEn = ayahData.surahNameEnglish || '';
 
-  /** U+00A0: ornate Quranic parens (matches preview); Arabic :/ayah and range hyphen; English name/num only. */
   var qNbsp = '\u00A0';
   var paragraphsToInsert = [];
   if (showTranslation && translationText) {
@@ -556,9 +629,7 @@ function insertAyah(ayahData, formatState, settings) {
   }
 
   var useBlockquote = !settings || settings.blockquoteInsertion !== false;
-  var result = useBlockquote
-    ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
-    : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
+  var result = insertAyahPayloadShared_(body, doc, paragraphsToInsert, formatState, useBlockquote);
   var message = result.fontWarning ? 'Ayah inserted. ' + result.fontWarning : 'Ayah inserted.';
   var out = { success: true, message: message };
   if (result.pendingBorders) {
@@ -568,24 +639,26 @@ function insertAyah(ayahData, formatState, settings) {
 }
 
 /**
- * Inserts a pre-assembled ayah range using the same anchor rules as insertAyah.
- * @param {Object} rangeData - { surah, ayahStart, ayahEnd, arabicText, translationText, surahNameArabic, surahNameEnglish }
- * @param {Object} formatState - legacy payload; Quran Arabic forced to Amiri regular in FormatService
- * @param {Object} settings - { showTranslation, blockquoteInsertion }
- * @return {Object} { success: boolean, message?: string }
+ * @param {Object} rangeData
+ * @param {Object} formatState
+ * @param {Object} settings
+ * @return {Object}
  */
 function insertAyahRange(rangeData, formatState, settings) {
   if (!rangeData || !rangeData.surah || !rangeData.ayahStart) {
     return { success: false, message: 'Invalid range data.' };
   }
 
-  var doc    = DocumentApp.getActiveDocument();
-  var body   = doc.getBody();
+  var doc = DocumentApp.getActiveDocument();
+  if (!doc) {
+    return { success: false, message: 'No active document' };
+  }
+  var body = doc.getBody();
 
   var showTranslation = settings && settings.showTranslation !== false;
-  var arabicText      = rangeData.arabicText || '';
+  var arabicText = rangeData.arabicText || '';
   var translationText = rangeData.translationText || '';
-  var surahNameEn     = rangeData.surahNameEnglish || '';
+  var surahNameEn = rangeData.surahNameEnglish || '';
 
   var qNbsp = '\u00A0';
   var paragraphsToInsert = [];
@@ -623,9 +696,7 @@ function insertAyahRange(rangeData, formatState, settings) {
   }
 
   var useBlockquote = !settings || settings.blockquoteInsertion !== false;
-  var result = useBlockquote
-    ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
-    : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
+  var result = insertAyahPayloadShared_(body, doc, paragraphsToInsert, formatState, useBlockquote);
   var out = { success: true, message: result.fontWarning ? 'Range inserted. ' + result.fontWarning : 'Range inserted.' };
   if (result.pendingBorders) {
     out.pendingBorders = result.pendingBorders;

--- a/tests/DocumentService.test.gs
+++ b/tests/DocumentService.test.gs
@@ -1,6 +1,6 @@
 /**
- * GAS-native tests for DocumentService.gs — resolveIsolatedInsertAnchor_(),
- * insertParagraphsAtPosition_(), insertBlockquoteTableAtPosition_(), and helpers.
+ * GAS-native tests for DocumentService.gs — insertParagraphsAtPosition_(),
+ * insertBlockquoteTableAtPosition_(), and helpers.
  * Run from Apps Script editor: select runDocumentServiceTests, click Run.
  */
 
@@ -52,6 +52,7 @@ function runDocumentServiceTests() {
 
   function createMockParagraph(text) {
     var para = {
+      _parentBody: null,
       _text: text,
       _textChildren: [],
       _align: null,
@@ -69,7 +70,7 @@ function runDocumentServiceTests() {
       setSpacingAfter: function (pt) { this._spacingAfter = pt; },
       getType: function () { return DocumentApp.ElementType.PARAGRAPH; },
       asParagraph: function () { return this; },
-      getParent: function () { return null; },
+      getParent: function () { return this._parentBody; },
       getChild: function (i) { return this._textChildren[i]; },
       getNumChildren: function () { return this._textChildren.length; },
       getChildIndex: function (child) {
@@ -129,12 +130,37 @@ function runDocumentServiceTests() {
     };
   }
 
+  function createMockListItem(text, listId, nestingLevel) {
+    var li = createMockParagraph(text);
+    li.getType = function () { return DocumentApp.ElementType.LIST_ITEM; };
+    li.asListItem = function () { return this; };
+    li.getListId = function () { return listId; };
+    li.getNestingLevel = function () { return nestingLevel == null ? 0 : nestingLevel; };
+    return li;
+  }
+
+  function wireParentsForBody_(bd) {
+    var j;
+    for (j = 0; j < bd._children.length; j++) {
+      bd._children[j]._parentBody = bd;
+    }
+  }
+
   function createMockBody(initialTexts) {
     var children = [];
+    var body;
+    function wireParents() {
+      var c;
+      for (c = 0; c < children.length; c++) {
+        if (children[c]._parentBody !== undefined) {
+          children[c]._parentBody = body;
+        }
+      }
+    }
     for (var i = 0; i < initialTexts.length; i++) {
       children.push(createMockParagraph(initialTexts[i]));
     }
-    return {
+    body = {
       _children: children,
       getParagraphs: function () {
         var paras = [];
@@ -155,11 +181,22 @@ function runDocumentServiceTests() {
       },
       insertParagraph: function (index, text) {
         var p = createMockParagraph(text);
+        p._parentBody = this;
         this._children.splice(index, 0, p);
         return p;
       },
+      insertListItem: function (index, templateLi) {
+        var nid = templateLi.getListId ? templateLi.getListId() : 'L';
+        var nest = templateLi.getNestingLevel ? templateLi.getNestingLevel() : 0;
+        var li = createMockListItem('', nid, nest);
+        li._parentBody = this;
+        this._children.splice(index, 0, li);
+        return li;
+      },
       insertTable: function (index, cells) {
         var t = createMockTable();
+        t._parentBody = this;
+        t.getParent = function () { return body; };
         this._children.splice(index, 0, t);
         return t;
       },
@@ -172,14 +209,17 @@ function runDocumentServiceTests() {
         }
       }
     };
+    wireParents();
+    return body;
   }
 
   /**
    * @param {*} body
    * @param {*} cursorElement - element for cursor (or null)
    * @param {Array} selectionElements - optional range elements (see mockRangeEl_)
+   * @param {number} [cursorOffsetOverride] - explicit cursor offset (else end of element text)
    */
-  function createMockDoc(body, cursorElement, selectionElements) {
+  function createMockDoc(body, cursorElement, selectionElements, cursorOffsetOverride) {
     return {
       getBody: function () { return body; },
       getId: function () { return 'mock-doc-id'; },
@@ -187,7 +227,18 @@ function runDocumentServiceTests() {
         if (!cursorElement) return null;
         return {
           getElement: function () { return cursorElement; },
-          getOffset: function () { return 0; }
+          getOffset: function () {
+            if (typeof cursorOffsetOverride === 'number') {
+              return cursorOffsetOverride;
+            }
+            if (cursorElement.getType && cursorElement.getType() === DocumentApp.ElementType.TEXT) {
+              return cursorElement.getText().length;
+            }
+            if (cursorElement.getText) {
+              return cursorElement.getText().length;
+            }
+            return 0;
+          }
         };
       },
       getSelection: function () {
@@ -274,123 +325,121 @@ function runDocumentServiceTests() {
 
   results.push('\ninsertParagraphsAtPosition_() — positioning');
 
-  it('cursor on empty paragraph (only child) — replaces empty, adds cleanup', function () {
+  it('cursor on empty paragraph (only child) — reuses para for ayah, one bottom buffer', function () {
     var body = createMockBody(['']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [content, cleanup]
     expect(body._children.length).toBe(2);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
     expect(body._children[0]._ltr).toBe(false);
     expect(body._children[1]._text).toBe('');
-    expect(body._children[1]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[1]._ltr).toBe(true);
+    expect(body._children[1]._heading).toBe(null);
   });
 
-  it('cursor on non-empty paragraph (last child) — top buffer, content, cleanup', function () {
+  it('cursor at end of non-empty paragraph (last child) — two top buffers, content, one bottom', function () {
     var body = createMockBody(['existing text']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [existing, topBuffer, content, cleanup]
-    expect(body._children.length).toBe(4);
+    expect(body._children.length).toBe(5);
     expect(body._children[0]._text).toBe('existing text');
     expect(body._children[1]._text).toBe('');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[3]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[3]._ltr).toBe(true);
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[4]._heading).toBe(null);
   });
 
-  it('no cursor, all paragraphs empty — appends top buffer, content, bottom after empties', function () {
+  it('no cursor, all paragraphs empty — no top buffer (2+ empties), append content + bottom', function () {
     var body = createMockBody(['', '', '']);
     var doc = createMockDoc(body, null);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // Fallback baseIndex=3, topBuffer → [e0,e1,e2, top, content, bottom]
-    expect(body._children.length).toBe(6);
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[5]._text).toBe('');
-    expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children.length).toBe(5);
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[4]._heading).toBe(null);
   });
 
-  it('new doc (single empty paragraph, no cursor) — content + cleanup', function () {
+  it('new doc (single empty paragraph, no cursor) — one top buffer, content, bottom', function () {
     var body = createMockBody(['']);
     var doc = createMockDoc(body, null);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // Original empty reused for content → cleanup added
-    // [content, cleanup]
-    expect(body._children.length).toBe(2);
-    expect(body._children[0]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children.length).toBe(4);
+    expect(body._children[0]._text).toBe('');
     expect(body._children[1]._text).toBe('');
-    expect(body._children[1]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[3]._heading).toBe(null);
   });
 
-  it('cursor at last paragraph (non-empty) — top buffer, content, cleanup is last', function () {
+  it('cursor at end of last paragraph — two top buffers, content, one bottom', function () {
     var body = createMockBody(['first', 'last']);
     var doc = createMockDoc(body, body._children[1]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [first, last, topBuffer, content, cleanup]
-    expect(body._children.length).toBe(5);
+    expect(body._children.length).toBe(6);
+    expect(body._children[0]._text).toBe('first');
+    expect(body._children[1]._text).toBe('last');
     expect(body._children[2]._text).toBe('');
-    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[4]._text).toBe('');
-    expect(body._children[4]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[4]._ltr).toBe(true);
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[5]._heading).toBe(null);
   });
 
   results.push('\ninsertParagraphsAtPosition_() — bottom buffer when not at doc end');
 
-  it('no cursor, trailing empties after last non-empty — top buffer, content, bottom after trailing empty', function () {
+  it('no cursor, trailing empties after last non-empty — one top buffer, one bottom', function () {
     var body = createMockBody(['first', 'second', '']);
     var doc = createMockDoc(body, null);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [first, second, '', top, content, bottom]
     expect(body._children.length).toBe(6);
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('second');
     expect(body._children[2]._text).toBe('');
     expect(body._children[3]._text).toBe('');
     expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[5]._heading).toBe(null);
   });
 
-  it('cursor at first paragraph with paragraphs below — top buffer, content, then rest (no extra bottom)', function () {
+  it('cursor at end of first paragraph with siblings — two top, content, two bottom', function () {
     var body = createMockBody(['first', 'second', 'third']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [first, topBuffer, content, second, third]
-    expect(body._children.length).toBe(5);
+    expect(body._children.length).toBe(8);
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('second');
-    expect(body._children[4]._text).toBe('third');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[6]._text).toBe('second');
+    expect(body._children[7]._text).toBe('third');
   });
 
-  it('cursor at first with only spaces paragraph below — top buffer, content, cursor in spaces paragraph', function () {
+  it('cursor at end of first with spaces-only paragraph below — two top, content, two bottom', function () {
     var body = createMockBody(['first', '   ']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    expect(body._children.length).toBe(4);
-    expect(body._children[1]._text).toBe('');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('   ');
+    expect(body._children.length).toBe(7);
+    expect(body._children[0]._text).toBe('first');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[6]._text).toBe('   ');
   });
 
   results.push('\ninsertParagraphsAtPosition_() — paragraph spacing (insert beautify)');
@@ -446,8 +495,7 @@ function runDocumentServiceTests() {
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), fs);
 
-    // [existing, topBuffer, arabic, translation, citation, bottom]
-    expect(body._children.length).toBe(6);
+    expect(body._children.length).toBe(7);
     expect(applyFormatCalls.length).toBe(3);
     expect(applyFormatCalls[0].fontName).toBe('Amiri');
     expect(applyFormatCalls[0].fontVariant).toBe('regular');
@@ -485,53 +533,51 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[0].bold).toBe(false);
   });
 
-  it('three content paragraphs at end — top buffer, all inserted, cleanup follows', function () {
+  it('three content paragraphs at end — two top buffers, all inserted, one bottom', function () {
     var body = createMockBody(['existing']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, topBuffer, arabic, translation, citation, cleanup]
-    expect(body._children.length).toBe(6);
+    expect(body._children.length).toBe(7);
     expect(body._children[1]._text).toBe('');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[2]._ltr).toBe(false);
-    expect(body._children[3]._text).toBe('"translation"');
-    expect(body._children[3]._ltr).toBe(true);
-    expect(body._children[4]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
+    expect(body._children[3]._ltr).toBe(false);
+    expect(body._children[4]._text).toBe('"translation"');
     expect(body._children[4]._ltr).toBe(true);
-    expect(body._children[5]._text).toBe('');
-    expect(body._children[5]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
+    expect(body._children[5]._text).toBe('(Al-Fatiha\u00A01:1)');
     expect(body._children[5]._ltr).toBe(true);
-    expect(body._children[5]._spacingBefore).toBe(0);
-    expect(body._children[5]._spacingAfter).toBe(0);
+    expect(body._children[6]._text).toBe('');
+    expect(body._children[6]._heading).toBe(null);
+    expect(body._children[6]._spacingBefore).toBe(null);
   });
 
-  it('three content paragraphs with content after — top buffer, no extra bottom before following paragraph', function () {
+  it('three content paragraphs with content after — two top, two bottom before following paragraph', function () {
     var body = createMockBody(['existing', 'after']);
     var doc = createMockDoc(body, body._children[0]);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // [existing, topBuffer, arabic, translation, citation, after]
-    expect(body._children.length).toBe(6);
+    expect(body._children.length).toBe(8);
     expect(body._children[1]._text).toBe('');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('"translation"');
-    expect(body._children[4]._text).toBe('(Al-Fatiha\u00A01:1)');
-    expect(body._children[5]._text).toBe('after');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('"translation"');
+    expect(body._children[5]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[6]._text).toBe('');
+    expect(body._children[7]._text).toBe('after');
   });
 
   results.push('\ninsertParagraphsAtPosition_() — regression: sequential insertion & removeChild');
 
-  it('sequential insert: second insertion goes AFTER citation, not between', function () {
+  it('sequential insert: second insertion adds another ayah block after the first', function () {
     var body = createMockBody(['']);
     var emptyPara = body._children[0];
     var doc = createMockDoc(body, emptyPara);
 
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
 
-    // After first insert: [arabic, translation, citation, cleanup]
     expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[1]._text).toBe('"translation"');
@@ -542,37 +588,20 @@ function runDocumentServiceTests() {
     var doc2 = createMockDoc(body, cleanup);
     insertParagraphsAtPosition_(body, doc2, singleArabicParagraph(), {});
 
-    // [arabic1, translation1, citation1, topBuffer, arabic2, cleanup2]
-    expect(body._children.length).toBe(6);
-    expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
-    expect(body._children[1]._text).toBe('"translation"');
-    expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
-    expect(body._children[3]._text).toBe('');
-    expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[5]._text).toBe('');
-  });
-
-  it('empty paragraph reuse avoids removeChild entirely', function () {
-    var body = createMockBody(['']);
-    var removeChildCalled = false;
-    var origRemoveChild = body.removeChild;
-    body.removeChild = function () {
-      removeChildCalled = true;
-      throw new Error("Can't remove the last paragraph in a document section.");
-    };
-    var doc = createMockDoc(body, body._children[0]);
-
-    var result = insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
-
-    expect(removeChildCalled).toBe(false);
-    expect(result.fontWarning).toBe(null);
-    expect(body._children[0]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    body.removeChild = origRemoveChild;
+    var ornateCount = 0;
+    var idx;
+    for (idx = 0; idx < body._children.length; idx++) {
+      if (body._children[idx]._text && body._children[idx]._text.indexOf('\uFD3F') === 0) {
+        ornateCount++;
+      }
+    }
+    expect(ornateCount).toBe(2);
+    expect(body._children[body._children.length - 1]._text).toBe('');
   });
 
   results.push('\ninsertBlockquoteTableAtPosition_()');
 
-  it('blockquote: empty doc — table + typing paragraph; inner spacing matches', function () {
+  it('blockquote: empty doc — table + one bottom buffer; inner spacing matches', function () {
     var body = createMockBody(['']);
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, arabicOnlyAyahInsert(), {});
@@ -580,8 +609,7 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(2);
     expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[1]._text).toBe('');
-    expect(body._children[1]._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(body._children[1]._ltr).toBe(true);
+    expect(body._children[1]._heading).toBe(null);
 
     var cell = body._children[0]._cell;
     expect(cell._bg).toBe(null);
@@ -600,6 +628,7 @@ function runDocumentServiceTests() {
     insertBlockquoteTableAtPosition_(body, doc, arabicAndTranslation(), {});
 
     expect(body._children.length).toBe(2);
+    expect(body._children[1]._heading).toBe(null);
     var cell = body._children[0]._cell;
     expect(cell._inner.length).toBe(3);
     expect(cell._inner[0]._spacingBefore).toBe(INSERT_SPACING_OUTER_PT);
@@ -608,17 +637,19 @@ function runDocumentServiceTests() {
     expect(cell._inner[2]._spacingAfter).toBe(INSERT_SPACING_OUTER_PT);
   });
 
-  it('blockquote: non-empty doc — top buffer, table, cursor in following paragraph (no extra typing para)', function () {
+  it('blockquote: non-empty doc — two top buffers, table, two bottom, then after', function () {
     var body = createMockBody(['existing', 'after']);
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [existing, topBuffer, TABLE, after]
-    expect(body._children.length).toBe(4);
+    expect(body._children.length).toBe(7);
     expect(body._children[0]._text).toBe('existing');
     expect(body._children[1]._text).toBe('');
-    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[3]._text).toBe('after');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[6]._text).toBe('after');
   });
 
   it('blockquote: empty doc skips top buffer paragraph', function () {
@@ -630,49 +661,29 @@ function runDocumentServiceTests() {
     expect(body._children[0]._cell._inner[0]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
   });
 
-  it('blockquote: typing paragraph has no explicit spacing', function () {
+  it('blockquote: bottom buffer paragraphs have no explicit spacing', function () {
     var body = createMockBody(['content above', 'more content']);
     var doc = createMockDoc(body, body._children[1]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [above, more, topBuffer, TABLE, typing]
-    var typing = body._children[4];
-    expect(typing._text).toBe('');
-    expect(typing._fontSize).toBe(null);
-    expect(typing._spacingBefore).toBe(null);
-    expect(typing._spacingAfter).toBe(null);
+    var b1 = body._children[4];
+    var b2 = body._children[5];
+    expect(b1._text).toBe('');
+    expect(b2._text).toBe('');
+    expect(b1._spacingBefore).toBe(null);
+    expect(b2._spacingAfter).toBe(null);
   });
 
-  it('blockquote: typing paragraph has default formatting', function () {
+  it('blockquote: bottom buffers are plain empty paragraphs', function () {
     var body = createMockBody(['text']);
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [text, topBuffer, TABLE, typingParagraph]
-    var typing = body._children[3];
+    var typing = body._children[4];
     expect(typing._text).toBe('');
-    expect(typing._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(typing._ltr).toBe(true);
+    expect(typing._heading).toBe(null);
+    expect(typing._ltr).toBe(null);
     expect(typing._fontSize).toBe(null);
-  });
-
-  it('blockquote: empty doc with removeChild failure reuses original paragraph as typing target', function () {
-    var body = createMockBody(['']);
-    var origPara = body._children[0];
-    var origRemoveChild = body.removeChild;
-    body.removeChild = function () {
-      throw new Error("Can't remove the last paragraph in a document section.");
-    };
-    var doc = createMockDoc(body, origPara);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-
-    expect(body._children.length).toBe(2);
-    expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
-    var typing = body._children[1];
-    expect(typing).toBe(origPara);
-    expect(typing._heading).toBe(DocumentApp.ParagraphHeading.NORMAL);
-    expect(typing._ltr).toBe(true);
-    body.removeChild = origRemoveChild;
   });
 
   it('hexToDocsRgb01_ parses normalized hex for Docs border color', function () {
@@ -774,7 +785,10 @@ function runDocumentServiceTests() {
   it('new table after one pre-existing table returns tableOrdinal 2', function () {
     var body = createMockBody(['text before', 'cursor here']);
     var existingTable = createMockTable();
+    existingTable._parentBody = body;
+    existingTable.getParent = function () { return body; };
     body._children.splice(1, 0, existingTable);
+    wireParentsForBody_(body);
     var cursorPara = body._children[2];
     var doc = createMockDoc(body, cursorPara);
     var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
@@ -784,9 +798,14 @@ function runDocumentServiceTests() {
   it('new table between two pre-existing tables returns tableOrdinal 2', function () {
     var body = createMockBody(['before', 'middle', 'after']);
     var table1 = createMockTable();
+    table1._parentBody = body;
+    table1.getParent = function () { return body; };
     body._children.splice(1, 0, table1);
     var table2 = createMockTable();
+    table2._parentBody = body;
+    table2.getParent = function () { return body; };
     body._children.splice(3, 0, table2);
+    wireParentsForBody_(body);
     var cursorPara = body._children[2];
     var doc = createMockDoc(body, cursorPara);
     var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
@@ -804,108 +823,23 @@ function runDocumentServiceTests() {
     applyBlockquoteCellBordersViaDocsApi_ = origBorders;
   });
 
-  // ── resolveIsolatedInsertAnchor_ — always-after-paragraph ──
-
-  results.push('\nresolveIsolatedInsertAnchor_() — simplified anchor (always after paragraph)');
-
-  it('cursor on non-empty paragraph inserts after it', function () {
-    var body = createMockBody(['first', 'second', 'third']);
-    var doc = createMockDoc(body, body._children[1]);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(2);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  it('cursor on empty paragraph reuses it', function () {
-    var body = createMockBody(['first', '', 'third']);
-    var doc = createMockDoc(body, body._children[1]);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(body._children[1]);
-  });
-
-  it('cursor on TEXT child of paragraph inserts after that paragraph', function () {
-    var body = createMockBody(['hello world']);
-    var textEl = body._children[0]._textChildren[0];
-    var doc = createMockDoc(body, textEl);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  it('selection on non-empty paragraph inserts after it', function () {
-    var body = createMockBody(['first', 'second', 'third']);
-    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1])]);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(2);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  it('selection on empty paragraph reuses it', function () {
-    var body = createMockBody(['first', '', 'third']);
-    var doc = createMockDoc(body, null, [mockRangeEl_(body._children[1])]);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(1);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(body._children[1]);
-  });
-
-  // ── resolveIsolatedInsertAnchor_ — nested cursor (inside table cell) ──
-
-  results.push('\nresolveIsolatedInsertAnchor_() — nested cursor inside table');
-
-  it('cursor inside table cell paragraph resolves after table with top buffer', function () {
-    var body = createMockBody(['before']);
-    var tbl = createMockTable();
-    body._children.push(tbl);
-    body._children.push(createMockParagraph('after'));
-    var cellPara = tbl._cell._inner[0];
-    cellPara.getParent = function () { return tbl; };
-    var doc = createMockDoc(body, cellPara);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(2);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  it('selection inside table cell resolves after table with top buffer', function () {
-    var body = createMockBody(['before']);
-    var tbl = createMockTable();
-    body._children.push(tbl);
-    body._children.push(createMockParagraph('after'));
-    var cellPara = tbl._cell._inner[0];
-    cellPara.getParent = function () { return tbl; };
-    var doc = createMockDoc(body, null, [mockRangeEl_(cellPara)]);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(2);
-    expect(anchor.topBuffer).toBe(true);
-    expect(anchor.removeTarget).toBe(null);
-  });
-
-  // ── resolveIsolatedInsertAnchor_ — list ──
-
-  results.push('\nresolveIsolatedInsertAnchor_() — list items');
-
-  function createMockListItem(text, listId) {
-    var li = createMockParagraph(text);
-    li.getType = function () { return DocumentApp.ElementType.LIST_ITEM; };
-    li.asListItem = function () { return this; };
-    li.getListId = function () { return listId; };
-    return li;
-  }
-
-  it('cursor in list — anchor after contiguous same-listId block', function () {
+  it('list item split: remainder list item preserves listId after plain insert', function () {
     var body = createMockBody(['intro']);
-    body._children.push(createMockListItem('one', 'L9'));
-    body._children.push(createMockListItem('two', 'L9'));
-    var doc = createMockDoc(body, body._children[1]);
-    var anchor = resolveIsolatedInsertAnchor_(body, doc);
-    expect(anchor.baseIndex).toBe(3);
-    expect(anchor.topBuffer).toBe(true);
+    body._children.push(createMockListItem('abcdef', 'L9', 0));
+    wireParentsForBody_(body);
+    var li = body._children[1];
+    var doc = createMockDoc(body, li, null, 3);
+    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
+    expect(body._children[1]._text).toBe('abc');
+    expect(body._children[1].getType()).toBe(DocumentApp.ElementType.LIST_ITEM);
+    var foundRemainder = false;
+    var i;
+    for (i = 0; i < body._children.length; i++) {
+      if (body._children[i]._text === 'def' && body._children[i].getListId && body._children[i].getListId() === 'L9') {
+        foundRemainder = true;
+      }
+    }
+    expect(foundRemainder).toBe(true);
   });
 
   // ── End-to-end: blockquote insert with cursor in table cell ──
@@ -915,74 +849,87 @@ function runDocumentServiceTests() {
   it('blockquote: cursor in table cell inserts table after the existing table', function () {
     var body = createMockBody(['before']);
     var tbl = createMockTable();
+    tbl._parentBody = body;
+    tbl.getParent = function () { return body; };
     body._children.push(tbl);
     body._children.push(createMockParagraph('after'));
+    wireParentsForBody_(body);
     var cellPara = tbl._cell._inner[0];
     cellPara.getParent = function () { return tbl; };
     var doc = createMockDoc(body, cellPara);
     var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // [before, existingTable, topBuffer, NEW TABLE, after]
     expect(body._children[0]._text).toBe('before');
     expect(body._children[1]).toBe(tbl);
     expect(body._children[2]._text).toBe('');
-    expect(body._children[3].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[4]._text).toBe('after');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[4].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[6]._text).toBe('');
+    expect(body._children[7]._text).toBe('after');
     expect(result.pendingBorders.tableOrdinal).toBe(2);
   });
 
   // ── End-to-end: cursor in middle or beginning of paragraph (no split) ──
 
-  results.push('\ninsertBlockquoteTableAtPosition_() — cursor in paragraph (no split)');
+  results.push('\ninsertBlockquoteTableAtPosition_() — cursor in paragraph (split at end)');
 
-  it('blockquote: cursor on paragraph inserts table after it', function () {
+  it('blockquote: cursor at end of paragraph splits then inserts table and buffers', function () {
     var body = createMockBody(['hello world', 'after']);
     var doc = createMockDoc(body, body._children[0]);
     insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["hello world", topBuffer, TABLE, "after"]
     expect(body._children[0]._text).toBe('hello world');
     expect(body._children[1]._text).toBe('');
-    expect(body._children[2].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[3]._text).toBe('after');
-  });
-
-  it('plain: cursor on paragraph inserts content after it', function () {
-    var body = createMockBody(['hello world', 'after']);
-    var doc = createMockDoc(body, body._children[0]);
-    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
-
-    // ["hello world", topBuffer, content, "after"]
-    expect(body._children[0]._text).toBe('hello world');
-    expect(body._children[1]._text).toBe('');
-    expect(body._children[2]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[3]._text).toBe('after');
-  });
-
-  it('blockquote: cursor on second of three paragraphs inserts after it', function () {
-    var body = createMockBody(['first', 'second', 'third']);
-    var doc = createMockDoc(body, body._children[1]);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-
-    // ["first", "second", topBuffer, TABLE, "third"]
-    expect(body._children[0]._text).toBe('first');
-    expect(body._children[1]._text).toBe('second');
     expect(body._children[2]._text).toBe('');
     expect(body._children[3].getType()).toBe(DocumentApp.ElementType.TABLE);
-    expect(body._children[4]._text).toBe('third');
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[6]._text).toBe('after');
   });
 
-  it('plain: cursor on second of three paragraphs inserts after it', function () {
+  it('plain: cursor at end of paragraph splits then inserts content and buffers', function () {
+    var body = createMockBody(['hello world', 'after']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    expect(body._children[0]._text).toBe('hello world');
+    expect(body._children[1]._text).toBe('');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[4]._text).toBe('');
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[6]._text).toBe('after');
+  });
+
+  it('blockquote: cursor at end of second paragraph — split, table, buffers', function () {
+    var body = createMockBody(['first', 'second', 'third']);
+    var doc = createMockDoc(body, body._children[1]);
+    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
+
+    expect(body._children[0]._text).toBe('first');
+    expect(body._children[1]._text).toBe('second');
+    expect(body._children[2]._text).toBe('');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[4].getType()).toBe(DocumentApp.ElementType.TABLE);
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[6]._text).toBe('');
+    expect(body._children[7]._text).toBe('third');
+  });
+
+  it('plain: cursor at end of second paragraph — split, content, buffers', function () {
     var body = createMockBody(['first', 'second', 'third']);
     var doc = createMockDoc(body, body._children[1]);
     insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
 
-    // ["first", "second", topBuffer, content, "third"]
     expect(body._children[0]._text).toBe('first');
     expect(body._children[1]._text).toBe('second');
     expect(body._children[2]._text).toBe('');
-    expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
-    expect(body._children[4]._text).toBe('third');
+    expect(body._children[3]._text).toBe('');
+    expect(body._children[4]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
+    expect(body._children[5]._text).toBe('');
+    expect(body._children[6]._text).toBe('');
+    expect(body._children[7]._text).toBe('third');
   });
 
   // ── Restore ─────────────────────────────────────────────────


### PR DESCRIPTION
Implements #119: shared insertion pipeline for plain and blockquote, backward-count top buffers, paragraph/list split with list continuation, conditional bottom buffer at document end, buffer-only `insertParagraph` outside ayah. Preserves ayah spacing and blockquote cell padding.

Closes #119

Made with [Cursor](https://cursor.com)