### PR TITLE
Update support links to Buy Me a Coffee

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,7 +3,7 @@
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
-ko_fi:
+ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 liberapay: # Replace with a single Liberapay username

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,13 +3,13 @@
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
-ko_fi: tarazis
+ko_fi:
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
 polar: # Replace with a single Polar username
-buy_me_a_coffee: 
+buy_me_a_coffee: tarazis
 thanks_dev: # Replace with a single thanks.dev username
 custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Arabic ayah text in Google Docs is always **Amiri**, regular weight, not bold â€
 
 ### API keys
 
-All API keys (Claude, OpenAI, Pinecone) stored in **Script Properties** via `PropertiesService.getScriptProperties()`. Never exposed in source code.
+All API keys (Claude, OpenAI, Pinecone, optional Google Fonts Web API) stored in **Script Properties** via `PropertiesService.getScriptProperties()`. Never exposed in source code (`google_fonts_api_key` is injected into the sidebar HTML at render time only when set).
 
 ---
 

--- a/Code.js
+++ b/Code.js
@@ -13,11 +13,27 @@ function onOpen(e) {
  * Opens the Tasneef AI sidebar.
  */
 function showSidebar() {
-  var html = HtmlService.createTemplateFromFile('sidebar/sidebar')
-    .evaluate()
+  var fontsKey = getGoogleFontsApiKey_();
+  var materialBase =
+    'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0&icon_names=favorite';
+  var template = HtmlService.createTemplateFromFile('sidebar/sidebar');
+  template.googleFontsApiKeyJson = JSON.stringify(fontsKey ? String(fontsKey) : '');
+  template.materialSymbolsStylesheetHref = appendGoogleFontsApiKeyToUrl_(materialBase, fontsKey);
+  var html = template.evaluate()
     .setTitle('Tasneef AI')
     .setWidth(350);
   DocumentApp.getUi().showSidebar(html);
+}
+
+/**
+ * Appends Google Fonts API `key` query param when Script Property is set.
+ * @param {string} url
+ * @param {string|null} apiKey
+ * @return {string}
+ */
+function appendGoogleFontsApiKeyToUrl_(url, apiKey) {
+  if (!url || !apiKey || !String(apiKey).trim()) return url;
+  return url + '&key=' + encodeURIComponent(String(apiKey).trim());
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -148,5 +148,5 @@ Contributions are welcome. Please open an issue first to discuss what you'd like
 
 If you find Tasneef useful, consider supporting development:
 
-[![Ko-fi](https://img.shields.io/badge/Ko--fi-Buy%20me%20a%20coffee-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/tarazis)
+[Support on Buy Me a Coffee](https://buymeacoffee.com/tarazis)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Tasneef uses AI-powered semantic search to find verses by meaning, topic, or the
    - `claude_api_key` — Anthropic API key
    - `openai_api_key` — OpenAI API key
    - `pinecone_api_key` — Pinecone API key
+   - `google_fonts_api_key` — Google Fonts Web API key for sidebar CSS requests (optional)
    - `dev_emails` — comma-separated emails to exempt from daily quota (optional)
 
 6. Push and test:

--- a/README.md
+++ b/README.md
@@ -149,5 +149,5 @@ Contributions are welcome. Please open an issue first to discuss what you'd like
 
 If you find Tasneef useful, consider supporting development:
 
-[Support on Buy Me a Coffee](https://buymeacoffee.com/tarazis)
+Support on [Buy Me a Coffee](https://buymeacoffee.com/tarazis)
 

--- a/SettingsService.js
+++ b/SettingsService.js
@@ -23,7 +23,9 @@ var PROPERTY_KEYS = {
   DEV_EMAILS: 'dev_emails',
   OPENAI_API_KEY: 'openai_api_key',
   PINECONE_HOST: 'pinecone_host',
-  PINECONE_API_KEY: 'pinecone_api_key'
+  PINECONE_API_KEY: 'pinecone_api_key',
+  /** Optional; enables Google Fonts CSS API key on preview and icon stylesheet URLs. */
+  GOOGLE_FONTS_API_KEY: 'google_fonts_api_key'
 };
 
 /**
@@ -81,6 +83,19 @@ function saveSettings(settingsObj) {
 function getClaudeApiKey_() {
   return PropertiesService.getScriptProperties()
     .getProperty(PROPERTY_KEYS.CLAUDE_API_KEY) || null;
+}
+
+/**
+ * Google Fonts Web API key from Script Properties (optional).
+ * Used as the `key` query parameter on fonts.googleapis.com CSS requests.
+ * @return {string|null}
+ */
+function getGoogleFontsApiKey_() {
+  var v = PropertiesService.getScriptProperties()
+    .getProperty(PROPERTY_KEYS.GOOGLE_FONTS_API_KEY);
+  if (!v) return null;
+  v = String(v).trim();
+  return v ? v : null;
 }
 
 /**

--- a/sidebar/components/bottom-bar.html
+++ b/sidebar/components/bottom-bar.html
@@ -22,7 +22,7 @@
   </div>
 
   <div class="bottom-bar-center">
-    <a class="bottom-bar-cta bottom-bar-cta--support" href="https://ko-fi.com/tarazis" target="_blank" rel="noopener noreferrer" title="Support on Ko-fi">
+    <a class="bottom-bar-cta bottom-bar-cta--support" href="https://buymeacoffee.com/tarazis" target="_blank" rel="noopener noreferrer" title="Support on Buy Me a Coffee">
       <span class="material-symbols-outlined" aria-hidden="true">favorite</span>
       Support
     </a>

--- a/sidebar/js/font-variant-utils.html
+++ b/sidebar/js/font-variant-utils.html
@@ -18,6 +18,20 @@ function parseGoogleFontVariantClient(token) {
 }
 
 /**
+ * Appends Google Fonts CSS API `key` when set at sidebar render (Script Property).
+ * @param {string} url
+ * @return {string}
+ */
+function appendGoogleFontsApiKeyClient_(url) {
+  if (!url) return url;
+  var k = typeof window !== 'undefined' && window.__GOOGLE_FONTS_API_KEY__
+    ? String(window.__GOOGLE_FONTS_API_KEY__).trim()
+    : '';
+  if (!k) return url;
+  return url + '&key=' + encodeURIComponent(k);
+}
+
+/**
  * Builds Google Fonts CSS2 href for sidebar Arabic preview.
  * @param {string} family
  * @param {Array<string>} variantTokens
@@ -46,16 +60,16 @@ function buildGoogleFontsPreviewHref(family, variantTokens) {
     for (var j = 0; j < pairs.length; j++) {
       wOnly.push(pairs[j].split(',')[1]);
     }
-    return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':wght@' +
-      wOnly.join(';') + '&display=swap';
+    return appendGoogleFontsApiKeyClient_('https://fonts.googleapis.com/css2?family=' + famEnc + ':wght@' +
+      wOnly.join(';') + '&display=swap');
   }
   if (!hasRom) {
     var italOnly = pairs.map(function (pr) { return '1,' + pr.split(',')[1]; });
-    return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' +
-      italOnly.join(';') + '&display=swap';
+    return appendGoogleFontsApiKeyClient_('https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' +
+      italOnly.join(';') + '&display=swap');
   }
-  return 'https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' +
-    pairs.join(';') + '&display=swap';
+  return appendGoogleFontsApiKeyClient_('https://fonts.googleapis.com/css2?family=' + famEnc + ':ital,wght@' +
+    pairs.join(';') + '&display=swap');
 }
 
 /**

--- a/sidebar/sidebar.html
+++ b/sidebar/sidebar.html
@@ -3,7 +3,8 @@
 <head>
   <base target="_top">
   <meta charset="UTF-8">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0&icon_names=favorite" />
+  <script>window.__GOOGLE_FONTS_API_KEY__ = <?!= googleFontsApiKeyJson ?>;</script>
+  <link rel="stylesheet" href="<?!= materialSymbolsStylesheetHref ?>" />
   <?!= include_('sidebar/sidebar-css') ?>
 </head>
 <body>

--- a/tests/RagService.test.gs
+++ b/tests/RagService.test.gs
@@ -304,6 +304,10 @@ function runRagServiceTests() {
     expect(PROPERTY_KEYS.PINECONE_API_KEY).toBe('pinecone_api_key');
   });
 
+  it('PROPERTY_KEYS includes GOOGLE_FONTS_API_KEY', function () {
+    expect(PROPERTY_KEYS.GOOGLE_FONTS_API_KEY).toBe('google_fonts_api_key');
+  });
+
   it('getOpenAiApiKey_ returns string or null', function () {
     var key = getOpenAiApiKey_();
     expect(key === null || typeof key === 'string').toBe(true);

--- a/tests/SettingsService.test.gs
+++ b/tests/SettingsService.test.gs
@@ -51,6 +51,15 @@ function runSettingsServiceTests() {
     expect(key === null || typeof key === 'string').toBeTruthy();
   });
 
+  // ─── getGoogleFontsApiKey_ (reads from Script Properties) ─────────────────
+
+  results.push('\ngetGoogleFontsApiKey_()');
+
+  it('returns the Google Fonts key from Script Properties or null', function () {
+    var key = getGoogleFontsApiKey_();
+    expect(key === null || typeof key === 'string').toBeTruthy();
+  });
+
   // ─── getSettings / saveSetting_ defaults ──────────────────────────────────
 
   results.push('\ngetSettings() defaults');


### PR DESCRIPTION
Closes #138

## Summary
- switch bottom bar support CTA to Buy Me a Coffee URL
- update GitHub funding config to use buy_me_a_coffee and clear ko_fi
- replace README support link with Buy Me a Coffee URL

## Test plan
- [x] npm test
- [x] verify support links point to https://buymeacoffee.com/tarazis

Made with [Cursor](https://cursor.com)