### PR TITLE
Lite: 2×1 blockquote + documents.currentonly scope

### DIFF
--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -8,10 +8,12 @@ var INSERT_SPACING_INNER_PT = 6;
 /** Paragraph spacing (points) for outer gap around non-quote inserts. */
 var TARGET_SPACING_PT = 8;
 
-/** Blockquote table: left accent (pt); accent color (fixed, not tied to body text color). */
-var BLOCKQUOTE_BORDER_LEFT_PT = 3;
+/** Blockquote 2×1 table: accent column width (pt); accent fill; content cell background. */
+var BLOCKQUOTE_ACCENT_COL_PT = 3;
 var BLOCKQUOTE_BORDER_LEFT_COLOR = '#3A8F7A';
 var BLOCKQUOTE_CELL_BACKGROUND = '#F7F7F7';
+/** Uniform padding (pt) on the verse content cell (replaces old 21pt left + border). */
+var BLOCKQUOTE_CONTENT_CELL_PADDING_PT = 18;
 
 /**
  * Walks an element up to its nearest body-level ancestor (direct child of body).
@@ -159,170 +161,21 @@ function applyBeautifiedInsertToParagraph_(p, item, formatState) {
 }
 
 /**
- * @param {string|null|undefined} hex
- * @return {{ red: number, green: number, blue: number }} RGB in 0–1 for Docs API
- */
-function hexToDocsRgb01_(hex) {
-  var h = normalizeHex6ForSettings_(hex);
-  if (!h) {
-    h = '#000000';
-  }
-  var r = parseInt(h.slice(1, 3), 16) / 255;
-  var g = parseInt(h.slice(3, 5), 16) / 255;
-  var b = parseInt(h.slice(5, 7), 16) / 255;
-  function q(x) {
-    return Math.round(x * 1e6) / 1e6;
-  }
-  return { red: q(r), green: q(g), blue: q(b) };
-}
-
-/**
- * @param {number} pt
- * @param {{ red: number, green: number, blue: number }} rgb01
- * @return {Object} Docs API TableCellBorder (OptionalColor nested per docs OptionalColor schema)
- */
-function docsTableBorderPt_(pt, rgb01) {
-  return {
-    dashStyle: 'SOLID',
-    width: { magnitude: pt, unit: 'PT' },
-    color: { color: { rgbColor: rgb01 } }
-  };
-}
-
-/**
- * Resolves structural startIndex of a table for Docs API batchUpdate using
- * ordinal position (Nth table in the document) rather than array-index heuristics.
- * Returns null when the expected table is not yet visible (triggers caller retry).
- * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal: "this is the Nth table in the body"
- * @return {number|null}
- */
-function resolveTableStartIndexForDocsApi_(docId, tableOrdinal) {
-  if (typeof Docs === 'undefined' || !Docs.Documents || !Docs.Documents.get) {
-    return null;
-  }
-  var docJson;
-  try {
-    docJson = Docs.Documents.get(docId);
-  } catch (e) {
-    Logger.log('resolveTableStartIndexForDocsApi_: Documents.get failed: ' + e);
-    return null;
-  }
-  var content = docJson.body && docJson.body.content;
-  if (!content || tableOrdinal < 1) {
-    return null;
-  }
-  var tablesFound = 0;
-  for (var i = 0; i < content.length; i++) {
-    if (content[i].table != null && content[i].startIndex != null) {
-      tablesFound++;
-      if (tablesFound === tableOrdinal) {
-        return content[i].startIndex;
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Per-side cell borders (left accent only) via Docs API; DocumentApp cannot set per side.
- * Advanced Docs (get/batchUpdate) needs https://www.googleapis.com/auth/documents in appsscript.json;
- * drive.file can yield 404 on documents.get for the active editor doc.
- * Call only after the document has been flushed (auto-flush on function return, or saveAndClose).
- * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal position of the target table among all body tables
- */
-function applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal) {
-  if (typeof Docs === 'undefined' || !Docs.Documents || !Docs.Documents.batchUpdate) {
-    return {
-      success: false,
-      message: 'Docs API unavailable for blockquote styling.'
-    };
-  }
-  var tableStart = null;
-  var maxAttempts = 10;
-  var attempt;
-  for (attempt = 0; attempt < maxAttempts; attempt++) {
-    tableStart = resolveTableStartIndexForDocsApi_(docId, tableOrdinal);
-    if (tableStart != null) {
-      break;
-    }
-    Utilities.sleep(200);
-  }
-  if (tableStart == null) {
-    Logger.log('blockquote borders: could not resolve table start index');
-    return {
-      success: false,
-      message: 'Ayah inserted but styling could not be applied after retries.',
-      attempts: maxAttempts
-    };
-  }
-
-  var rgb = hexToDocsRgb01_(BLOCKQUOTE_BORDER_LEFT_COLOR);
-  var black01 = { red: 0, green: 0, blue: 0 };
-  var zero = docsTableBorderPt_(0, black01);
-  var leftRgb = docsTableBorderPt_(BLOCKQUOTE_BORDER_LEFT_PT, rgb);
-
-  var tableRange = {
-    tableCellLocation: {
-      tableStartLocation: { index: tableStart },
-      rowIndex: 0,
-      columnIndex: 0
-    },
-    rowSpan: 1,
-    columnSpan: 1
-  };
-
-  var bgRgb = hexToDocsRgb01_(BLOCKQUOTE_CELL_BACKGROUND);
-
-  var requests = [
-    {
-      updateTableCellStyle: {
-        tableRange: tableRange,
-        tableCellStyle: {
-          borderTop: zero,
-          borderRight: zero,
-          borderBottom: zero,
-          borderLeft: leftRgb,
-          backgroundColor: { color: { rgbColor: bgRgb } }
-        },
-        fields: 'borderTop,borderRight,borderBottom,borderLeft,backgroundColor'
-      }
-    }
-  ];
-
-  try {
-    Docs.Documents.batchUpdate({ requests: requests }, docId);
-    return { success: true };
-  } catch (e) {
-    Logger.log('blockquote borders batchUpdate: ' + e);
-    return {
-      success: false,
-      message: 'Ayah inserted but styling could not be applied.',
-      error: String(e)
-    };
-  }
-}
-
-/**
- * Inserts a 1×1 table at the anchor, places beautified paragraphs in the cell, styles the shell.
- * Border styling is NOT applied here — the caller receives pendingBorders and must invoke
- * applyBlockquoteBorders() in a separate server call so that the auto-flush between calls
- * makes the table visible to the Docs REST API without needing saveAndClose().
+ * Inserts a 2×1 table at the anchor: narrow green accent column + grey content cell.
+ * Styled entirely with DocumentApp (no Docs REST API; works with documents.currentonly).
  * @param {Body} body
  * @param {Document} doc
  * @param {Array<Object>} paragraphsToInsert
  * @param {Object} formatState
- * @return {Object} { fontWarning: string|null, pendingBorders: {docId: string, tableOrdinal: number}|null }
+ * @return {Object} { fontWarning: string|null }
  */
 function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState) {
   var anchor = resolveNativeInsertAnchor_(body, doc);
   var insertIndex = anchor.baseIndex;
   var removeTarget = anchor.removeTarget;
 
-  var table = body.insertTable(insertIndex, [['']]);
+  var table = body.insertTable(insertIndex, [['', '']]);
 
-  // Hide default table chrome immediately to minimize unstyled flash.
   try {
     if (typeof table.setBorderWidth === 'function') {
       table.setBorderWidth(0);
@@ -342,21 +195,38 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
     }
   }
 
-  var cell = table.getRow(0).getCell(0);
-  cell.setPaddingLeft(21); // to account for the 3px thick border
-  cell.setPaddingTop(18);
-  cell.setPaddingRight(18);
-  cell.setPaddingBottom(18);
+  var row = table.getRow(0);
+  var accentCell = row.getCell(0);
+  var contentCell = row.getCell(1);
+
+  accentCell.setBackgroundColor(BLOCKQUOTE_BORDER_LEFT_COLOR);
+  if (typeof accentCell.setWidth === 'function') {
+    accentCell.setWidth(BLOCKQUOTE_ACCENT_COL_PT);
+  }
+  accentCell.setPaddingLeft(0);
+  accentCell.setPaddingTop(0);
+  accentCell.setPaddingRight(0);
+  accentCell.setPaddingBottom(0);
+  try {
+    accentCell.getChild(0).asParagraph().setText('\u200B');
+  } catch (ignore) {
+  }
+
+  contentCell.setBackgroundColor(BLOCKQUOTE_CELL_BACKGROUND);
+  contentCell.setPaddingLeft(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
+  contentCell.setPaddingTop(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
+  contentCell.setPaddingRight(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
+  contentCell.setPaddingBottom(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
 
   var fontWarning = null;
   for (var i = 0; i < paragraphsToInsert.length; i++) {
     var item = paragraphsToInsert[i];
     var p;
     if (i === 0) {
-      p = cell.getChild(0).asParagraph();
+      p = contentCell.getChild(0).asParagraph();
       p.setText(item.text);
     } else {
-      p = cell.insertParagraph(i, item.text);
+      p = contentCell.insertParagraph(i, item.text);
     }
     fontWarning = applyBeautifiedInsertToParagraph_(p, item, formatState) || fontWarning;
   }
@@ -375,26 +245,15 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
     if (cursorParagraph) {
       doc.setCursor(doc.newPosition(cursorParagraph, 0));
     } else {
-      // No following paragraph exists: keep cursor in the inserted block.
-      doc.setCursor(doc.newPosition(cell.getChild(cell.getNumChildren() - 1).asParagraph(), 0));
+      doc.setCursor(
+        doc.newPosition(contentCell.getChild(contentCell.getNumChildren() - 1).asParagraph(), 0)
+      );
     }
   } catch (e) {
     // setCursor is unavailable in non-UI contexts (e.g. triggers); fail silently
   }
 
-  var docId = doc.getId();
-  var bodyChildIndex = body.getChildIndex(table);
-  var tableOrdinal = 0;
-  for (var ci = 0; ci <= bodyChildIndex; ci++) {
-    if (body.getChild(ci).getType() === DocumentApp.ElementType.TABLE) {
-      tableOrdinal++;
-    }
-  }
-
-  return {
-    fontWarning: fontWarning,
-    pendingBorders: { docId: docId, tableOrdinal: tableOrdinal }
-  };
+  return { fontWarning: fontWarning };
 }
 
 /**
@@ -463,17 +322,6 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
 }
 
 /**
- * Public entry point for the client to apply blockquote cell borders via a second RPC.
- * Called after insertAyah/insertAyahRange returns pendingBorders; the auto-flush between
- * the two server calls ensures the Docs REST API can see the newly inserted table.
- * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal position of the target table
- */
-function applyBlockquoteBorders(docId, tableOrdinal) {
-  return applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal);
-}
-
-/**
  * Inserts an ayah into the document using resolveNativeInsertAnchor_
  * (block-boundary cursor insertion, selection-end insertion, doc-end fallback).
  * @param {Object} ayahData - { surah, ayah, surahNameArabic, surahNameEnglish, textUthmani, textSimple, translationText }
@@ -534,11 +382,7 @@ function insertAyah(ayahData, formatState, settings) {
     ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
     : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
   var message = result.fontWarning ? 'Ayah inserted. ' + result.fontWarning : 'Ayah inserted.';
-  var out = { success: true, message: message };
-  if (result.pendingBorders) {
-    out.pendingBorders = result.pendingBorders;
-  }
-  return out;
+  return { success: true, message: message };
 }
 
 /**
@@ -596,9 +440,8 @@ function insertAyahRange(rangeData, formatState, settings) {
   var result = useBlockquote
     ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
     : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
-  var out = { success: true, message: result.fontWarning ? 'Range inserted. ' + result.fontWarning : 'Range inserted.' };
-  if (result.pendingBorders) {
-    out.pendingBorders = result.pendingBorders;
-  }
-  return out;
+  return {
+    success: true,
+    message: result.fontWarning ? 'Range inserted. ' + result.fontWarning : 'Range inserted.'
+  };
 }

--- a/src/SettingsService.js
+++ b/src/SettingsService.js
@@ -9,7 +9,7 @@ var AI_SEARCH_DAILY_LIMIT = 10;
 
 var SETTINGS_DEFAULTS = {
   showTranslation: true,
-  /** When true, ayah/range inserts are wrapped in a styled 1×1 table (blockquote look). */
+  /** When true, ayah/range inserts use a styled 2×1 table (green accent column + grey content). */
   blockquoteInsertion: true,
   insertArabic: true,
   arabicStyle: 'uthmani'     // "uthmani" | "simple"

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -1,18 +1,9 @@
 {
   "timeZone": "America/New_York",
-  "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Docs",
-        "version": "v1",
-        "serviceId": "docs"
-      }
-    ]
-  },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
-    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/documents.currentonly",
     "https://www.googleapis.com/auth/script.container.ui",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/userinfo.email"

--- a/src/sidebar/js/render-helpers.html
+++ b/src/sidebar/js/render-helpers.html
@@ -3,11 +3,6 @@
 //   buildCardHtml, buildRangeData (card-builder.html),
 //   _buildAyahDataForInsert (search-utils.html)
 
-/**
- * Fire-and-forget: applies blockquote cell borders via a deferred second RPC.
- * The auto-flush between the insert call and this call ensures the Docs REST API
- * can see the newly inserted table without needing saveAndClose().
- */
 function showTransientToast(message) {
   if (!message) return;
   var host = document.getElementById('sidebar-toast-host');
@@ -33,6 +28,7 @@ function showTransientToast(message) {
   }, 3800);
 }
 
+/** No-op unless the server returns legacy pendingBorders (older deployments). */
 function _applyPendingBorders(result, done) {
   if (!result || !result.pendingBorders) {
     if (done) done();

--- a/src/tests/DocumentService.test.gs
+++ b/src/tests/DocumentService.test.gs
@@ -1,6 +1,6 @@
 /**
  * GAS-native tests for DocumentService.gs — resolveNativeInsertAnchor_(),
- * insertParagraphsAtPosition_(), insertBlockquoteTableAtPosition_(), and helpers.
+ * insertParagraphsAtPosition_(), insertBlockquoteTableAtPosition_() (2×1 blockquote), and helpers.
  * Run from Apps Script editor: select runDocumentServiceTests, click Run.
  */
 
@@ -101,11 +101,13 @@ function runDocumentServiceTests() {
     return {
       _inner: innerParas,
       _bg: null,
+      _width: null,
       _padL: null,
       _padT: null,
       _padR: null,
       _padB: null,
       setBackgroundColor: function (c) { this._bg = c; },
+      setWidth: function (w) { this._width = w; },
       setPaddingLeft: function (x) { this._padL = x; },
       setPaddingTop: function (x) { this._padT = x; },
       setPaddingRight: function (x) { this._padR = x; },
@@ -121,14 +123,17 @@ function runDocumentServiceTests() {
   }
 
   function createMockTable() {
-    var cell = createMockTableCell();
+    var accentCell = createMockTableCell();
+    var contentCell = createMockTableCell();
     return {
-      _cell: cell,
+      _accentCell: accentCell,
+      _contentCell: contentCell,
+      _cell: contentCell,
       getType: function () { return DocumentApp.ElementType.TABLE; },
       getRow: function () {
         return {
-          getCell: function () {
-            return cell;
+          getCell: function (idx) {
+            return idx === 0 ? accentCell : contentCell;
           }
         };
       }
@@ -637,12 +642,19 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(1);
     expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
 
-    var cell = body._children[0]._cell;
-    expect(cell._bg).toBe(null);
-    expect(cell._padL).toBe(21);
-    expect(cell._padT).toBe(18);
-    expect(cell._padR).toBe(18);
-    expect(cell._padB).toBe(18);
+    var accent = body._children[0]._accentCell;
+    var cell = body._children[0]._contentCell;
+    expect(accent._bg).toBe(BLOCKQUOTE_BORDER_LEFT_COLOR);
+    expect(accent._width).toBe(BLOCKQUOTE_ACCENT_COL_PT);
+    expect(accent._padL).toBe(0);
+    expect(accent._padT).toBe(0);
+    expect(accent._padR).toBe(0);
+    expect(accent._padB).toBe(0);
+    expect(cell._bg).toBe(BLOCKQUOTE_CELL_BACKGROUND);
+    expect(cell._padL).toBe(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
+    expect(cell._padT).toBe(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
+    expect(cell._padR).toBe(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
+    expect(cell._padB).toBe(BLOCKQUOTE_CONTENT_CELL_PADDING_PT);
     expect(cell._inner.length).toBe(1);
     expect(cell._inner[0]._spacingBefore).toBe(null);
     expect(cell._inner[0]._spacingAfter).toBe(null);
@@ -654,7 +666,7 @@ function runDocumentServiceTests() {
     insertBlockquoteTableAtPosition_(body, doc, arabicAndTranslation(), {});
 
     expect(body._children.length).toBe(1);
-    var cell = body._children[0]._cell;
+    var cell = body._children[0]._contentCell;
     expect(cell._inner.length).toBe(3);
     expect(cell._inner[0]._spacingBefore).toBe(null);
     expect(cell._inner[0]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
@@ -711,222 +723,12 @@ function runDocumentServiceTests() {
     body.removeChild = origRemoveChild;
   });
 
-  it('hexToDocsRgb01_ parses normalized hex for Docs border color', function () {
-    var rgb = hexToDocsRgb01_('#3A8F7A');
-    expect(rgb.red > 0.2 && rgb.red < 0.25).toBe(true);
-    expect(rgb.green > 0.55 && rgb.green < 0.58).toBe(true);
-    expect(rgb.blue > 0.46 && rgb.blue < 0.49).toBe(true);
-  });
-
-  // ── resolveTableStartIndexForDocsApi_ ──────────────────────
-
-  results.push('\nresolveTableStartIndexForDocsApi_()');
-
-  var originalDocs = typeof Docs !== 'undefined' ? Docs : undefined;
-
-  function stubDocsGet(contentArray) {
-    Docs = {
-      Documents: {
-        get: function () {
-          return { body: { content: contentArray } };
-        },
-        batchUpdate: function () {}
-      }
-    };
-  }
-
-  function restoreDocs() {
-    if (originalDocs !== undefined) {
-      Docs = originalDocs;
-    }
-  }
-
-  function makeTableContent(startIndex) {
-    return [
-      { sectionBreak: {} },
-      { paragraph: {}, startIndex: 0 },
-      { table: {}, startIndex: startIndex }
-    ];
-  }
-
-  it('ordinal 1 returns startIndex of the only table', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { paragraph: {}, startIndex: 0 },
-      { table: {}, startIndex: 42 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 1);
-    expect(result).toBe(42);
-    restoreDocs();
-  });
-
-  it('ordinal 3 returns startIndex of the third table (skips paragraphs)', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { paragraph: {}, startIndex: 0 },
-      { table: {}, startIndex: 10 },
-      { paragraph: {}, startIndex: 20 },
-      { table: {}, startIndex: 30 },
-      { paragraph: {}, startIndex: 50 },
-      { table: {}, startIndex: 70 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 3);
-    expect(result).toBe(70);
-    restoreDocs();
-  });
-
-  it('ordinal 2 with only 1 table returns null (propagation delay)', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { table: {}, startIndex: 10 },
-      { paragraph: {}, startIndex: 30 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 2);
-    expect(result).toBe(null);
-    restoreDocs();
-  });
-
-  it('ordinal 0 returns null (invalid)', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { table: {}, startIndex: 10 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 0);
-    expect(result).toBe(null);
-    restoreDocs();
-  });
-
-  it('empty content array returns null', function () {
-    stubDocsGet([]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 1);
-    expect(result).toBe(null);
-    restoreDocs();
-  });
-
-  // ── applyBlockquoteCellBordersViaDocsApi_ ───────────────────
-
-  results.push('\napplyBlockquoteCellBordersViaDocsApi_()');
-
-  it('retries up to 10 times with 200ms sleeps when table is not visible yet', function () {
-    var gets = 0;
-    var sleeps = 0;
-    var origUtilities = Utilities;
-    var origDocsLocal = Docs;
-    Utilities = { sleep: function (ms) { if (ms === 200) sleeps++; } };
-    Docs = {
-      Documents: {
-        get: function () {
-          gets++;
-          return { body: { content: [] } };
-        },
-        batchUpdate: function () {}
-      }
-    };
-    var result = applyBlockquoteCellBordersViaDocsApi_('fake-id', 1);
-    expect(gets).toBe(10);
-    expect(sleeps).toBe(10);
-    expect(result.success).toBe(false);
-    expect(result.attempts).toBe(10);
-    Utilities = origUtilities;
-    Docs = origDocsLocal;
-  });
-
-  it('returns success true when Docs batchUpdate succeeds', function () {
-    var batchCalls = 0;
-    var origUtilities = Utilities;
-    var origDocsLocal = Docs;
-    Utilities = { sleep: function () {} };
-    Docs = {
-      Documents: {
-        get: function () {
-          return { body: { content: makeTableContent(42) } };
-        },
-        batchUpdate: function () {
-          batchCalls++;
-        }
-      }
-    };
-    var result = applyBlockquoteCellBordersViaDocsApi_('fake-id', 1);
-    expect(batchCalls).toBe(1);
-    expect(result.success).toBe(true);
-    Utilities = origUtilities;
-    Docs = origDocsLocal;
-  });
-
-  it('returns failure object when Docs batchUpdate throws', function () {
-    var origUtilities = Utilities;
-    var origDocsLocal = Docs;
-    Utilities = { sleep: function () {} };
-    Docs = {
-      Documents: {
-        get: function () {
-          return { body: { content: makeTableContent(42) } };
-        },
-        batchUpdate: function () {
-          throw new Error('batch failed');
-        }
-      }
-    };
-    var result = applyBlockquoteCellBordersViaDocsApi_('fake-id', 1);
-    expect(result.success).toBe(false);
-    expect(typeof result.message).toBe('string');
-    Utilities = origUtilities;
-    Docs = origDocsLocal;
-  });
-
-  it('applyBlockquoteBorders returns underlying success result', function () {
-    var origFn = applyBlockquoteCellBordersViaDocsApi_;
-    applyBlockquoteCellBordersViaDocsApi_ = function () {
-      return { success: true, message: 'ok' };
-    };
-    var result = applyBlockquoteBorders('d', 1);
-    expect(result.success).toBe(true);
-    applyBlockquoteCellBordersViaDocsApi_ = origFn;
-  });
-
-  // ── tableOrdinal computation in insertBlockquoteTableAtPosition_ ──
-
-  results.push('\ninsertBlockquoteTableAtPosition_() — ordinal targeting (pendingBorders)');
-
-  it('single table in empty doc returns pendingBorders with tableOrdinal 1', function () {
+  it('insertBlockquoteTableAtPosition_ returns only fontWarning (no pendingBorders)', function () {
     var body = createMockBody(['']);
     var doc = createMockDoc(body, body._children[0]);
     var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(result.pendingBorders.docId).toBe('mock-doc-id');
-    expect(result.pendingBorders.tableOrdinal).toBe(1);
-  });
-
-  it('new table after one pre-existing table returns tableOrdinal 2', function () {
-    var body = createMockBody(['text before', 'cursor here']);
-    var existingTable = createMockTable();
-    body._children.splice(1, 0, existingTable);
-    var cursorPara = body._children[2];
-    var doc = createMockDoc(body, cursorPara);
-    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(result.pendingBorders.tableOrdinal).toBe(2);
-  });
-
-  it('new table between two pre-existing tables returns tableOrdinal 2', function () {
-    var body = createMockBody(['before', 'middle', 'after']);
-    var table1 = createMockTable();
-    body._children.splice(1, 0, table1);
-    var table2 = createMockTable();
-    body._children.splice(3, 0, table2);
-    var cursorPara = body._children[2];
-    var doc = createMockDoc(body, cursorPara);
-    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(result.pendingBorders.tableOrdinal).toBe(2);
-  });
-
-  it('blockquote does NOT call applyBlockquoteCellBordersViaDocsApi_ inline', function () {
-    var called = false;
-    var origBorders = applyBlockquoteCellBordersViaDocsApi_;
-    applyBlockquoteCellBordersViaDocsApi_ = function () { called = true; };
-    var body = createMockBody(['']);
-    var doc = createMockDoc(body, body._children[0]);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(called).toBe(false);
-    applyBlockquoteCellBordersViaDocsApi_ = origBorders;
+    expect(result.fontWarning).toBe(null);
+    expect(result.pendingBorders).toBe(undefined);
   });
 
   // ── resolveNativeInsertAnchor_ — selection end + cursor split ──


### PR DESCRIPTION
Replaces the 1×1 table plus Google Docs REST API border styling with a 2×1 DocumentApp-only blockquote: a 3pt-wide green accent column and a grey content cell, with `0pt` table borders. Drops the Advanced Docs service and switches OAuth from full `documents` to `documents.currentonly` for a narrower marketplace permission.

Removes the deferred `pendingBorders` / `applyBlockquoteBorders` second RPC; the client path remains a no-op when `pendingBorders` is absent.

Closes #148.