### PR TITLE
Blockquote table: top cell padding for Amiri harakat

### DIFF
--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -343,8 +343,8 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
   }
 
   var cell = table.getRow(0).getCell(0);
-  cell.setPaddingLeft(21);
-  cell.setPaddingTop(18);
+  cell.setPaddingLeft(21); // to account for the 3px thick border
+  cell.setPaddingTop(21); // to account for Amiri's font harakat (vowels) at the top
   cell.setPaddingRight(18);
   cell.setPaddingBottom(18);
 


### PR DESCRIPTION
Closes #141.

Increases blockquote table cell top padding (18 → 21) so Amiri harakat are not clipped, and documents left padding relative to the thick border.