### PR TITLE
Use drive.file and documents.currentonly for Docs API blockquote

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -1,4 +1,8 @@
 /**
+ * @OnlyCurrentDoc
+ */
+
+/**
  * Adds the Tasneef AI menu to the Google Docs UI when the document opens.
  * @param {Object} e - The onOpen event object.
  */

--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -226,8 +226,9 @@ function resolveTableStartIndexForDocsApi_(docId, tableOrdinal) {
 
 /**
  * Per-side cell borders (left accent only) via Docs API; DocumentApp cannot set per side.
- * Advanced Docs (get/batchUpdate) needs https://www.googleapis.com/auth/documents in appsscript.json;
- * drive.file can yield 404 on documents.get for the active editor doc.
+ * Advanced Docs get/batchUpdate use https://www.googleapis.com/auth/drive.file (per-file); inserts use
+ * https://www.googleapis.com/auth/documents.currentonly via @OnlyCurrentDoc. If Documents.get fails
+ * (e.g. 404), the host file may not be authorized for this app under drive.file yet.
  * Call only after the document has been flushed (auto-flush on function return, or saveAndClose).
  * @param {string} docId
  * @param {number} tableOrdinal - 1-based ordinal position of the target table among all body tables

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -12,7 +12,8 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
-    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/documents.currentonly",
+    "https://www.googleapis.com/auth/drive.file",
     "https://www.googleapis.com/auth/script.container.ui",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/userinfo.email"


### PR DESCRIPTION
Closes #146

Replace sensitive `https://www.googleapis.com/auth/documents` with `https://www.googleapis.com/auth/drive.file` for Advanced Docs API (`Documents.get` / `batchUpdate` for blockquote cell borders).

Add `https://www.googleapis.com/auth/documents.currentonly` and `@OnlyCurrentDoc` in `Code.js` so DocumentApp insertion stays limited to the active document (Advanced Services do not use `currentonly`).

After deploy, users must re-authorize. Smoke-test blockquote insert and border styling in a live Doc.

Made with [Cursor](https://cursor.com)