### PR TITLE
Add RAG-based semantic search via @rag toggle

### DIFF
--- a/ClaudeAPI.js
+++ b/ClaudeAPI.js
@@ -195,6 +195,14 @@ function _handleExactSearch(classified) {
 function _handleSemanticSearch(classified) {
   var refs = classified.references;
 
+  var rawCount = (refs && Array.isArray(refs)) ? refs.length : 0;
+  Logger.log('[CLAUDE SEARCH] Claude returned ' + rawCount + ' raw reference(s):');
+  if (refs && Array.isArray(refs)) {
+    for (var ci = 0; ci < refs.length && ci < AI_MAX_REFERENCES; ci++) {
+      Logger.log('  [' + (ci + 1) + '] Surah ' + refs[ci].surah + ':' + refs[ci].ayah + ' (no score — Claude semantic search)');
+    }
+  }
+
   if (!refs || !Array.isArray(refs) || !refs.length) {
     return { type: 'error', error: 'No results found. Try a different query.' };
   }
@@ -208,11 +216,15 @@ function _handleSemanticSearch(classified) {
     }
   }
 
+  Logger.log('[CLAUDE SEARCH] After validation: ' + validRefs.length + ' valid ref(s) remain.');
+
   if (!validRefs.length) {
     return { type: 'error', error: 'No valid results found. Try a different query.' };
   }
 
-  return { type: 'references', references: _mergeConsecutiveReferences(validRefs) };
+  var merged = _mergeConsecutiveReferences(validRefs);
+  Logger.log('[CLAUDE SEARCH] Final result: ' + merged.length + ' merged group(s) shown to user.');
+  return { type: 'references', references: merged };
 }
 
 /**

--- a/ClaudeAPI.js
+++ b/ClaudeAPI.js
@@ -34,7 +34,8 @@ var UNIFIED_SYSTEM_PROMPT =
   '{"action":"exact_search","query":"بسم الله الرحمن"}\n\n' +
   '3. semantic_search — User describes a topic, theme, or meaning to search for (in any language).\n' +
   'Return up to 50 of the most relevant {surah, ayah} references, ordered by relevance.\n' +
-  '{"action":"semantic_search","references":[{"surah":2,"ayah":153},{"surah":3,"ayah":200}]}\n\n' +
+  'Always include a "query" field containing the cleaned English search intent as a string.\n' +
+  '{"action":"semantic_search","query":"patience in hardship","references":[{"surah":2,"ayah":153},{"surah":3,"ayah":200}]}\n\n' +
   '4. clarify — The request is ambiguous or missing information.\n' +
   '{"action":"clarify","message":"Your clarifying question here"}\n' +
   '</actions>\n\n' +
@@ -65,9 +66,9 @@ var UNIFIED_SYSTEM_PROMPT =
   'User: "find the verse that contains الله نور السماوات"\n' +
   '{"action":"exact_search","query":"الله نور السماوات"}\n\n' +
   'User: "verses about patience in hardship"\n' +
-  '{"action":"semantic_search","references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":3,"ayah":200}]}\n\n' +
+  '{"action":"semantic_search","query":"patience in hardship","references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":3,"ayah":200}]}\n\n' +
   'User: "ما هي الآيات التي تتحدث عن الصبر"\n' +
-  '{"action":"semantic_search","references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":31,"ayah":17}]}\n\n' +
+  '{"action":"semantic_search","query":"verses about patience","references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":31,"ayah":17}]}\n\n' +
   'User: "show me Al-Imran 190 to 194"\n' +
   '{"action":"fetch_ayah","references":[{"surah":3,"ayahStart":190,"ayahEnd":194}]}\n\n' +
   'User: "give me al baqarah 255 and al mulk 1 to 3"\n' +
@@ -96,6 +97,18 @@ function performAISearch(messages) {
   var lastMessage = messages[messages.length - 1];
   if (!lastMessage || !lastMessage.content || !lastMessage.content.trim()) {
     return { type: 'error', error: 'Please enter a query.' };
+  }
+
+  // Detect and strip @rag prefix for RAG-powered semantic search
+  var useRag = false;
+  var rawContent = lastMessage.content.trim();
+  if (rawContent.indexOf('@rag') === 0) {
+    useRag = true;
+    rawContent = rawContent.slice(4).trim();
+    if (!rawContent) {
+      return { type: 'error', error: 'Please enter a query after @rag.' };
+    }
+    messages[messages.length - 1] = { role: lastMessage.role, content: rawContent };
   }
 
   var apiKey = getClaudeApiKey_();
@@ -136,7 +149,7 @@ function performAISearch(messages) {
       response = _handleExactSearch(classified);
       break;
     case 'semantic_search':
-      response = _handleSemanticSearch(classified);
+      response = useRag ? _handleRagSearch(classified) : _handleSemanticSearch(classified);
       break;
     case 'clarify':
       response = { type: 'clarify', message: classified.message || 'Could you be more specific?' };

--- a/ClaudeAPI.js
+++ b/ClaudeAPI.js
@@ -12,6 +12,7 @@
 var CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
 var CLAUDE_MODEL = 'claude-haiku-4-5-20251001';
 var CLAUDE_MAX_TOKENS = 1024;
+var CLAUDE_RAG_RERANK_MAX_TOKENS = 512;
 var AI_MAX_REFERENCES = 50;
 var CONVERSATION_CONTEXT_LIMIT = 3;
 var FETCH_AYAH_SAFETY_CAP = 300;
@@ -33,9 +34,11 @@ var UNIFIED_SYSTEM_PROMPT =
   'Extract only the Quranic Arabic text into "query", stripping any surrounding instructions.\n' +
   '{"action":"exact_search","query":"بسم الله الرحمن"}\n\n' +
   '3. semantic_search — User describes a topic, theme, or meaning to search for (in any language).\n' +
-  'Return up to 50 of the most relevant {surah, ayah} references, ordered by relevance.\n' +
-  'Always include a "query" field containing the cleaned English search intent as a string.\n' +
-  '{"action":"semantic_search","query":"patience in hardship","references":[{"surah":2,"ayah":153},{"surah":3,"ayah":200}]}\n\n' +
+  'Include a "queries" array of exactly 3 short strings: reformulate the same user intent from different angles ' +
+  '(different vocabulary, synonyms, Islamic terminology alongside English, and phrasing that could appear ' +
+  'in an English Quran translation or tafseer). Questions in Arabic should still use English-oriented query strings.\n' +
+  'Include a "references" array of up to 50 {surah, ayah} pairs, ordered by relevance, for the standard semantic results path.\n' +
+  '{"action":"semantic_search","queries":["patience and steadfastness in the face of hardship","sabr during trials and tests from Allah","enduring difficulty with faith and perseverance"],"references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":3,"ayah":200}]}\n\n' +
   '4. clarify — The request is ambiguous or missing information.\n' +
   '{"action":"clarify","message":"Your clarifying question here"}\n' +
   '</actions>\n\n' +
@@ -48,6 +51,8 @@ var UNIFIED_SYSTEM_PROMPT =
   'Extract only the Quranic text into "query".\n' +
   '- Use semantic_search when the user describes what to find by meaning, topic, or theme, ' +
   'in any language (including Arabic questions about Quran topics).\n' +
+  '- For semantic_search: always include both "queries" (exactly 3 strings) and "references" (up to 50 pairs). ' +
+  'The add-on uses "queries" for expanded vector retrieval when RAG mode is on; it uses "references" when RAG is off.\n' +
   '- If a surah name is given without an ayah number, return the full surah using fetch_ayah. ' +
   'You must know the correct total ayah count for the surah.\n' +
   '- Never assume or correct a surah name, surah number, or ayah number. ' +
@@ -65,10 +70,14 @@ var UNIFIED_SYSTEM_PROMPT =
   '{"action":"exact_search","query":"إن مع العسر يسرا"}\n\n' +
   'User: "find the verse that contains الله نور السماوات"\n' +
   '{"action":"exact_search","query":"الله نور السماوات"}\n\n' +
+  'User: "verses about the love of the prophet"\n' +
+  '{"action":"semantic_search","queries":["love and devotion to the Messenger Muhammad","preferring the Prophet over worldly attachments and family","sending blessings and salutations upon the Prophet salawat"],"references":[{"surah":3,"ayah":31},{"surah":33,"ayah":56},{"surah":9,"ayah":24},{"surah":48,"ayah":29}]}\n\n' +
+  'User: "ayahs about love between husband and wife"\n' +
+  '{"action":"semantic_search","queries":["love and mercy between spouses mawaddah rahmah","marriage as a sign of Allah and tranquility between partners","the bond between husband and wife in Islam"],"references":[{"surah":30,"ayah":21},{"surah":2,"ayah":187},{"surah":4,"ayah":1}]}\n\n' +
   'User: "verses about patience in hardship"\n' +
-  '{"action":"semantic_search","query":"patience in hardship","references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":3,"ayah":200}]}\n\n' +
+  '{"action":"semantic_search","queries":["patience and steadfastness in the face of hardship","sabr during trials and tests from Allah","enduring difficulty with faith and perseverance"],"references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":3,"ayah":200}]}\n\n' +
   'User: "ما هي الآيات التي تتحدث عن الصبر"\n' +
-  '{"action":"semantic_search","query":"verses about patience","references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":31,"ayah":17}]}\n\n' +
+  '{"action":"semantic_search","queries":["patience and steadfastness in the face of hardship","sabr during trials and tests from Allah","enduring difficulty with faith and perseverance"],"references":[{"surah":2,"ayah":153},{"surah":2,"ayah":155},{"surah":31,"ayah":17}]}\n\n' +
   'User: "show me Al-Imran 190 to 194"\n' +
   '{"action":"fetch_ayah","references":[{"surah":3,"ayahStart":190,"ayahEnd":194}]}\n\n' +
   'User: "give me al baqarah 255 and al mulk 1 to 3"\n' +
@@ -80,6 +89,11 @@ var UNIFIED_SYSTEM_PROMPT =
   'User: "show me surah 116"\n' +
   '{"action":"clarify","message":"Surah 116 is not a valid surah number. The Quran has 114 surahs (1-114). Which surah did you mean?"}\n' +
   '</examples>';
+
+var RAG_RERANK_SYSTEM_PROMPT =
+  'You are a Quran relevance ranker. Given a user\'s search query and a list of candidate ayahs, return the 10 most relevant ayahs ranked by how directly they address the user\'s intent.\n\n' +
+  'Return ONLY a JSON array of ayah keys in order of relevance, most relevant first.\n' +
+  'Example: ["30:21","4:19","2:231"]';
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -99,9 +113,11 @@ function performAISearch(messages) {
     return { type: 'error', error: 'Please enter a query.' };
   }
 
+  var originalUserMessageForRerank = lastMessage.content.trim();
+
   // Detect and strip @rag prefix for RAG-powered semantic search
   var useRag = false;
-  var rawContent = lastMessage.content.trim();
+  var rawContent = originalUserMessageForRerank;
   if (rawContent.indexOf('@rag') === 0) {
     useRag = true;
     rawContent = rawContent.slice(4).trim();
@@ -149,7 +165,7 @@ function performAISearch(messages) {
       response = _handleExactSearch(classified);
       break;
     case 'semantic_search':
-      response = useRag ? _handleRagSearch(classified) : _handleSemanticSearch(classified);
+      response = useRag ? _handleRagSearch(classified, originalUserMessageForRerank) : _handleSemanticSearch(classified);
       break;
     case 'clarify':
       response = { type: 'clarify', message: classified.message || 'Could you be more specific?' };
@@ -298,6 +314,33 @@ function _mergeConsecutiveReferences(refs) {
 }
 
 /**
+ * Merges consecutive same-surah ayahs into range groups without reordering the input.
+ * Use for RAG (@rag) so Pinecone/rerank order is preserved; unlike _mergeConsecutiveReferences,
+ * which sorts by surah/ayah first for canonical display on other paths.
+ * @param {Array<{surah: number, ayah: number}>} refs - Flat references in desired output order
+ * @return {Array<{surah: number, ayahStart: number, ayahEnd: number}>} Merged groups
+ */
+function _mergeConsecutiveReferencesInInputOrder_(refs) {
+  if (!refs || !refs.length) return [];
+
+  var groups = [];
+  var cur = { surah: refs[0].surah, ayahStart: refs[0].ayah, ayahEnd: refs[0].ayah };
+
+  for (var i = 1; i < refs.length; i++) {
+    var r = refs[i];
+    if (r.surah === cur.surah && r.ayah === cur.ayahEnd + 1) {
+      cur.ayahEnd = r.ayah;
+    } else {
+      groups.push(cur);
+      cur = { surah: r.surah, ayahStart: r.ayah, ayahEnd: r.ayah };
+    }
+  }
+  groups.push(cur);
+
+  return groups;
+}
+
+/**
  * Expands an array of multi-reference items into a flat list of {surah, ayah} pairs.
  * Each item may be a single ayah or a range (ayahStart/ayahEnd).
  * Invalid items are silently skipped; total count is capped at FETCH_AYAH_SAFETY_CAP.
@@ -359,6 +402,101 @@ function _trimConversationContext(messages) {
     valid = valid.slice(valid.length - CONVERSATION_CONTEXT_LIMIT);
   }
   return valid;
+}
+
+/**
+ * Calls Claude to rerank RAG candidate ayahs by English translation relevance.
+ * @param {string} apiKey - Anthropic API key
+ * @param {string} userQuery - User search query for reranking (without @rag prefix)
+ * @param {string} candidateBlock - Lines "surah:ayah — translation"
+ * @return {string|null} Model text, or null on HTTP/body failure
+ */
+function _callClaudeForRagRerank_(apiKey, userQuery, candidateBlock) {
+  if (!apiKey || !candidateBlock || !String(candidateBlock).trim()) {
+    return null;
+  }
+
+  var userContent =
+    'User query: ' + (userQuery || '') + '\n\n' +
+    'Candidate ayahs:\n' +
+    candidateBlock;
+
+  var payload = {
+    model: CLAUDE_MODEL,
+    max_tokens: CLAUDE_RAG_RERANK_MAX_TOKENS,
+    temperature: 0,
+    system: RAG_RERANK_SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: userContent }]
+  };
+
+  var options = {
+    method: 'post',
+    contentType: 'application/json',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01'
+    },
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  };
+
+  var response = UrlFetchApp.fetch(CLAUDE_API_URL, options);
+  if (response.getResponseCode() !== 200) {
+    return null;
+  }
+
+  var body = JSON.parse(response.getContentText());
+  if (!body || !body.content || !body.content.length) {
+    return null;
+  }
+
+  var text = '';
+  for (var i = 0; i < body.content.length; i++) {
+    if (body.content[i].type === 'text') {
+      text += body.content[i].text;
+    }
+  }
+  return text ? text.trim() : null;
+}
+
+/**
+ * Parses Claude rerank response: JSON array of "surah:ayah" keys.
+ * @param {string} text - Raw model output
+ * @return {string[]|null} Validated keys, or null if unusable
+ */
+function _parseRerankedAyahKeys_(text) {
+  if (!text || typeof text !== 'string') return null;
+
+  var cleaned = text.replace(/```json?\s*/gi, '').replace(/```/g, '').trim();
+
+  var parsed;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (e) {
+    var match = cleaned.match(/\[[\s\S]*\]/);
+    if (!match) return null;
+    try {
+      parsed = JSON.parse(match[0]);
+    } catch (e2) {
+      return null;
+    }
+  }
+
+  if (!Array.isArray(parsed) || !parsed.length) return null;
+
+  var out = [];
+  for (var i = 0; i < parsed.length; i++) {
+    if (typeof parsed[i] !== 'string') continue;
+    var key = parsed[i].trim();
+    var parts = key.split(':');
+    if (parts.length !== 2) continue;
+    var s = parseInt(parts[0], 10);
+    var a = parseInt(parts[1], 10);
+    if (!(s >= 1 && s <= 114 && a >= 1)) continue;
+    out.push(s + ':' + a);
+  }
+
+  return out.length ? out : null;
 }
 
 /**

--- a/RagEnglishTranslationSource.js
+++ b/RagEnglishTranslationSource.js
@@ -1,0 +1,62 @@
+/**
+ * RagEnglishTranslationSource.js
+ *
+ * English translation strings for RAG reranking (server-side).
+ * Swap implementation of getRagEnglishTranslationMap_() to use another source later.
+ *
+ * Keep TRANSLATION_JSON_URL_FOR_RAG_ in sync with sidebar/js/quran-caches.html TRANSLATION_URL.
+ */
+
+var TRANSLATION_JSON_URL_FOR_RAG_ =
+  'https://tarazis.github.io/tasneef-data/quran/en-sahih-international-simple.json';
+
+/** @type {Object<string,string>|null} */
+var _ragEnglishTranslationMapCache_ = null;
+
+/**
+ * Parses flat translation JSON: keys "surah:ayah", values { t: "..." }.
+ * @param {Object} obj
+ * @return {Object<string,string>}
+ */
+function _parseRagTranslationFlat_(obj) {
+  var map = {};
+  if (!obj || typeof obj !== 'object') return map;
+  for (var key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key) && obj[key] && obj[key].t) {
+      map[key] = String(obj[key].t);
+    }
+  }
+  return map;
+}
+
+/**
+ * Fetches and returns surah:ayah → English translation text map, or null on failure.
+ * Result is cached for the remainder of the Apps Script execution (warm instance).
+ * @return {Object<string,string>|null}
+ */
+function getRagEnglishTranslationMap_() {
+  if (_ragEnglishTranslationMapCache_) {
+    return _ragEnglishTranslationMapCache_;
+  }
+
+  try {
+    var response = UrlFetchApp.fetch(TRANSLATION_JSON_URL_FOR_RAG_, {
+      muteHttpExceptions: true
+    });
+    if (response.getResponseCode() !== 200) {
+      return null;
+    }
+    var body = JSON.parse(response.getContentText());
+    _ragEnglishTranslationMapCache_ = _parseRagTranslationFlat_(body);
+    return _ragEnglishTranslationMapCache_;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Clears the in-memory translation map (for tests only).
+ */
+function clearRagEnglishTranslationMapCacheForTests_() {
+  _ragEnglishTranslationMapCache_ = null;
+}

--- a/RagService.js
+++ b/RagService.js
@@ -2,12 +2,17 @@
  * RagService.js
  * RAG-powered semantic search via OpenAI embeddings + Pinecone vector DB.
  * Called from ClaudeAPI.js when the user triggers @rag mode on a semantic_search query.
+ * After retrieval, optionally reranks the top candidate ayahs with Claude using English translations.
  *
  * Every failure silently falls back to _handleSemanticSearch (Claude's references).
  */
 
-var RAG_SCORE_THRESHOLD = 0.75;
-var RAG_TOP_K = 10;
+var RAG_SCORE_THRESHOLD = 0.35;
+var RAG_TOP_K = 20;
+var RAG_MAX_EXPAND_QUERIES = 3;
+var RAG_CANDIDATE_POOL = 20;
+var RAG_FINAL_MAX_AYAH = 10;
+var RAG_LOG_QUERY_MAX_LEN = 80;
 var OPENAI_EMBEDDING_URL = 'https://api.openai.com/v1/embeddings';
 var OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
 
@@ -40,19 +45,177 @@ function getPineconeApiKey_() {
     .getProperty(PROPERTY_KEYS.PINECONE_API_KEY) || null;
 }
 
+// ─── Query normalization (multi-query expansion) ─────────────────────────────
+
+/**
+ * Builds the list of query strings for RAG from Claude output.
+ * Prefers classified.queries (capped); falls back to legacy classified.query.
+ * @param {Object} classified
+ * @return {string[]}
+ */
+function _normalizeRagQueryStrings_(classified) {
+  var out = [];
+  var raw = classified && classified.queries;
+  if (raw && Array.isArray(raw)) {
+    for (var i = 0; i < raw.length && out.length < RAG_MAX_EXPAND_QUERIES; i++) {
+      var t = (raw[i] === null || raw[i] === undefined) ? '' : String(raw[i]).trim();
+      if (t) out.push(t);
+    }
+  }
+  if (!out.length && classified) {
+    var legacy = (classified.query || '').trim();
+    if (legacy) out.push(legacy);
+  }
+  return out;
+}
+
+/**
+ * Truncates a string for Logger output.
+ * @param {string} s
+ * @return {string}
+ */
+function _truncateForRagLog_(s) {
+  if (!s || typeof s !== 'string') return '';
+  if (s.length <= RAG_LOG_QUERY_MAX_LEN) return s;
+  return s.substring(0, RAG_LOG_QUERY_MAX_LEN) + '…';
+}
+
+/**
+ * Merges Pinecone match lists from multiple query vectors: one row per ayah (max score wins).
+ * @param {Array<{queryIndex: number, queryText: string, matches: Array<{score: number, metadata: Object}>}>} runs
+ * @return {Array<{surah: number, ayah: number, score: number, winningQueryIndex: number, winningQueryText: string}>}
+ */
+function _mergeRagMatchesByAyah_(runs) {
+  var best = {};
+  for (var r = 0; r < runs.length; r++) {
+    var run = runs[r];
+    var qi = run.queryIndex;
+    var qtext = run.queryText || '';
+    var matches = run.matches || [];
+    for (var j = 0; j < matches.length; j++) {
+      var m = matches[j];
+      var meta = m.metadata;
+      if (!meta) continue;
+      var s = parseInt(meta.surah_number, 10);
+      var a = parseInt(meta.ayah_number, 10);
+      if (!(s >= 1 && s <= 114 && a >= 1)) continue;
+      var key = s + ':' + a;
+      var sc = m.score;
+      var row = best[key];
+      if (!row || sc > row.score) {
+        best[key] = {
+          score: sc,
+          surah: s,
+          ayah: a,
+          winningQueryIndex: qi,
+          winningQueryText: qtext
+        };
+      }
+    }
+  }
+  var arr = [];
+  for (var k in best) {
+    if (Object.prototype.hasOwnProperty.call(best, k)) {
+      arr.push(best[k]);
+    }
+  }
+  arr.sort(function (x, y) {
+    return y.score - x.score;
+  });
+  return arr;
+}
+
+/**
+ * Builds final flat {surah, ayah} list: reranked keys first (validated against pool), then Pinecone order to fill/cap.
+ * @param {Array<{surah: number, ayah: number}>} pineconeOrderedRefs - score order, length <= RAG_CANDIDATE_POOL
+ * @param {string[]|null} rerankedKeys - Claude "surah:ayah" keys, or null for score-only
+ * @param {number} [maxOut] - defaults to RAG_FINAL_MAX_AYAH
+ * @return {Array<{surah: number, ayah: number}>}
+ */
+function _finalizeRagAyahRefs_(pineconeOrderedRefs, rerankedKeys, maxOut) {
+  var cap = maxOut != null ? maxOut : RAG_FINAL_MAX_AYAH;
+  var pineconeKeyList = [];
+  for (var i = 0; i < pineconeOrderedRefs.length; i++) {
+    var r = pineconeOrderedRefs[i];
+    pineconeKeyList.push(parseInt(r.surah, 10) + ':' + parseInt(r.ayah, 10));
+  }
+
+  var allowed = {};
+  for (var a = 0; a < pineconeKeyList.length; a++) {
+    allowed[pineconeKeyList[a]] = true;
+  }
+
+  var out = [];
+  var seen = {};
+
+  function pushKey(key) {
+    if (out.length >= cap) return;
+    if (!key || !allowed[key]) return;
+    if (seen[key]) return;
+    seen[key] = true;
+    var parts = String(key).split(':');
+    if (parts.length !== 2) return;
+    var s = parseInt(parts[0], 10);
+    var ay = parseInt(parts[1], 10);
+    if (!(s >= 1 && s <= 114 && ay >= 1)) return;
+    out.push({ surah: s, ayah: ay });
+  }
+
+  if (rerankedKeys && Array.isArray(rerankedKeys)) {
+    for (var j = 0; j < rerankedKeys.length; j++) {
+      pushKey(String(rerankedKeys[j]).trim());
+    }
+  }
+
+  for (var k = 0; k < pineconeKeyList.length; k++) {
+    pushKey(pineconeKeyList[k]);
+  }
+
+  return out;
+}
+
+/**
+ * Fallback text for rerank prompt when originalUserQueryForRerank is not passed (e.g. tests).
+ * @param {Object} classified
+ * @return {string}
+ */
+function _rerankUserQueryFallback_(classified) {
+  var qs = _normalizeRagQueryStrings_(classified);
+  if (qs.length) return qs[0];
+  return String(classified && classified.query ? classified.query : '').trim();
+}
+
+/**
+ * Removes a leading @rag prefix so the reranker receives the same query text as intent classification.
+ * @param {string} text
+ * @return {string}
+ */
+function _stripRagPrefixForRerankUserQuery_(text) {
+  if (!text || typeof text !== 'string') return '';
+  var t = text.trim();
+  if (t.indexOf('@rag') === 0) {
+    t = t.slice(4).trim();
+  }
+  return t;
+}
+
 // ─── API calls ───────────────────────────────────────────────────────────────
 
 /**
- * Calls OpenAI embeddings API to get a vector for the given text.
+ * Calls OpenAI embeddings API for one or more strings (single batch request).
  * @param {string} apiKey - OpenAI API key
- * @param {string} query - Text to embed
- * @return {number[]} 1536-dimensional embedding vector
+ * @param {string[]} inputs - Non-empty list of texts to embed
+ * @return {number[][]} One vector per input, ordered by input index
  * @throws {Error} On non-200 response or malformed body
  */
-function _getEmbedding(apiKey, query) {
+function _getEmbeddings(apiKey, inputs) {
+  if (!inputs || !inputs.length) {
+    throw new Error('OpenAI embeddings: inputs array must be non-empty');
+  }
+
   var payload = {
     model: OPENAI_EMBEDDING_MODEL,
-    input: query
+    input: inputs
   };
 
   var options = {
@@ -69,7 +232,33 @@ function _getEmbedding(apiKey, query) {
   }
 
   var body = JSON.parse(response.getContentText());
-  return body.data[0].embedding;
+  var rows = body.data || [];
+  rows.sort(function (a, b) {
+    return (a.index || 0) - (b.index || 0);
+  });
+
+  var out = [];
+  for (var i = 0; i < rows.length; i++) {
+    if (!rows[i].embedding) {
+      throw new Error('OpenAI embeddings: missing embedding at index ' + i);
+    }
+    out.push(rows[i].embedding);
+  }
+  if (out.length !== inputs.length) {
+    throw new Error('OpenAI embeddings: expected ' + inputs.length + ' vectors, got ' + out.length);
+  }
+  return out;
+}
+
+/**
+ * Calls OpenAI embeddings API to get a vector for the given text.
+ * @param {string} apiKey - OpenAI API key
+ * @param {string} query - Text to embed
+ * @return {number[]} 1536-dimensional embedding vector
+ * @throws {Error} On non-200 response or malformed body
+ */
+function _getEmbedding(apiKey, query) {
+  return _getEmbeddings(apiKey, [query])[0];
 }
 
 /**
@@ -108,55 +297,89 @@ function _queryPinecone(host, apiKey, vector) {
 // ─── Handler ─────────────────────────────────────────────────────────────────
 
 /**
- * Handles semantic search via RAG: embeds query → queries Pinecone → maps to references.
+ * Handles semantic search via RAG: batch-embeds query reformulations, queries Pinecone per vector,
+ * merges by ayah (max score), filters by threshold, optional Claude rerank, cap, merge consecutive refs.
  * Falls back to _handleSemanticSearch on any failure.
- * @param {Object} classified - Claude classification with { query, references }
+ * @param {Object} classified - Claude classification with { queries?, query?, references }
+ * @param {string} [originalUserQueryForRerank] - Last user message as typed (from performAISearch; @rag stripped before rerank prompt)
  * @return {Object} { type: 'references', references: [{surah, ayahStart, ayahEnd}] } or fallback
  */
-function _handleRagSearch(classified) {
-  var query = (classified.query || '').trim();
-  if (!query) return _handleSemanticSearch(classified);
+function _handleRagSearch(classified, originalUserQueryForRerank) {
+  Logger.log('[RAG SEARCH] Entered _handleRagSearch');
+
+  var queryStrings = _normalizeRagQueryStrings_(classified);
+  if (!queryStrings.length) {
+    Logger.log('[RAG SEARCH] FAIL: no queries or legacy query from classification — falling back to Claude.');
+    return _handleSemanticSearch(classified);
+  }
+
+  Logger.log('[RAG SEARCH] Using ' + queryStrings.length + ' expansion query string(s).');
 
   var openAiKey = getOpenAiApiKey_();
-  if (!openAiKey) return _handleSemanticSearch(classified);
+  if (!openAiKey) {
+    Logger.log('[RAG SEARCH] FAIL: openai_api_key not set in Script Properties — falling back to Claude.');
+    return _handleSemanticSearch(classified);
+  }
 
-  var vector;
+  var vectors;
   try {
-    vector = _getEmbedding(openAiKey, query);
+    vectors = _getEmbeddings(openAiKey, queryStrings);
+    Logger.log('[RAG SEARCH] OpenAI batch embedding OK — ' + vectors.length + ' vector(s), dim ' + vectors[0].length);
   } catch (e) {
+    Logger.log('[RAG SEARCH] FAIL: OpenAI embedding error: ' + e.message + ' — falling back to Claude.');
     return _handleSemanticSearch(classified);
   }
 
   var pineconeHost = getPineconeHost_();
   var pineconeKey = getPineconeApiKey_();
-  if (!pineconeHost || !pineconeKey) return _handleSemanticSearch(classified);
-
-  var matches;
-  try {
-    matches = _queryPinecone(pineconeHost, pineconeKey, vector);
-  } catch (e) {
+  if (!pineconeHost || !pineconeKey) {
+    Logger.log('[RAG SEARCH] FAIL: pinecone_host=' + (pineconeHost ? 'SET' : 'MISSING') +
+      ', pinecone_api_key=' + (pineconeKey ? 'SET' : 'MISSING') + ' — falling back to Claude.');
     return _handleSemanticSearch(classified);
   }
 
-  Logger.log('[RAG SEARCH] Query: "' + query + '" — Pinecone returned ' + matches.length + ' match(es):');
-  for (var j = 0; j < matches.length; j++) {
-    var m = matches[j];
-    var matchMeta = m.metadata || {};
-    Logger.log('  [' + (j + 1) + '] Surah ' + matchMeta.surah_number + ':' + matchMeta.ayah_number +
-      ' — score: ' + m.score.toFixed(4) +
-      (m.score < RAG_SCORE_THRESHOLD ? ' (BELOW threshold, filtered out)' : ' (KEPT)'));
+  var runs = [];
+  for (var qi = 0; qi < vectors.length; qi++) {
+    var qLabel = queryStrings[qi];
+    var trunc = _truncateForRagLog_(qLabel);
+    var matches;
+    try {
+      matches = _queryPinecone(pineconeHost, pineconeKey, vectors[qi]);
+    } catch (e) {
+      Logger.log('[RAG SEARCH] FAIL: Pinecone query error (query[' + qi + ']): ' + e.message + ' — falling back to Claude.');
+      return _handleSemanticSearch(classified);
+    }
+
+    for (var j = 0; j < matches.length; j++) {
+      var m = matches[j];
+      var matchMeta = m.metadata || {};
+      Logger.log('[RAG SEARCH] raw match — query[' + qi + '] "' + trunc + '" — Surah ' +
+        matchMeta.surah_number + ':' + matchMeta.ayah_number + ' — score: ' + m.score.toFixed(4));
+    }
+
+    runs.push({
+      queryIndex: qi,
+      queryText: qLabel,
+      matches: matches
+    });
+  }
+
+  var mergedRows = _mergeRagMatchesByAyah_(runs);
+
+  Logger.log('[RAG SEARCH] After merge across queries: ' + mergedRows.length + ' unique ayah key(s), sorted by score desc.');
+
+  for (var mi = 0; mi < mergedRows.length; mi++) {
+    var row = mergedRows[mi];
+    var below = row.score < RAG_SCORE_THRESHOLD;
+    Logger.log('[RAG SEARCH] merged — Surah ' + row.surah + ':' + row.ayah + ' — best score: ' + row.score.toFixed(4) +
+      ' — from query[' + row.winningQueryIndex + '] "' + _truncateForRagLog_(row.winningQueryText) + '"' +
+      (below ? ' (BELOW threshold, filtered out)' : ' (KEPT)'));
   }
 
   var validRefs = [];
-  for (var i = 0; i < matches.length; i++) {
-    if (matches[i].score < RAG_SCORE_THRESHOLD) continue;
-    var meta = matches[i].metadata;
-    if (!meta) continue;
-    var s = parseInt(meta.surah_number, 10);
-    var a = parseInt(meta.ayah_number, 10);
-    if (s >= 1 && s <= 114 && a >= 1) {
-      validRefs.push({ surah: s, ayah: a });
-    }
+  for (var ri = 0; ri < mergedRows.length; ri++) {
+    if (mergedRows[ri].score < RAG_SCORE_THRESHOLD) continue;
+    validRefs.push({ surah: mergedRows[ri].surah, ayah: mergedRows[ri].ayah });
   }
 
   Logger.log('[RAG SEARCH] After score filter (threshold=' + RAG_SCORE_THRESHOLD + '): ' + validRefs.length + ' valid ref(s) remain.');
@@ -166,7 +389,64 @@ function _handleRagSearch(classified) {
     return _handleSemanticSearch(classified);
   }
 
-  var merged = _mergeConsecutiveReferences(validRefs);
-  Logger.log('[RAG SEARCH] Final result: ' + merged.length + ' merged group(s) shown to user.');
+  var pool = validRefs.slice(0, RAG_CANDIDATE_POOL);
+  var pineconeKeysForLog = [];
+  for (var pi = 0; pi < pool.length; pi++) {
+    pineconeKeysForLog.push(pool[pi].surah + ':' + pool[pi].ayah);
+  }
+  Logger.log('[RAG SEARCH] Pinecone-ranked order (top ' + pool.length + '): ' + JSON.stringify(pineconeKeysForLog));
+
+  var userQueryForRerank =
+    (originalUserQueryForRerank && String(originalUserQueryForRerank).trim()) ||
+    _rerankUserQueryFallback_(classified);
+  userQueryForRerank = _stripRagPrefixForRerankUserQuery_(userQueryForRerank);
+  if (!userQueryForRerank) {
+    userQueryForRerank = _rerankUserQueryFallback_(classified);
+  }
+
+  var translationMap = getRagEnglishTranslationMap_();
+  var rerankedKeys = null;
+
+  if (!translationMap) {
+    Logger.log('[RAG SEARCH] WARN: English translation map unavailable — skipping rerank, using Pinecone order.');
+  } else {
+    var lines = [];
+    for (var li = 0; li < pool.length; li++) {
+      var pr = pool[li];
+      var pkey = pr.surah + ':' + pr.ayah;
+      var ttext = translationMap[pkey];
+      if (!ttext || !String(ttext).trim()) {
+        ttext = '[translation unavailable]';
+      }
+      lines.push(pkey + ' — ' + ttext);
+    }
+    var candidateBlock = lines.join('\n');
+
+    var claudeKey = getClaudeApiKey_();
+    if (!claudeKey) {
+      Logger.log('[RAG SEARCH] WARN: Claude API key missing — skipping rerank, using Pinecone order.');
+    } else {
+      var rawRerank = _callClaudeForRagRerank_(claudeKey, userQueryForRerank, candidateBlock);
+      if (!rawRerank) {
+        Logger.log('[RAG SEARCH] WARN: Claude rerank returned empty or HTTP error — using Pinecone order.');
+      } else {
+        rerankedKeys = _parseRerankedAyahKeys_(rawRerank);
+        if (!rerankedKeys) {
+          Logger.log('[RAG SEARCH] WARN: Could not parse reranker JSON array — using Pinecone order.');
+        }
+      }
+    }
+  }
+
+  var finalFlat = _finalizeRagAyahRefs_(pool, rerankedKeys, RAG_FINAL_MAX_AYAH);
+  var finalKeysForLog = [];
+  for (var fi = 0; fi < finalFlat.length; fi++) {
+    finalKeysForLog.push(finalFlat[fi].surah + ':' + finalFlat[fi].ayah);
+  }
+  Logger.log('[RAG SEARCH] Final order (after rerank or fallback, cap ' + RAG_FINAL_MAX_AYAH + '): ' +
+    JSON.stringify(finalKeysForLog));
+
+  var merged = _mergeConsecutiveReferencesInInputOrder_(finalFlat);
+  Logger.log('[RAG SEARCH] SUCCESS — returning ' + merged.length + ' RAG group(s) (not falling back to Claude).');
   return { type: 'references', references: merged };
 }

--- a/RagService.js
+++ b/RagService.js
@@ -1,0 +1,156 @@
+/**
+ * RagService.js
+ * RAG-powered semantic search via OpenAI embeddings + Pinecone vector DB.
+ * Called from ClaudeAPI.js when the user triggers @rag mode on a semantic_search query.
+ *
+ * Every failure silently falls back to _handleSemanticSearch (Claude's references).
+ */
+
+var RAG_SCORE_THRESHOLD = 0.75;
+var RAG_TOP_K = 10;
+var OPENAI_EMBEDDING_URL = 'https://api.openai.com/v1/embeddings';
+var OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
+
+// ─── Property getters (trailing _ hides from google.script.run) ──────────────
+
+/**
+ * Returns the OpenAI API key from Script Properties, or null if not set.
+ * @return {string|null}
+ */
+function getOpenAiApiKey_() {
+  return PropertiesService.getScriptProperties()
+    .getProperty(PROPERTY_KEYS.OPENAI_API_KEY) || null;
+}
+
+/**
+ * Returns the Pinecone index host URL from Script Properties, or null if not set.
+ * @return {string|null}
+ */
+function getPineconeHost_() {
+  return PropertiesService.getScriptProperties()
+    .getProperty(PROPERTY_KEYS.PINECONE_HOST) || null;
+}
+
+/**
+ * Returns the Pinecone API key from Script Properties, or null if not set.
+ * @return {string|null}
+ */
+function getPineconeApiKey_() {
+  return PropertiesService.getScriptProperties()
+    .getProperty(PROPERTY_KEYS.PINECONE_API_KEY) || null;
+}
+
+// ─── API calls ───────────────────────────────────────────────────────────────
+
+/**
+ * Calls OpenAI embeddings API to get a vector for the given text.
+ * @param {string} apiKey - OpenAI API key
+ * @param {string} query - Text to embed
+ * @return {number[]} 1536-dimensional embedding vector
+ * @throws {Error} On non-200 response or malformed body
+ */
+function _getEmbedding(apiKey, query) {
+  var payload = {
+    model: OPENAI_EMBEDDING_MODEL,
+    input: query
+  };
+
+  var options = {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { 'Authorization': 'Bearer ' + apiKey },
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  };
+
+  var response = UrlFetchApp.fetch(OPENAI_EMBEDDING_URL, options);
+  if (response.getResponseCode() !== 200) {
+    throw new Error('OpenAI API returned HTTP ' + response.getResponseCode());
+  }
+
+  var body = JSON.parse(response.getContentText());
+  return body.data[0].embedding;
+}
+
+/**
+ * Queries the Pinecone vector index with the given embedding.
+ * @param {string} host - Pinecone index host URL (e.g. https://tasneef-english-xxx.svc.xxx.pinecone.io)
+ * @param {string} apiKey - Pinecone API key
+ * @param {number[]} vector - Query vector
+ * @return {Array<{id: string, score: number, metadata: Object}>} Matches array
+ * @throws {Error} On non-200 response
+ */
+function _queryPinecone(host, apiKey, vector) {
+  var url = host + '/query';
+  var payload = {
+    vector: vector,
+    topK: RAG_TOP_K,
+    includeMetadata: true
+  };
+
+  var options = {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { 'Api-Key': apiKey },
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  };
+
+  var response = UrlFetchApp.fetch(url, options);
+  if (response.getResponseCode() !== 200) {
+    throw new Error('Pinecone API returned HTTP ' + response.getResponseCode());
+  }
+
+  var body = JSON.parse(response.getContentText());
+  return body.matches || [];
+}
+
+// ─── Handler ─────────────────────────────────────────────────────────────────
+
+/**
+ * Handles semantic search via RAG: embeds query → queries Pinecone → maps to references.
+ * Falls back to _handleSemanticSearch on any failure.
+ * @param {Object} classified - Claude classification with { query, references }
+ * @return {Object} { type: 'references', references: [{surah, ayahStart, ayahEnd}] } or fallback
+ */
+function _handleRagSearch(classified) {
+  var query = (classified.query || '').trim();
+  if (!query) return _handleSemanticSearch(classified);
+
+  var openAiKey = getOpenAiApiKey_();
+  if (!openAiKey) return _handleSemanticSearch(classified);
+
+  var vector;
+  try {
+    vector = _getEmbedding(openAiKey, query);
+  } catch (e) {
+    return _handleSemanticSearch(classified);
+  }
+
+  var pineconeHost = getPineconeHost_();
+  var pineconeKey = getPineconeApiKey_();
+  if (!pineconeHost || !pineconeKey) return _handleSemanticSearch(classified);
+
+  var matches;
+  try {
+    matches = _queryPinecone(pineconeHost, pineconeKey, vector);
+  } catch (e) {
+    return _handleSemanticSearch(classified);
+  }
+
+  var validRefs = [];
+  for (var i = 0; i < matches.length; i++) {
+    if (matches[i].score < RAG_SCORE_THRESHOLD) continue;
+    var meta = matches[i].metadata;
+    if (!meta) continue;
+    var s = parseInt(meta.surah_number, 10);
+    var a = parseInt(meta.ayah_number, 10);
+    if (s >= 1 && s <= 114 && a >= 1) {
+      validRefs.push({ surah: s, ayah: a });
+    }
+  }
+
+  if (!validRefs.length) return _handleSemanticSearch(classified);
+
+  return { type: 'references', references: _mergeConsecutiveReferences(validRefs) };
+}

--- a/RagService.js
+++ b/RagService.js
@@ -138,6 +138,15 @@ function _handleRagSearch(classified) {
     return _handleSemanticSearch(classified);
   }
 
+  Logger.log('[RAG SEARCH] Query: "' + query + '" — Pinecone returned ' + matches.length + ' match(es):');
+  for (var j = 0; j < matches.length; j++) {
+    var m = matches[j];
+    var matchMeta = m.metadata || {};
+    Logger.log('  [' + (j + 1) + '] Surah ' + matchMeta.surah_number + ':' + matchMeta.ayah_number +
+      ' — score: ' + m.score.toFixed(4) +
+      (m.score < RAG_SCORE_THRESHOLD ? ' (BELOW threshold, filtered out)' : ' (KEPT)'));
+  }
+
   var validRefs = [];
   for (var i = 0; i < matches.length; i++) {
     if (matches[i].score < RAG_SCORE_THRESHOLD) continue;
@@ -150,7 +159,14 @@ function _handleRagSearch(classified) {
     }
   }
 
-  if (!validRefs.length) return _handleSemanticSearch(classified);
+  Logger.log('[RAG SEARCH] After score filter (threshold=' + RAG_SCORE_THRESHOLD + '): ' + validRefs.length + ' valid ref(s) remain.');
 
-  return { type: 'references', references: _mergeConsecutiveReferences(validRefs) };
+  if (!validRefs.length) {
+    Logger.log('[RAG SEARCH] No valid refs after score filtering — falling back to Claude references.');
+    return _handleSemanticSearch(classified);
+  }
+
+  var merged = _mergeConsecutiveReferences(validRefs);
+  Logger.log('[RAG SEARCH] Final result: ' + merged.length + ' merged group(s) shown to user.');
+  return { type: 'references', references: merged };
 }

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -18,7 +18,10 @@ var SETTINGS_DEFAULTS = {
 var PROPERTY_KEYS = {
   SETTINGS_PREFIX: 'setting_',
   CLAUDE_API_KEY: 'claude_api_key',
-  AI_SEARCH_COUNT: 'ai_search_count'
+  AI_SEARCH_COUNT: 'ai_search_count',
+  OPENAI_API_KEY: 'openai_api_key',
+  PINECONE_HOST: 'pinecone_host',
+  PINECONE_API_KEY: 'pinecone_api_key'
 };
 
 /**

--- a/tests/ClaudeAPI.test.gs
+++ b/tests/ClaudeAPI.test.gs
@@ -497,6 +497,43 @@ function runClaudeAPITests() {
     expect(result.references[0].ayahEnd).toBe(10);
   });
 
+  // ── @rag prefix detection (unit) ───────────────────────────────────────────
+
+  results.push('\n@rag prefix detection');
+
+  it('detects @rag prefix and strips it from messages', function () {
+    var msgs = [{ role: 'user', content: '@rag patience in hardship' }];
+    // We test the detection logic directly via performAISearch input validation
+    // The @rag prefix should be stripped before reaching Claude
+    var content = msgs[0].content.trim();
+    expect(content.indexOf('@rag') === 0).toBe(true);
+    var stripped = content.slice(4).trim();
+    expect(stripped).toBe('patience in hardship');
+  });
+
+  it('handles @rag with extra spaces', function () {
+    var content = '@rag   mercy and forgiveness';
+    var stripped = content.slice(4).trim();
+    expect(stripped).toBe('mercy and forgiveness');
+  });
+
+  it('does not detect @rag in middle of text', function () {
+    var content = 'search for @rag results';
+    expect(content.indexOf('@rag') === 0).toBe(false);
+  });
+
+  it('returns error for @rag with no query', function () {
+    var result = performAISearch([{ role: 'user', content: '@rag' }]);
+    expect(result.type).toBe('error');
+    expect(result.error).toBe('Please enter a query after @rag.');
+  });
+
+  it('returns error for @rag followed by only whitespace', function () {
+    var result = performAISearch([{ role: 'user', content: '@rag   ' }]);
+    expect(result.type).toBe('error');
+    expect(result.error).toBe('Please enter a query after @rag.');
+  });
+
   // ── performAISearch (integration) ──────────────────────────────────────────
 
   results.push('\nperformAISearch()');

--- a/tests/ClaudeAPI.test.gs
+++ b/tests/ClaudeAPI.test.gs
@@ -91,6 +91,17 @@ function runClaudeAPITests() {
     expect(parsed.references[0].surah).toBe(2);
   });
 
+  it('parses a semantic_search JSON object with queries and references', function () {
+    var text = '{"action":"semantic_search","queries":["patience in hardship","sabr during trials"],"references":[{"surah":2,"ayah":153}]}';
+    var parsed = _parseClassificationResponse(text);
+    expect(parsed.action).toBe('semantic_search');
+    expect(parsed.queries.length).toBe(2);
+    expect(parsed.queries[0]).toBe('patience in hardship');
+    expect(parsed.queries[1]).toBe('sabr during trials');
+    expect(parsed.references.length).toBe(1);
+    expect(parsed.references[0].surah).toBe(2);
+  });
+
   it('parses a clarify JSON object', function () {
     var parsed = _parseClassificationResponse('{"action":"clarify","message":"Which surah?"}');
     expect(parsed.action).toBe('clarify');
@@ -118,6 +129,43 @@ function runClaudeAPITests() {
 
   it('returns null for invalid JSON', function () {
     expect(_parseClassificationResponse('not json at all') === null).toBe(true);
+  });
+
+  // ── _parseRerankedAyahKeys_ (unit tests, no network) ───────────────────────
+
+  results.push('\n_parseRerankedAyahKeys_()');
+
+  it('parses a bare JSON array of ayah keys', function () {
+    var keys = _parseRerankedAyahKeys_('["30:21","4:19","2:231"]');
+    expect(keys.length).toBe(3);
+    expect(keys[0]).toBe('30:21');
+    expect(keys[1]).toBe('4:19');
+    expect(keys[2]).toBe('2:231');
+  });
+
+  it('parses JSON array wrapped in markdown fences', function () {
+    var keys = _parseRerankedAyahKeys_('```json\n["2:153","3:200"]\n```');
+    expect(keys.length).toBe(2);
+    expect(keys[0]).toBe('2:153');
+  });
+
+  it('extracts array from surrounding text', function () {
+    var keys = _parseRerankedAyahKeys_('Here: ["67:1","67:2"]');
+    expect(keys.length).toBe(2);
+  });
+
+  it('filters out invalid surah or ayah', function () {
+    var keys = _parseRerankedAyahKeys_('["2:153","0:1","200:1","2:255"]');
+    expect(keys.length).toBe(2);
+    expect(keys[0]).toBe('2:153');
+    expect(keys[1]).toBe('2:255');
+  });
+
+  it('returns null for empty or non-array', function () {
+    expect(_parseRerankedAyahKeys_(null) === null).toBe(true);
+    expect(_parseRerankedAyahKeys_('') === null).toBe(true);
+    expect(_parseRerankedAyahKeys_('{}') === null).toBe(true);
+    expect(_parseRerankedAyahKeys_('[]') === null).toBe(true);
   });
 
   // ── _trimConversationContext (unit tests) ─────────────────────────────────
@@ -264,6 +312,47 @@ function runClaudeAPITests() {
     expect(groups[1].surah).toBe(67);
     expect(groups[1].ayahStart).toBe(1);
     expect(groups[1].ayahEnd).toBe(3);
+  });
+
+  // ── _mergeConsecutiveReferencesInInputOrder_ (RAG score order) ─────────────
+
+  results.push('\n_mergeConsecutiveReferencesInInputOrder_()');
+
+  it('preserves input order across surahs without sorting', function () {
+    var refs = [{ surah: 3, ayah: 124 }, { surah: 2, ayah: 255 }, { surah: 3, ayah: 123 }];
+    var groups = _mergeConsecutiveReferencesInInputOrder_(refs);
+    expect(groups.length).toBe(3);
+    expect(groups[0].surah).toBe(3);
+    expect(groups[0].ayahStart).toBe(124);
+    expect(groups[0].ayahEnd).toBe(124);
+    expect(groups[1].surah).toBe(2);
+    expect(groups[1].ayahStart).toBe(255);
+    expect(groups[2].surah).toBe(3);
+    expect(groups[2].ayahStart).toBe(123);
+  });
+
+  it('merges adjacent consecutive same-surah ayahs in input order', function () {
+    var refs = [{ surah: 3, ayah: 190 }, { surah: 3, ayah: 191 }, { surah: 2, ayah: 255 }];
+    var groups = _mergeConsecutiveReferencesInInputOrder_(refs);
+    expect(groups.length).toBe(2);
+    expect(groups[0].surah).toBe(3);
+    expect(groups[0].ayahStart).toBe(190);
+    expect(groups[0].ayahEnd).toBe(191);
+    expect(groups[1].surah).toBe(2);
+    expect(groups[1].ayahStart).toBe(255);
+  });
+
+  it('keeps non-adjacent same-surah refs separate unlike sorted merge', function () {
+    var refs = [{ surah: 2, ayah: 255 }, { surah: 2, ayah: 153 }];
+    var groups = _mergeConsecutiveReferencesInInputOrder_(refs);
+    expect(groups.length).toBe(2);
+    expect(groups[0].ayahStart).toBe(255);
+    expect(groups[1].ayahStart).toBe(153);
+  });
+
+  it('returns empty for empty or null input order merge', function () {
+    expect(_mergeConsecutiveReferencesInInputOrder_([]).length).toBe(0);
+    expect(_mergeConsecutiveReferencesInInputOrder_(null).length).toBe(0);
   });
 
   // ── _handleSemanticSearch (unit — returns merged reference groups) ────────

--- a/tests/RagService.test.gs
+++ b/tests/RagService.test.gs
@@ -38,6 +38,11 @@ function runRagServiceTests() {
         if (typeof actual !== 'number' || actual <= n) {
           throw new Error('Expected > ' + n + ' but got ' + JSON.stringify(actual));
         }
+      },
+      arrayLength: function (n) {
+        if (!Array.isArray(actual) || actual.length !== n) {
+          throw new Error('Expected array length ' + n + ' but got ' + JSON.stringify(actual && actual.length));
+        }
       }
     };
   }
@@ -46,23 +51,173 @@ function runRagServiceTests() {
 
   results.push('\nRAG constants');
 
-  it('RAG_SCORE_THRESHOLD is 0.75', function () {
-    expect(RAG_SCORE_THRESHOLD).toBe(0.75);
+  it('RAG_SCORE_THRESHOLD is 0.35', function () {
+    expect(RAG_SCORE_THRESHOLD).toBe(0.35);
   });
 
-  it('RAG_TOP_K is 10', function () {
-    expect(RAG_TOP_K).toBe(10);
+  it('RAG_TOP_K is 20', function () {
+    expect(RAG_TOP_K).toBe(20);
   });
 
   it('OPENAI_EMBEDDING_MODEL is text-embedding-3-small', function () {
     expect(OPENAI_EMBEDDING_MODEL).toBe('text-embedding-3-small');
   });
 
+  it('RAG_MAX_EXPAND_QUERIES is 3', function () {
+    expect(RAG_MAX_EXPAND_QUERIES).toBe(3);
+  });
+
+  it('RAG_CANDIDATE_POOL is 20', function () {
+    expect(RAG_CANDIDATE_POOL).toBe(20);
+  });
+
+  it('RAG_FINAL_MAX_AYAH is 10', function () {
+    expect(RAG_FINAL_MAX_AYAH).toBe(10);
+  });
+
+  // ── _normalizeRagQueryStrings_ / _mergeRagMatchesByAyah_ (unit) ───────────
+
+  results.push('\n_normalizeRagQueryStrings_()');
+
+  it('collects trimmed queries from classified.queries capped at 3', function () {
+    var q = ['a', ' b ', '', 'c', 'd', 'e', 'f', 'g'];
+    var out = _normalizeRagQueryStrings_({ queries: q });
+    expect(out).arrayLength(3);
+    expect(out[0]).toBe('a');
+    expect(out[1]).toBe('b');
+    expect(out[2]).toBe('c');
+  });
+
+  it('falls back to legacy query when queries missing or empty', function () {
+    var out = _normalizeRagQueryStrings_({ query: '  legacy  ', references: [] });
+    expect(out).arrayLength(1);
+    expect(out[0]).toBe('legacy');
+  });
+
+  it('prefers queries over legacy query when both present', function () {
+    var out = _normalizeRagQueryStrings_({ queries: ['from array'], query: 'legacy' });
+    expect(out).arrayLength(1);
+    expect(out[0]).toBe('from array');
+  });
+
+  results.push('\n_mergeRagMatchesByAyah_()');
+
+  it('keeps higher score when same ayah appears from two query runs', function () {
+    var runs = [
+      {
+        queryIndex: 0,
+        queryText: 'a',
+        matches: [{ score: 0.5, metadata: { surah_number: 2, ayah_number: 255 } }]
+      },
+      {
+        queryIndex: 1,
+        queryText: 'b',
+        matches: [{ score: 0.91, metadata: { surah_number: 2, ayah_number: 255 } }]
+      }
+    ];
+    var merged = _mergeRagMatchesByAyah_(runs);
+    expect(merged).arrayLength(1);
+    expect(merged[0].score).toBe(0.91);
+    expect(merged[0].winningQueryIndex).toBe(1);
+    expect(merged[0].surah).toBe(2);
+    expect(merged[0].ayah).toBe(255);
+  });
+
+  it('sorts merged rows by score descending', function () {
+    var runs = [
+      {
+        queryIndex: 0,
+        queryText: 'q',
+        matches: [
+          { score: 0.4, metadata: { surah_number: 1, ayah_number: 1 } },
+          { score: 0.9, metadata: { surah_number: 2, ayah_number: 255 } }
+        ]
+      }
+    ];
+    var merged = _mergeRagMatchesByAyah_(runs);
+    expect(merged).arrayLength(2);
+    expect(merged[0].score).toBe(0.9);
+    expect(merged[1].score).toBe(0.4);
+  });
+
+  results.push('\n_finalizeRagAyahRefs_()');
+
+  it('uses Pinecone order only when rerankedKeys is null', function () {
+    var pool = [
+      { surah: 2, ayah: 255 },
+      { surah: 1, ayah: 1 },
+      { surah: 3, ayah: 200 }
+    ];
+    var out = _finalizeRagAyahRefs_(pool, null, 10);
+    expect(out).arrayLength(3);
+    expect(out[0].surah).toBe(2);
+    expect(out[0].ayah).toBe(255);
+    expect(out[1].surah).toBe(1);
+    expect(out[2].surah).toBe(3);
+  });
+
+  it('reorders by reranked keys then fills from Pinecone order', function () {
+    var pool = [
+      { surah: 1, ayah: 1 },
+      { surah: 2, ayah: 255 },
+      { surah: 3, ayah: 200 }
+    ];
+    var out = _finalizeRagAyahRefs_(pool, ['3:200', '1:1'], 10);
+    expect(out).arrayLength(3);
+    expect(out[0].surah).toBe(3);
+    expect(out[0].ayah).toBe(200);
+    expect(out[1].surah).toBe(1);
+    expect(out[2].surah).toBe(2);
+  });
+
+  it('caps at maxOut and ignores keys outside the pool', function () {
+    var pool = [
+      { surah: 2, ayah: 153 },
+      { surah: 2, ayah: 155 },
+      { surah: 3, ayah: 200 }
+    ];
+    var out = _finalizeRagAyahRefs_(pool, ['99:1', '2:155', '2:153', '2:155'], 2);
+    expect(out).arrayLength(2);
+    expect(out[0].surah).toBe(2);
+    expect(out[0].ayah).toBe(155);
+    expect(out[1].surah).toBe(2);
+    expect(out[1].ayah).toBe(153);
+  });
+
+  results.push('\n_rerankUserQueryFallback_()');
+
+  it('prefers first expansion string when present', function () {
+    var q = _rerankUserQueryFallback_({
+      queries: ['first expansion', 'second', 'third'],
+      query: 'legacy'
+    });
+    expect(q).toBe('first expansion');
+  });
+
+  it('uses legacy query when queries missing', function () {
+    var q = _rerankUserQueryFallback_({ query: '  legacy text  ' });
+    expect(q).toBe('legacy text');
+  });
+
+  results.push('\n_stripRagPrefixForRerankUserQuery_()');
+
+  it('strips leading @rag and trims', function () {
+    expect(_stripRagPrefixForRerankUserQuery_('@rag patience in hardship')).toBe('patience in hardship');
+  });
+
+  it('strips @rag with extra spaces after token', function () {
+    expect(_stripRagPrefixForRerankUserQuery_('@rag   mercy')).toBe('mercy');
+  });
+
+  it('leaves query unchanged when @rag is not a prefix', function () {
+    expect(_stripRagPrefixForRerankUserQuery_('search @rag topic')).toBe('search @rag topic');
+  });
+
   // ── _handleRagSearch fallback cases (unit, no network) ────────────────────
 
   results.push('\n_handleRagSearch() — fallback to _handleSemanticSearch');
 
-  it('falls back when query is missing', function () {
+  it('falls back when queries and legacy query are missing', function () {
     var classified = { references: [{ surah: 2, ayah: 153 }] };
     var result = _handleRagSearch(classified);
     expect(result.type).toBe('references');
@@ -71,14 +226,14 @@ function runRagServiceTests() {
     expect(result.references[0].ayahStart).toBe(153);
   });
 
-  it('falls back when query is empty string', function () {
-    var classified = { query: '', references: [{ surah: 1, ayah: 1 }] };
+  it('falls back when queries empty and legacy query empty', function () {
+    var classified = { queries: [], query: '', references: [{ surah: 1, ayah: 1 }] };
     var result = _handleRagSearch(classified);
     expect(result.type).toBe('references');
     expect(result.references[0].surah).toBe(1);
   });
 
-  it('falls back when query is whitespace only', function () {
+  it('falls back when queries missing and legacy query whitespace only', function () {
     var classified = { query: '   ', references: [{ surah: 1, ayah: 1 }] };
     var result = _handleRagSearch(classified);
     expect(result.type).toBe('references');
@@ -88,7 +243,7 @@ function runRagServiceTests() {
     // If no OpenAI key in Script Properties, should fall back
     var openAiKey = getOpenAiApiKey_();
     if (!openAiKey) {
-      var classified = { query: 'patience', references: [{ surah: 2, ayah: 153 }] };
+      var classified = { queries: ['patience'], references: [{ surah: 2, ayah: 153 }] };
       var result = _handleRagSearch(classified);
       expect(result.type).toBe('references');
       expect(result.references[0].surah).toBe(2);
@@ -142,6 +297,13 @@ function runRagServiceTests() {
       expect(typeof embedding[0]).toBe('number');
     });
 
+    it('_getEmbeddings returns one vector per input string', function () {
+      var vecs = _getEmbeddings(openAiKey, ['patience in hardship', 'mercy and forgiveness']);
+      expect(vecs).arrayLength(2);
+      expect(vecs[0].length).toBe(1536);
+      expect(vecs[1].length).toBe(1536);
+    });
+
     results.push('\n_queryPinecone() — integration');
 
     it('returns matches with expected metadata fields', function () {
@@ -158,9 +320,9 @@ function runRagServiceTests() {
 
     results.push('\n_handleRagSearch() — integration');
 
-    it('returns valid references for a known query', function () {
+    it('returns valid references for a known queries array', function () {
       var classified = {
-        query: 'patience in hardship',
+        queries: ['patience in hardship', 'steadfastness during trials', 'sabr and perseverance'],
         references: [{ surah: 2, ayah: 153 }]
       };
       var result = _handleRagSearch(classified);
@@ -172,7 +334,7 @@ function runRagServiceTests() {
 
     it('returns merged groups for RAG results', function () {
       var classified = {
-        query: 'mercy and forgiveness',
+        queries: ['mercy and forgiveness', 'Allah is forgiving', 'pardoning sins'],
         references: [{ surah: 1, ayah: 1 }]
       };
       var result = _handleRagSearch(classified);

--- a/tests/RagService.test.gs
+++ b/tests/RagService.test.gs
@@ -1,0 +1,200 @@
+/**
+ * GAS-native tests for RagService.js
+ *
+ * Run from Apps Script editor: select runRagServiceTests, click Run.
+ * View results in View → Logs.
+ *
+ * Unit tests run without network (mock UrlFetchApp).
+ * Integration tests require OpenAI + Pinecone keys in Script Properties.
+ */
+
+function runRagServiceTests() {
+  var passed = 0;
+  var failed = 0;
+  var results = [];
+
+  function it(label, fn) {
+    try {
+      fn();
+      results.push('  ✓ ' + label);
+      passed++;
+    } catch (e) {
+      results.push('  ✗ ' + label + '\n      → ' + (e.message || e));
+      failed++;
+    }
+  }
+
+  function expect(actual) {
+    return {
+      toBe: function (expected) {
+        if (actual !== expected) {
+          throw new Error('Expected ' + JSON.stringify(expected) + ' but got ' + JSON.stringify(actual));
+        }
+      },
+      toBeTruthy: function () {
+        if (!actual) throw new Error('Expected truthy but got ' + JSON.stringify(actual));
+      },
+      toBeGreaterThan: function (n) {
+        if (typeof actual !== 'number' || actual <= n) {
+          throw new Error('Expected > ' + n + ' but got ' + JSON.stringify(actual));
+        }
+      }
+    };
+  }
+
+  // ── Constants (unit) ──────────────────────────────────────────────────────
+
+  results.push('\nRAG constants');
+
+  it('RAG_SCORE_THRESHOLD is 0.75', function () {
+    expect(RAG_SCORE_THRESHOLD).toBe(0.75);
+  });
+
+  it('RAG_TOP_K is 10', function () {
+    expect(RAG_TOP_K).toBe(10);
+  });
+
+  it('OPENAI_EMBEDDING_MODEL is text-embedding-3-small', function () {
+    expect(OPENAI_EMBEDDING_MODEL).toBe('text-embedding-3-small');
+  });
+
+  // ── _handleRagSearch fallback cases (unit, no network) ────────────────────
+
+  results.push('\n_handleRagSearch() — fallback to _handleSemanticSearch');
+
+  it('falls back when query is missing', function () {
+    var classified = { references: [{ surah: 2, ayah: 153 }] };
+    var result = _handleRagSearch(classified);
+    expect(result.type).toBe('references');
+    // Should use Claude's references via _handleSemanticSearch
+    expect(result.references[0].surah).toBe(2);
+    expect(result.references[0].ayahStart).toBe(153);
+  });
+
+  it('falls back when query is empty string', function () {
+    var classified = { query: '', references: [{ surah: 1, ayah: 1 }] };
+    var result = _handleRagSearch(classified);
+    expect(result.type).toBe('references');
+    expect(result.references[0].surah).toBe(1);
+  });
+
+  it('falls back when query is whitespace only', function () {
+    var classified = { query: '   ', references: [{ surah: 1, ayah: 1 }] };
+    var result = _handleRagSearch(classified);
+    expect(result.type).toBe('references');
+  });
+
+  it('falls back when OpenAI API key is not set', function () {
+    // If no OpenAI key in Script Properties, should fall back
+    var openAiKey = getOpenAiApiKey_();
+    if (!openAiKey) {
+      var classified = { query: 'patience', references: [{ surah: 2, ayah: 153 }] };
+      var result = _handleRagSearch(classified);
+      expect(result.type).toBe('references');
+      expect(result.references[0].surah).toBe(2);
+    }
+  });
+
+  // ── Property key getters (unit) ───────────────────────────────────────────
+
+  results.push('\nProperty key getters');
+
+  it('PROPERTY_KEYS includes OPENAI_API_KEY', function () {
+    expect(PROPERTY_KEYS.OPENAI_API_KEY).toBe('openai_api_key');
+  });
+
+  it('PROPERTY_KEYS includes PINECONE_HOST', function () {
+    expect(PROPERTY_KEYS.PINECONE_HOST).toBe('pinecone_host');
+  });
+
+  it('PROPERTY_KEYS includes PINECONE_API_KEY', function () {
+    expect(PROPERTY_KEYS.PINECONE_API_KEY).toBe('pinecone_api_key');
+  });
+
+  it('getOpenAiApiKey_ returns string or null', function () {
+    var key = getOpenAiApiKey_();
+    expect(key === null || typeof key === 'string').toBe(true);
+  });
+
+  it('getPineconeHost_ returns string or null', function () {
+    var host = getPineconeHost_();
+    expect(host === null || typeof host === 'string').toBe(true);
+  });
+
+  it('getPineconeApiKey_ returns string or null', function () {
+    var key = getPineconeApiKey_();
+    expect(key === null || typeof key === 'string').toBe(true);
+  });
+
+  // ── Integration tests (require API keys in Script Properties) ─────────────
+
+  var openAiKey = getOpenAiApiKey_();
+  var pineconeHost = getPineconeHost_();
+  var pineconeKey = getPineconeApiKey_();
+
+  if (openAiKey && pineconeHost && pineconeKey) {
+    results.push('\n_getEmbedding() — integration');
+
+    it('returns a 1536-length array for a sample query', function () {
+      var embedding = _getEmbedding(openAiKey, 'patience in hardship');
+      expect(Array.isArray(embedding)).toBe(true);
+      expect(embedding.length).toBe(1536);
+      expect(typeof embedding[0]).toBe('number');
+    });
+
+    results.push('\n_queryPinecone() — integration');
+
+    it('returns matches with expected metadata fields', function () {
+      var embedding = _getEmbedding(openAiKey, 'patience in hardship');
+      var matches = _queryPinecone(pineconeHost, pineconeKey, embedding);
+      expect(Array.isArray(matches)).toBe(true);
+      expect(matches.length).toBeGreaterThan(0);
+      var first = matches[0];
+      expect(typeof first.score).toBe('number');
+      expect(first.metadata !== null && first.metadata !== undefined).toBe(true);
+      expect(typeof first.metadata.surah_number).toBe('number');
+      expect(typeof first.metadata.ayah_number).toBe('number');
+    });
+
+    results.push('\n_handleRagSearch() — integration');
+
+    it('returns valid references for a known query', function () {
+      var classified = {
+        query: 'patience in hardship',
+        references: [{ surah: 2, ayah: 153 }]
+      };
+      var result = _handleRagSearch(classified);
+      expect(result.type).toBe('references');
+      expect(result.references.length).toBeGreaterThan(0);
+      expect(result.references[0].surah).toBeGreaterThan(0);
+      expect(result.references[0].ayahStart).toBeGreaterThan(0);
+    });
+
+    it('returns merged groups for RAG results', function () {
+      var classified = {
+        query: 'mercy and forgiveness',
+        references: [{ surah: 1, ayah: 1 }]
+      };
+      var result = _handleRagSearch(classified);
+      expect(result.type).toBe('references');
+      // Each group should have surah, ayahStart, ayahEnd
+      var g = result.references[0];
+      expect(typeof g.surah).toBe('number');
+      expect(typeof g.ayahStart).toBe('number');
+      expect(typeof g.ayahEnd).toBe('number');
+    });
+  } else {
+    results.push('\n  ⊘ Skipped integration tests (missing OpenAI/Pinecone keys in Script Properties)');
+  }
+
+  // ── Summary ─────────────────────────────────────────────────────────────
+
+  results.push('\n─────────────────────────────────────────');
+  results.push('Results: ' + passed + ' passed, ' + failed + ' failed');
+
+  Logger.log(results.join('\n'));
+
+  if (failed > 0) {
+    throw new Error(failed + ' test(s) failed — see Logs for details');
+  }
+}


### PR DESCRIPTION
## Summary

- Add optional RAG path (OpenAI embeddings + Pinecone vector DB) for semantic search, activated by `@rag` query prefix
- Update Claude system prompt to include `query` field in `semantic_search` action responses
- New `RagService.js` module with OpenAI embedding + Pinecone query + reference mapping
- Silent fallback to Claude-generated references on any RAG failure (missing keys, API errors, no matches above threshold)
- Zero client-side changes — RAG returns same `{type: 'references', references: [...]}` shape

Closes #121

## Test plan

- [ ] Unit tests for RAG service (fallback, threshold filtering, metadata mapping)
- [ ] Unit tests for `@rag` prefix detection and stripping
- [ ] Integration tests with live OpenAI/Pinecone APIs (run in Apps Script editor)
- [ ] Manual: query without `@rag` works as before
- [ ] Manual: `@rag patience in hardship` returns Pinecone results
- [ ] Manual: `@rag` with non-semantic action (e.g., fetch_ayah) unaffected by flag
- [ ] Manual: `@rag` with missing API keys falls back silently to Claude refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)