### PR TITLE
Blockquote: DocumentApp 2×1 table + documents.currentonly

### DIFF
--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -8,10 +8,11 @@ var INSERT_SPACING_INNER_PT = 6;
 /** Paragraph spacing (points) for outer gap around non-quote inserts. */
 var TARGET_SPACING_PT = 8;
 
-/** Blockquote table: left accent (pt); accent color (fixed, not tied to body text color). */
-var BLOCKQUOTE_BORDER_LEFT_PT = 3;
-var BLOCKQUOTE_BORDER_LEFT_COLOR = '#3A8F7A';
-var BLOCKQUOTE_CELL_BACKGROUND = '#F7F7F7';
+/** Blockquote 2×1 table (DocumentApp; matches app primary and documents.currentonly). */
+var BLOCKQUOTE_ACCENT_WIDTH_PT = 3;
+var BLOCKQUOTE_ACCENT_COLOR = '#0d6e4f';
+var BLOCKQUOTE_CONTENT_BACKGROUND = '#F7F5F0';
+var BLOCKQUOTE_CONTENT_PADDING_PT = 18;
 
 /**
  * Walks an element up to its nearest body-level ancestor (direct child of body).
@@ -159,170 +160,21 @@ function applyBeautifiedInsertToParagraph_(p, item, formatState) {
 }
 
 /**
- * @param {string|null|undefined} hex
- * @return {{ red: number, green: number, blue: number }} RGB in 0–1 for Docs API
- */
-function hexToDocsRgb01_(hex) {
-  var h = normalizeHex6ForSettings_(hex);
-  if (!h) {
-    h = '#000000';
-  }
-  var r = parseInt(h.slice(1, 3), 16) / 255;
-  var g = parseInt(h.slice(3, 5), 16) / 255;
-  var b = parseInt(h.slice(5, 7), 16) / 255;
-  function q(x) {
-    return Math.round(x * 1e6) / 1e6;
-  }
-  return { red: q(r), green: q(g), blue: q(b) };
-}
-
-/**
- * @param {number} pt
- * @param {{ red: number, green: number, blue: number }} rgb01
- * @return {Object} Docs API TableCellBorder (OptionalColor nested per docs OptionalColor schema)
- */
-function docsTableBorderPt_(pt, rgb01) {
-  return {
-    dashStyle: 'SOLID',
-    width: { magnitude: pt, unit: 'PT' },
-    color: { color: { rgbColor: rgb01 } }
-  };
-}
-
-/**
- * Resolves structural startIndex of a table for Docs API batchUpdate using
- * ordinal position (Nth table in the document) rather than array-index heuristics.
- * Returns null when the expected table is not yet visible (triggers caller retry).
- * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal: "this is the Nth table in the body"
- * @return {number|null}
- */
-function resolveTableStartIndexForDocsApi_(docId, tableOrdinal) {
-  if (typeof Docs === 'undefined' || !Docs.Documents || !Docs.Documents.get) {
-    return null;
-  }
-  var docJson;
-  try {
-    docJson = Docs.Documents.get(docId);
-  } catch (e) {
-    Logger.log('resolveTableStartIndexForDocsApi_: Documents.get failed: ' + e);
-    return null;
-  }
-  var content = docJson.body && docJson.body.content;
-  if (!content || tableOrdinal < 1) {
-    return null;
-  }
-  var tablesFound = 0;
-  for (var i = 0; i < content.length; i++) {
-    if (content[i].table != null && content[i].startIndex != null) {
-      tablesFound++;
-      if (tablesFound === tableOrdinal) {
-        return content[i].startIndex;
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Per-side cell borders (left accent only) via Docs API; DocumentApp cannot set per side.
- * Advanced Docs (get/batchUpdate) needs https://www.googleapis.com/auth/documents in appsscript.json;
- * drive.file can yield 404 on documents.get for the active editor doc.
- * Call only after the document has been flushed (auto-flush on function return, or saveAndClose).
- * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal position of the target table among all body tables
- */
-function applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal) {
-  if (typeof Docs === 'undefined' || !Docs.Documents || !Docs.Documents.batchUpdate) {
-    return {
-      success: false,
-      message: 'Docs API unavailable for blockquote styling.'
-    };
-  }
-  var tableStart = null;
-  var maxAttempts = 10;
-  var attempt;
-  for (attempt = 0; attempt < maxAttempts; attempt++) {
-    tableStart = resolveTableStartIndexForDocsApi_(docId, tableOrdinal);
-    if (tableStart != null) {
-      break;
-    }
-    Utilities.sleep(200);
-  }
-  if (tableStart == null) {
-    Logger.log('blockquote borders: could not resolve table start index');
-    return {
-      success: false,
-      message: 'Ayah inserted but styling could not be applied after retries.',
-      attempts: maxAttempts
-    };
-  }
-
-  var rgb = hexToDocsRgb01_(BLOCKQUOTE_BORDER_LEFT_COLOR);
-  var black01 = { red: 0, green: 0, blue: 0 };
-  var zero = docsTableBorderPt_(0, black01);
-  var leftRgb = docsTableBorderPt_(BLOCKQUOTE_BORDER_LEFT_PT, rgb);
-
-  var tableRange = {
-    tableCellLocation: {
-      tableStartLocation: { index: tableStart },
-      rowIndex: 0,
-      columnIndex: 0
-    },
-    rowSpan: 1,
-    columnSpan: 1
-  };
-
-  var bgRgb = hexToDocsRgb01_(BLOCKQUOTE_CELL_BACKGROUND);
-
-  var requests = [
-    {
-      updateTableCellStyle: {
-        tableRange: tableRange,
-        tableCellStyle: {
-          borderTop: zero,
-          borderRight: zero,
-          borderBottom: zero,
-          borderLeft: leftRgb,
-          backgroundColor: { color: { rgbColor: bgRgb } }
-        },
-        fields: 'borderTop,borderRight,borderBottom,borderLeft,backgroundColor'
-      }
-    }
-  ];
-
-  try {
-    Docs.Documents.batchUpdate({ requests: requests }, docId);
-    return { success: true };
-  } catch (e) {
-    Logger.log('blockquote borders batchUpdate: ' + e);
-    return {
-      success: false,
-      message: 'Ayah inserted but styling could not be applied.',
-      error: String(e)
-    };
-  }
-}
-
-/**
- * Inserts a 1×1 table at the anchor, places beautified paragraphs in the cell, styles the shell.
- * Border styling is NOT applied here — the caller receives pendingBorders and must invoke
- * applyBlockquoteBorders() in a separate server call so that the auto-flush between calls
- * makes the table visible to the Docs REST API without needing saveAndClose().
+ * Inserts a 2×1 table at the anchor: accent column (app primary) + content column.
+ * Styling uses DocumentApp only (compatible with https://www.googleapis.com/auth/documents.currentonly).
  * @param {Body} body
  * @param {Document} doc
  * @param {Array<Object>} paragraphsToInsert
  * @param {Object} formatState
- * @return {Object} { fontWarning: string|null, pendingBorders: {docId: string, tableOrdinal: number}|null }
+ * @return {Object} { fontWarning: string|null }
  */
 function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState) {
   var anchor = resolveNativeInsertAnchor_(body, doc);
   var insertIndex = anchor.baseIndex;
   var removeTarget = anchor.removeTarget;
 
-  var table = body.insertTable(insertIndex, [['']]);
+  var table = body.insertTable(insertIndex, [['', '']]);
 
-  // Hide default table chrome immediately to minimize unstyled flash.
   try {
     if (typeof table.setBorderWidth === 'function') {
       table.setBorderWidth(0);
@@ -342,12 +194,26 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
     }
   }
 
-  var cell = table.getRow(0).getCell(0);
-  cell.setPaddingLeft(21); // to account for the 3px thick border
-  cell.setPaddingTop(18);
-  cell.setPaddingRight(18);
-  cell.setPaddingBottom(18);
+  var row = table.getRow(0);
+  var accentCell = row.getCell(0);
+  var contentCell = row.getCell(1);
 
+  accentCell.setBackgroundColor(BLOCKQUOTE_ACCENT_COLOR);
+  if (typeof accentCell.setWidth === 'function') {
+    accentCell.setWidth(BLOCKQUOTE_ACCENT_WIDTH_PT);
+  }
+  accentCell.setPaddingLeft(0);
+  accentCell.setPaddingTop(0);
+  accentCell.setPaddingRight(0);
+  accentCell.setPaddingBottom(0);
+
+  contentCell.setBackgroundColor(BLOCKQUOTE_CONTENT_BACKGROUND);
+  contentCell.setPaddingLeft(BLOCKQUOTE_CONTENT_PADDING_PT);
+  contentCell.setPaddingTop(BLOCKQUOTE_CONTENT_PADDING_PT);
+  contentCell.setPaddingRight(BLOCKQUOTE_CONTENT_PADDING_PT);
+  contentCell.setPaddingBottom(BLOCKQUOTE_CONTENT_PADDING_PT);
+
+  var cell = contentCell;
   var fontWarning = null;
   for (var i = 0; i < paragraphsToInsert.length; i++) {
     var item = paragraphsToInsert[i];
@@ -375,25 +241,14 @@ function insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatS
     if (cursorParagraph) {
       doc.setCursor(doc.newPosition(cursorParagraph, 0));
     } else {
-      // No following paragraph exists: keep cursor in the inserted block.
       doc.setCursor(doc.newPosition(cell.getChild(cell.getNumChildren() - 1).asParagraph(), 0));
     }
   } catch (e) {
     // setCursor is unavailable in non-UI contexts (e.g. triggers); fail silently
   }
 
-  var docId = doc.getId();
-  var bodyChildIndex = body.getChildIndex(table);
-  var tableOrdinal = 0;
-  for (var ci = 0; ci <= bodyChildIndex; ci++) {
-    if (body.getChild(ci).getType() === DocumentApp.ElementType.TABLE) {
-      tableOrdinal++;
-    }
-  }
-
   return {
-    fontWarning: fontWarning,
-    pendingBorders: { docId: docId, tableOrdinal: tableOrdinal }
+    fontWarning: fontWarning
   };
 }
 
@@ -463,17 +318,6 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
 }
 
 /**
- * Public entry point for the client to apply blockquote cell borders via a second RPC.
- * Called after insertAyah/insertAyahRange returns pendingBorders; the auto-flush between
- * the two server calls ensures the Docs REST API can see the newly inserted table.
- * @param {string} docId
- * @param {number} tableOrdinal - 1-based ordinal position of the target table
- */
-function applyBlockquoteBorders(docId, tableOrdinal) {
-  return applyBlockquoteCellBordersViaDocsApi_(docId, tableOrdinal);
-}
-
-/**
  * Inserts an ayah into the document using resolveNativeInsertAnchor_
  * (block-boundary cursor insertion, selection-end insertion, doc-end fallback).
  * @param {Object} ayahData - { surah, ayah, surahNameArabic, surahNameEnglish, textUthmani, textSimple, translationText }
@@ -534,11 +378,7 @@ function insertAyah(ayahData, formatState, settings) {
     ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
     : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
   var message = result.fontWarning ? 'Ayah inserted. ' + result.fontWarning : 'Ayah inserted.';
-  var out = { success: true, message: message };
-  if (result.pendingBorders) {
-    out.pendingBorders = result.pendingBorders;
-  }
-  return out;
+  return { success: true, message: message };
 }
 
 /**
@@ -596,9 +436,5 @@ function insertAyahRange(rangeData, formatState, settings) {
   var result = useBlockquote
     ? insertBlockquoteTableAtPosition_(body, doc, paragraphsToInsert, formatState)
     : insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState);
-  var out = { success: true, message: result.fontWarning ? 'Range inserted. ' + result.fontWarning : 'Range inserted.' };
-  if (result.pendingBorders) {
-    out.pendingBorders = result.pendingBorders;
-  }
-  return out;
+  return { success: true, message: result.fontWarning ? 'Range inserted. ' + result.fontWarning : 'Range inserted.' };
 }

--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -360,7 +360,7 @@ function insertAyah(ayahData, formatState, settings) {
       spacingAfter: INSERT_SPACING_INNER_PT
     });
     paragraphsToInsert.push({
-      text: '(' + surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah + ')',
+      text: surahNameEn + qNbsp + ayahData.surah + ':' + ayahData.ayah,
       align: DocumentApp.HorizontalAlignment.CENTER,
       insertTextRole: 'citation'
     });
@@ -418,8 +418,8 @@ function insertAyahRange(rangeData, formatState, settings) {
       spacingAfter: INSERT_SPACING_INNER_PT
     });
     paragraphsToInsert.push({
-      text: '(' + surahNameEn + qNbsp + rangeData.surah + ':' +
-            rangeData.ayahStart + '-' + rangeData.ayahEnd + ')',
+      text: surahNameEn + qNbsp + rangeData.surah + ':' +
+            rangeData.ayahStart + '-' + rangeData.ayahEnd,
       align: DocumentApp.HorizontalAlignment.CENTER,
       insertTextRole: 'citation'
     });

--- a/src/FormatService.js
+++ b/src/FormatService.js
@@ -14,7 +14,7 @@ var ENGLISH_TRANSLATION_INSERT_FONT = 'Figtree';
 var INSERT_QURAN_FONT_SIZE_PT = 16;
 var INSERT_QURAN_TEXT_COLOR = '#1A1A1A';
 
-/** Fixed typography for inserted translation and English citation (same color as Quran body). */
+/** Fixed typography for inserted translation; English citation is italic Figtree (same text color as Quran body). */
 var INSERT_TRANSLATION_FONT_SIZE_PT = 12;
 var INSERT_CITATION_FONT_SIZE_PT = 11;
 
@@ -79,7 +79,7 @@ function formatStateForInsertTranslationEnglish_() {
 function formatStateForInsertCitationEnglish_() {
   return {
     fontName: ENGLISH_TRANSLATION_INSERT_FONT,
-    fontVariant: 'regular',
+    fontVariant: 'italic',
     bold: false,
     fontSize: INSERT_CITATION_FONT_SIZE_PT,
     textColor: INSERT_QURAN_TEXT_COLOR

--- a/src/FormatService.js
+++ b/src/FormatService.js
@@ -12,7 +12,7 @@ var ENGLISH_TRANSLATION_INSERT_FONT = 'Figtree';
 
 /** Fixed typography for inserted Quran Arabic (Amiri only; client formatState is ignored for family/variant/bold). */
 var INSERT_QURAN_FONT_SIZE_PT = 16;
-var INSERT_QURAN_TEXT_COLOR = '#202124';
+var INSERT_QURAN_TEXT_COLOR = '#1A1A1A';
 
 /** Fixed typography for inserted translation and English citation (same color as Quran body). */
 var INSERT_TRANSLATION_FONT_SIZE_PT = 12;

--- a/src/SettingsService.js
+++ b/src/SettingsService.js
@@ -9,7 +9,7 @@ var AI_SEARCH_DAILY_LIMIT = 10;
 
 var SETTINGS_DEFAULTS = {
   showTranslation: true,
-  /** When true, ayah/range inserts are wrapped in a styled 1×1 table (blockquote look). */
+  /** When true, ayah/range inserts are wrapped in a styled 2×1 table (blockquote look). */
   blockquoteInsertion: true,
   insertArabic: true,
   arabicStyle: 'uthmani'     // "uthmani" | "simple"

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -1,18 +1,9 @@
 {
   "timeZone": "America/New_York",
-  "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Docs",
-        "version": "v1",
-        "serviceId": "docs"
-      }
-    ]
-  },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
-    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/documents.currentonly",
     "https://www.googleapis.com/auth/script.container.ui",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/userinfo.email"

--- a/src/sidebar/js/font-variant-utils.html
+++ b/src/sidebar/js/font-variant-utils.html
@@ -105,7 +105,7 @@ function ensureGoogleFontsPreviewStylesheet(family, variantTokens, onReady) {
 
 /** Matches server-side insert: Quran Arabic preview in result cards (pt / hex). */
 var INSERT_PREVIEW_ARABIC_PT = 16;
-var INSERT_PREVIEW_ARABIC_COLOR = '#202124';
+var INSERT_PREVIEW_ARABIC_COLOR = '#1A1A1A';
 
 /**
  * Inline style for Arabic preview (.arabic) from formatState.

--- a/src/sidebar/js/render-helpers.html
+++ b/src/sidebar/js/render-helpers.html
@@ -3,58 +3,6 @@
 //   buildCardHtml, buildRangeData (card-builder.html),
 //   _buildAyahDataForInsert (search-utils.html)
 
-/**
- * Fire-and-forget: applies blockquote cell borders via a deferred second RPC.
- * The auto-flush between the insert call and this call ensures the Docs REST API
- * can see the newly inserted table without needing saveAndClose().
- */
-function showTransientToast(message) {
-  if (!message) return;
-  var host = document.getElementById('sidebar-toast-host');
-  if (!host) {
-    host = document.createElement('div');
-    host.id = 'sidebar-toast-host';
-    host.className = 'sidebar-toast-host';
-    document.body.appendChild(host);
-  }
-  var toast = document.createElement('div');
-  toast.className = 'sidebar-toast';
-  toast.setAttribute('role', 'status');
-  toast.textContent = message;
-  host.appendChild(toast);
-
-  setTimeout(function() {
-    toast.classList.add('sidebar-toast-hide');
-    setTimeout(function() {
-      if (toast.parentNode) {
-        toast.parentNode.removeChild(toast);
-      }
-    }, 220);
-  }, 3800);
-}
-
-function _applyPendingBorders(result, done) {
-  if (!result || !result.pendingBorders) {
-    if (done) done();
-    return;
-  }
-  var pb = result.pendingBorders;
-  google.script.run
-    .withSuccessHandler(function(borderResult) {
-      if (!borderResult || borderResult.success !== true) {
-        showTransientToast("Ayah inserted but styling couldn't be applied — try re-inserting.");
-        console.error('Blockquote border styling failed:', borderResult && borderResult.message);
-      }
-      if (done) done();
-    })
-    .withFailureHandler(function(err) {
-      showTransientToast("Ayah inserted but styling couldn't be applied — try re-inserting.");
-      console.error('Blockquote border styling failed:', err);
-      if (done) done();
-    })
-    .applyBlockquoteBorders(pb.docId, pb.tableOrdinal);
-}
-
 function makeSkeleton(count) {
   var html = '';
   for (var i = 0; i < count; i++) {
@@ -141,10 +89,8 @@ function onInsertClick(e) {
         if (result && !result.success) {
           console.warn('Range insert warning:', result.message);
         }
-        _applyPendingBorders(result, function() {
-          btn.disabled = false;
-          btn.classList.remove('btn-loading');
-        });
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
       })
       .withFailureHandler(function(err) {
         btn.disabled = false;
@@ -176,10 +122,8 @@ function onInsertClick(e) {
       if (result && !result.success) {
         console.warn('Insert warning:', result.message);
       }
-      _applyPendingBorders(result, function() {
-        btn.disabled = false;
-        btn.classList.remove('btn-loading');
-      });
+      btn.disabled = false;
+      btn.classList.remove('btn-loading');
     })
     .withFailureHandler(function(err) {
       btn.disabled = false;

--- a/src/sidebar/sidebar-css.html
+++ b/src/sidebar/sidebar-css.html
@@ -158,11 +158,11 @@
   .results-list { flex: 1; overflow-y: auto; padding: var(--space-lg) var(--sidebar-inline); min-height: 0; }
   .result-card { padding: var(--space-md); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: var(--space-md); font-size: 12px; transition: border-color var(--transition-fast), box-shadow var(--transition-fast); }
 .result-card:hover { box-shadow: var(--shadow-sm); }
-  .result-card .ref-arabic { font-size: 11px; direction: rtl; text-align: right; color: #202124; margin-bottom: var(--space-xs); font-family: Amiri, serif; }
-  .result-card .ref-english { font-size: 11px; color: #202124; margin-top: var(--space-xs); margin-bottom: var(--space-xs); }
+  .result-card .ref-arabic { font-size: 11px; direction: rtl; text-align: right; color: #1A1A1A; margin-bottom: var(--space-xs); font-family: Amiri, serif; }
+  .result-card .ref-english { font-size: 11px; color: #1A1A1A; margin-top: var(--space-xs); margin-bottom: var(--space-xs); }
   @keyframes arabic-font-in { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: translateY(0); } }
   .result-card .arabic {
-    font-size: 16pt; direction: rtl; text-align: right; font-family: Amiri, serif; color: #202124; margin: var(--space-sm) 0; line-height: 1.8;
+    font-size: 16pt; direction: rtl; text-align: right; font-family: Amiri, serif; color: #1A1A1A; margin: var(--space-sm) 0; line-height: 1.8;
     animation: arabic-font-in 0.2s ease;
     transition: opacity 0.42s ease-out;
   }
@@ -173,7 +173,7 @@
   }
   .result-card .arabic.range-block { line-height: 2.2; white-space: normal; word-break: normal; }
   .result-card mark { background: #fff59d; padding: 0 2px; }
-  .result-card .translation { font-size: 12px; color: #202124; margin: var(--space-sm) 0 0; line-height: 1.5; }
+  .result-card .translation { font-size: 12px; color: #1A1A1A; margin: var(--space-sm) 0 0; line-height: 1.5; }
   .result-card .btn-toggle-translation { display: inline-block; font-size: 11px; color: var(--color-primary); cursor: pointer; margin-top: var(--space-xs); user-select: none; }
   .result-card .btn-toggle-translation:hover { text-decoration: underline; }
   .result-card .btn-insert-result { display: block; width: 100%; margin-top: var(--space-sm); padding: var(--space-sm) var(--space-md); font-size: 12px; }

--- a/src/tests/DocumentService.test.gs
+++ b/src/tests/DocumentService.test.gs
@@ -1,6 +1,6 @@
 /**
  * GAS-native tests for DocumentService.gs — resolveNativeInsertAnchor_(),
- * insertParagraphsAtPosition_(), insertBlockquoteTableAtPosition_(), and helpers.
+ * insertParagraphsAtPosition_(), insertBlockquoteTableAtPosition_(), and helpers (no Docs API).
  * Run from Apps Script editor: select runDocumentServiceTests, click Run.
  */
 
@@ -105,7 +105,9 @@ function runDocumentServiceTests() {
       _padT: null,
       _padR: null,
       _padB: null,
+      _width: null,
       setBackgroundColor: function (c) { this._bg = c; },
+      setWidth: function (w) { this._width = w; },
       setPaddingLeft: function (x) { this._padL = x; },
       setPaddingTop: function (x) { this._padT = x; },
       setPaddingRight: function (x) { this._padR = x; },
@@ -121,17 +123,23 @@ function runDocumentServiceTests() {
   }
 
   function createMockTable() {
-    var cell = createMockTableCell();
+    var accentCell = createMockTableCell();
+    var contentCell = createMockTableCell();
     return {
-      _cell: cell,
+      _cell: contentCell,
+      _accentCell: accentCell,
+      _contentCell: contentCell,
       getType: function () { return DocumentApp.ElementType.TABLE; },
       getRow: function () {
+        var ac = accentCell;
+        var cc = contentCell;
         return {
-          getCell: function () {
-            return cell;
+          getCell: function (i) {
+            return i === 0 ? ac : cc;
           }
         };
-      }
+      },
+      setBorderWidth: function () {}
     };
   }
 
@@ -521,17 +529,17 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[0].fontVariant).toBe('regular');
     expect(applyFormatCalls[0].fontSize).toBe(16);
     expect(applyFormatCalls[0].bold).toBe(false);
-    expect(applyFormatCalls[0].textColor).toBe('#202124');
+    expect(applyFormatCalls[0].textColor).toBe('#1A1A1A');
     expect(applyFormatCalls[1].fontName).toBe('Figtree');
     expect(applyFormatCalls[1].fontVariant).toBe('regular');
     expect(applyFormatCalls[1].fontSize).toBe(12);
     expect(applyFormatCalls[1].bold).toBe(false);
-    expect(applyFormatCalls[1].textColor).toBe('#202124');
+    expect(applyFormatCalls[1].textColor).toBe('#1A1A1A');
     expect(applyFormatCalls[2].fontName).toBe('Figtree');
     expect(applyFormatCalls[2].fontVariant).toBe('regular');
     expect(applyFormatCalls[2].fontSize).toBe(11);
     expect(applyFormatCalls[2].bold).toBe(false);
-    expect(applyFormatCalls[2].textColor).toBe('#202124');
+    expect(applyFormatCalls[2].textColor).toBe('#1A1A1A');
   });
 
   it('Arabic-only insert applies single Quran format call', function () {
@@ -549,7 +557,7 @@ function runDocumentServiceTests() {
     insertParagraphsAtPosition_(body, doc, arabicOnlyAyahInsert(), fs);
     expect(applyFormatCalls.length).toBe(1);
     expect(applyFormatCalls[0].fontSize).toBe(16);
-    expect(applyFormatCalls[0].textColor).toBe('#202124');
+    expect(applyFormatCalls[0].textColor).toBe('#1A1A1A');
     expect(applyFormatCalls[0].bold).toBe(false);
   });
 
@@ -637,9 +645,17 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(1);
     expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
 
-    var cell = body._children[0]._cell;
-    expect(cell._bg).toBe(null);
-    expect(cell._padL).toBe(21);
+    var tbl = body._children[0];
+    var accent = tbl._accentCell;
+    var cell = tbl._contentCell;
+    expect(accent._bg).toBe('#0d6e4f');
+    expect(accent._width).toBe(3);
+    expect(accent._padL).toBe(0);
+    expect(accent._padT).toBe(0);
+    expect(accent._padR).toBe(0);
+    expect(accent._padB).toBe(0);
+    expect(cell._bg).toBe('#F7F5F0');
+    expect(cell._padL).toBe(18);
     expect(cell._padT).toBe(18);
     expect(cell._padR).toBe(18);
     expect(cell._padB).toBe(18);
@@ -709,224 +725,6 @@ function runDocumentServiceTests() {
     expect(body._children[0].getType()).toBe(DocumentApp.ElementType.TABLE);
     expect(body._children[1]).toBe(origPara);
     body.removeChild = origRemoveChild;
-  });
-
-  it('hexToDocsRgb01_ parses normalized hex for Docs border color', function () {
-    var rgb = hexToDocsRgb01_('#3A8F7A');
-    expect(rgb.red > 0.2 && rgb.red < 0.25).toBe(true);
-    expect(rgb.green > 0.55 && rgb.green < 0.58).toBe(true);
-    expect(rgb.blue > 0.46 && rgb.blue < 0.49).toBe(true);
-  });
-
-  // ── resolveTableStartIndexForDocsApi_ ──────────────────────
-
-  results.push('\nresolveTableStartIndexForDocsApi_()');
-
-  var originalDocs = typeof Docs !== 'undefined' ? Docs : undefined;
-
-  function stubDocsGet(contentArray) {
-    Docs = {
-      Documents: {
-        get: function () {
-          return { body: { content: contentArray } };
-        },
-        batchUpdate: function () {}
-      }
-    };
-  }
-
-  function restoreDocs() {
-    if (originalDocs !== undefined) {
-      Docs = originalDocs;
-    }
-  }
-
-  function makeTableContent(startIndex) {
-    return [
-      { sectionBreak: {} },
-      { paragraph: {}, startIndex: 0 },
-      { table: {}, startIndex: startIndex }
-    ];
-  }
-
-  it('ordinal 1 returns startIndex of the only table', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { paragraph: {}, startIndex: 0 },
-      { table: {}, startIndex: 42 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 1);
-    expect(result).toBe(42);
-    restoreDocs();
-  });
-
-  it('ordinal 3 returns startIndex of the third table (skips paragraphs)', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { paragraph: {}, startIndex: 0 },
-      { table: {}, startIndex: 10 },
-      { paragraph: {}, startIndex: 20 },
-      { table: {}, startIndex: 30 },
-      { paragraph: {}, startIndex: 50 },
-      { table: {}, startIndex: 70 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 3);
-    expect(result).toBe(70);
-    restoreDocs();
-  });
-
-  it('ordinal 2 with only 1 table returns null (propagation delay)', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { table: {}, startIndex: 10 },
-      { paragraph: {}, startIndex: 30 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 2);
-    expect(result).toBe(null);
-    restoreDocs();
-  });
-
-  it('ordinal 0 returns null (invalid)', function () {
-    stubDocsGet([
-      { sectionBreak: {} },
-      { table: {}, startIndex: 10 }
-    ]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 0);
-    expect(result).toBe(null);
-    restoreDocs();
-  });
-
-  it('empty content array returns null', function () {
-    stubDocsGet([]);
-    var result = resolveTableStartIndexForDocsApi_('fake-id', 1);
-    expect(result).toBe(null);
-    restoreDocs();
-  });
-
-  // ── applyBlockquoteCellBordersViaDocsApi_ ───────────────────
-
-  results.push('\napplyBlockquoteCellBordersViaDocsApi_()');
-
-  it('retries up to 10 times with 200ms sleeps when table is not visible yet', function () {
-    var gets = 0;
-    var sleeps = 0;
-    var origUtilities = Utilities;
-    var origDocsLocal = Docs;
-    Utilities = { sleep: function (ms) { if (ms === 200) sleeps++; } };
-    Docs = {
-      Documents: {
-        get: function () {
-          gets++;
-          return { body: { content: [] } };
-        },
-        batchUpdate: function () {}
-      }
-    };
-    var result = applyBlockquoteCellBordersViaDocsApi_('fake-id', 1);
-    expect(gets).toBe(10);
-    expect(sleeps).toBe(10);
-    expect(result.success).toBe(false);
-    expect(result.attempts).toBe(10);
-    Utilities = origUtilities;
-    Docs = origDocsLocal;
-  });
-
-  it('returns success true when Docs batchUpdate succeeds', function () {
-    var batchCalls = 0;
-    var origUtilities = Utilities;
-    var origDocsLocal = Docs;
-    Utilities = { sleep: function () {} };
-    Docs = {
-      Documents: {
-        get: function () {
-          return { body: { content: makeTableContent(42) } };
-        },
-        batchUpdate: function () {
-          batchCalls++;
-        }
-      }
-    };
-    var result = applyBlockquoteCellBordersViaDocsApi_('fake-id', 1);
-    expect(batchCalls).toBe(1);
-    expect(result.success).toBe(true);
-    Utilities = origUtilities;
-    Docs = origDocsLocal;
-  });
-
-  it('returns failure object when Docs batchUpdate throws', function () {
-    var origUtilities = Utilities;
-    var origDocsLocal = Docs;
-    Utilities = { sleep: function () {} };
-    Docs = {
-      Documents: {
-        get: function () {
-          return { body: { content: makeTableContent(42) } };
-        },
-        batchUpdate: function () {
-          throw new Error('batch failed');
-        }
-      }
-    };
-    var result = applyBlockquoteCellBordersViaDocsApi_('fake-id', 1);
-    expect(result.success).toBe(false);
-    expect(typeof result.message).toBe('string');
-    Utilities = origUtilities;
-    Docs = origDocsLocal;
-  });
-
-  it('applyBlockquoteBorders returns underlying success result', function () {
-    var origFn = applyBlockquoteCellBordersViaDocsApi_;
-    applyBlockquoteCellBordersViaDocsApi_ = function () {
-      return { success: true, message: 'ok' };
-    };
-    var result = applyBlockquoteBorders('d', 1);
-    expect(result.success).toBe(true);
-    applyBlockquoteCellBordersViaDocsApi_ = origFn;
-  });
-
-  // ── tableOrdinal computation in insertBlockquoteTableAtPosition_ ──
-
-  results.push('\ninsertBlockquoteTableAtPosition_() — ordinal targeting (pendingBorders)');
-
-  it('single table in empty doc returns pendingBorders with tableOrdinal 1', function () {
-    var body = createMockBody(['']);
-    var doc = createMockDoc(body, body._children[0]);
-    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(result.pendingBorders.docId).toBe('mock-doc-id');
-    expect(result.pendingBorders.tableOrdinal).toBe(1);
-  });
-
-  it('new table after one pre-existing table returns tableOrdinal 2', function () {
-    var body = createMockBody(['text before', 'cursor here']);
-    var existingTable = createMockTable();
-    body._children.splice(1, 0, existingTable);
-    var cursorPara = body._children[2];
-    var doc = createMockDoc(body, cursorPara);
-    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(result.pendingBorders.tableOrdinal).toBe(2);
-  });
-
-  it('new table between two pre-existing tables returns tableOrdinal 2', function () {
-    var body = createMockBody(['before', 'middle', 'after']);
-    var table1 = createMockTable();
-    body._children.splice(1, 0, table1);
-    var table2 = createMockTable();
-    body._children.splice(3, 0, table2);
-    var cursorPara = body._children[2];
-    var doc = createMockDoc(body, cursorPara);
-    var result = insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(result.pendingBorders.tableOrdinal).toBe(2);
-  });
-
-  it('blockquote does NOT call applyBlockquoteCellBordersViaDocsApi_ inline', function () {
-    var called = false;
-    var origBorders = applyBlockquoteCellBordersViaDocsApi_;
-    applyBlockquoteCellBordersViaDocsApi_ = function () { called = true; };
-    var body = createMockBody(['']);
-    var doc = createMockDoc(body, body._children[0]);
-    insertBlockquoteTableAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(called).toBe(false);
-    applyBlockquoteCellBordersViaDocsApi_ = origBorders;
   });
 
   // ── resolveNativeInsertAnchor_ — selection end + cursor split ──

--- a/src/tests/DocumentService.test.gs
+++ b/src/tests/DocumentService.test.gs
@@ -265,7 +265,7 @@ function runDocumentServiceTests() {
         spacingAfter: INSERT_SPACING_INNER_PT
       },
       {
-        text: '(Al-Fatiha\u00A01:1)',
+        text: 'Al-Fatiha\u00A01:1',
         align: DocumentApp.HorizontalAlignment.CENTER,
         insertTextRole: 'citation'
       }
@@ -536,7 +536,7 @@ function runDocumentServiceTests() {
     expect(applyFormatCalls[1].bold).toBe(false);
     expect(applyFormatCalls[1].textColor).toBe('#1A1A1A');
     expect(applyFormatCalls[2].fontName).toBe('Figtree');
-    expect(applyFormatCalls[2].fontVariant).toBe('regular');
+    expect(applyFormatCalls[2].fontVariant).toBe('italic');
     expect(applyFormatCalls[2].fontSize).toBe(11);
     expect(applyFormatCalls[2].bold).toBe(false);
     expect(applyFormatCalls[2].textColor).toBe('#1A1A1A');
@@ -573,7 +573,7 @@ function runDocumentServiceTests() {
     expect(body._children[1]._ltr).toBe(false);
     expect(body._children[2]._text).toBe('"translation"');
     expect(body._children[2]._ltr).toBe(true);
-    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[3]._text).toBe('Al-Fatiha\u00A01:1');
     expect(body._children[3]._ltr).toBe(true);
   });
 
@@ -587,7 +587,7 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(5);
     expect(body._children[1]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[2]._text).toBe('"translation"');
-    expect(body._children[3]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[3]._text).toBe('Al-Fatiha\u00A01:1');
     expect(body._children[4]._text).toBe('after');
   });
 
@@ -604,7 +604,7 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(3);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[1]._text).toBe('"translation"');
-    expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[2]._text).toBe('Al-Fatiha\u00A01:1');
 
     var doc2 = createMockDoc(body, body._children[2]);
     insertParagraphsAtPosition_(body, doc2, singleArabicParagraph(), {});
@@ -613,7 +613,7 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(4);
     expect(body._children[0]._text).toBe('\uFD3F\u00A0arabic\u00A0\uFD3E');
     expect(body._children[1]._text).toBe('"translation"');
-    expect(body._children[2]._text).toBe('(Al-Fatiha\u00A01:1)');
+    expect(body._children[2]._text).toBe('Al-Fatiha\u00A01:1');
     expect(body._children[3]._text).toBe('\uFD3F\u00A0test\u00A0\uFD3E');
   });
 

--- a/src/tests/FormatService.test.gs
+++ b/src/tests/FormatService.test.gs
@@ -71,11 +71,11 @@ function runFormatServiceTests() {
     expect(a.bold).toBe(false);
     expect(a.textColor).toBe('#1A1A1A');
   });
-  it('citation role yields Figtree 11pt same color as Quran', function () {
+  it('citation role yields Figtree 11pt italic same color as Quran', function () {
     var item = { insertTextRole: 'citation' };
     var a = formatStateForBeautifiedInsertParagraph(item, { fontName: 'Amiri', bold: true });
     expect(a.fontName).toBe('Figtree');
-    expect(a.fontVariant).toBe('regular');
+    expect(a.fontVariant).toBe('italic');
     expect(a.fontSize).toBe(11);
     expect(a.bold).toBe(false);
     expect(a.textColor).toBe('#1A1A1A');

--- a/src/tests/FormatService.test.gs
+++ b/src/tests/FormatService.test.gs
@@ -69,7 +69,7 @@ function runFormatServiceTests() {
     expect(a.fontVariant).toBe('regular');
     expect(a.fontSize).toBe(12);
     expect(a.bold).toBe(false);
-    expect(a.textColor).toBe('#202124');
+    expect(a.textColor).toBe('#1A1A1A');
   });
   it('citation role yields Figtree 11pt same color as Quran', function () {
     var item = { insertTextRole: 'citation' };
@@ -78,7 +78,7 @@ function runFormatServiceTests() {
     expect(a.fontVariant).toBe('regular');
     expect(a.fontSize).toBe(11);
     expect(a.bold).toBe(false);
-    expect(a.textColor).toBe('#202124');
+    expect(a.textColor).toBe('#1A1A1A');
   });
   it('quran role forces Amiri regular non-bold and 16pt primary color', function () {
     var fs = { fontName: 'Scheherazade New', fontVariant: '700', bold: true };
@@ -87,7 +87,7 @@ function runFormatServiceTests() {
     expect(a.fontName).toBe('Amiri');
     expect(a.fontVariant).toBe('regular');
     expect(a.fontSize).toBe(16);
-    expect(a.textColor).toBe('#202124');
+    expect(a.textColor).toBe('#1A1A1A');
     expect(a.bold).toBe(false);
   });
   it('quran role does not mutate original formatState', function () {

--- a/tests/buildResultCardHtml.test.js
+++ b/tests/buildResultCardHtml.test.js
@@ -50,7 +50,7 @@ function parseGoogleFontVariantClient(token) {
 }
 
 var INSERT_PREVIEW_ARABIC_PT = 16;
-var INSERT_PREVIEW_ARABIC_COLOR = '#202124';
+var INSERT_PREVIEW_ARABIC_COLOR = '#1A1A1A';
 
 function arabicPreviewFontStyle(fs) {
   var fam = (fs && fs.fontName) || 'Amiri';
@@ -568,7 +568,7 @@ function runTests() {
     };
     var html = buildCardHtml(r, fs);
     assert.ok(html.indexOf('font-size:16pt') >= 0, 'fixed 16pt preview');
-    assert.ok(html.indexOf('color:#202124') >= 0, 'fixed insert text color');
+    assert.ok(html.indexOf('color:#1A1A1A') >= 0, 'fixed insert text color');
   });
 
   it('single: legacy bold flag does not change Arabic preview weight', function () {
@@ -602,7 +602,7 @@ function runTests() {
       textColor: 'not-a-color'
     };
     var html = buildCardHtml(r, fs);
-    assert.ok(html.indexOf('color:#202124') >= 0, 'fixed insert color');
+    assert.ok(html.indexOf('color:#1A1A1A') >= 0, 'fixed insert color');
   });
 
   it('single: falls back to "Surah" when surahNameEnglish is empty', function () {

--- a/tests/renderHelpers.test.js
+++ b/tests/renderHelpers.test.js
@@ -19,39 +19,9 @@ function createButton() {
   };
 }
 
-function finalizeButton(btn) {
+function finalizeInsertButton(btn) {
   btn.disabled = false;
   btn.classList.remove('btn-loading');
-}
-
-function handleInsertSuccess(btn, result, applyPendingBordersFn) {
-  applyPendingBordersFn(result, function () {
-    finalizeButton(btn);
-  });
-}
-
-function makeApplyPendingBordersStub(opts) {
-  const calls = [];
-  const toasts = [];
-  return {
-    calls,
-    toasts,
-    fn: function (result, done) {
-      calls.push(result);
-      if (!result || !result.pendingBorders) {
-        done();
-        return;
-      }
-      if (opts && opts.fail) {
-        toasts.push("Ayah inserted but styling couldn't be applied — try re-inserting.");
-      }
-      if (!opts || !opts.deferDone) {
-        done();
-      } else {
-        opts.deferDone(done);
-      }
-    }
-  };
 }
 
 function runTests() {
@@ -63,46 +33,13 @@ function runTests() {
     console.log('✓ ' + name);
   }
 
-  it('re-enables immediately when no pendingBorders exists', function () {
+  it('re-enables insert button after successful RPC (no follow-up border step)', function () {
     const btn = createButton();
     btn.disabled = true;
     btn.classList.add('btn-loading');
-    const stub = makeApplyPendingBordersStub();
-    handleInsertSuccess(btn, { success: true }, stub.fn);
+    finalizeInsertButton(btn);
     assert.strictEqual(btn.disabled, false);
     assert.strictEqual(btn.classList.has('btn-loading'), false);
-  });
-
-  it('keeps loading state until deferred border callback completes', function () {
-    const btn = createButton();
-    btn.disabled = true;
-    btn.classList.add('btn-loading');
-    let releaseDone = null;
-    const stub = makeApplyPendingBordersStub({
-      deferDone: function (done) {
-        releaseDone = done;
-      }
-    });
-    handleInsertSuccess(btn, { pendingBorders: { docId: 'x', tableOrdinal: 1 } }, stub.fn);
-    assert.strictEqual(btn.disabled, true);
-    assert.strictEqual(btn.classList.has('btn-loading'), true);
-    releaseDone();
-    assert.strictEqual(btn.disabled, false);
-    assert.strictEqual(btn.classList.has('btn-loading'), false);
-  });
-
-  it('records styling-failure toast path when border RPC fails', function () {
-    const btn = createButton();
-    btn.disabled = true;
-    btn.classList.add('btn-loading');
-    const stub = makeApplyPendingBordersStub({ fail: true });
-    handleInsertSuccess(btn, { pendingBorders: { docId: 'x', tableOrdinal: 1 } }, stub.fn);
-    assert.strictEqual(stub.toasts.length, 1);
-    assert.strictEqual(
-      stub.toasts[0],
-      "Ayah inserted but styling couldn't be applied — try re-inserting."
-    );
-    assert.strictEqual(btn.disabled, false);
   });
 
   console.log('\nrenderHelpers tests passed: ' + passed);


### PR DESCRIPTION
Closes #150

## Summary

- OAuth scope is `documents.currentonly` so the add-on avoids the sensitive full `documents` scope for marketplace review.
- Removed the Advanced Docs service and the deferred `applyBlockquoteBorders` RPC. Blockquote styling is done entirely in `insertBlockquoteTableAtPosition_` with a **2×1** table: accent column `#0d6e4f` at 3 pt width with zero padding, content column `#F7F5F0` with uniform 18 pt padding.
- Insert text color is `#1A1A1A` for all beautified inserts; sidebar preview CSS and `INSERT_PREVIEW_ARABIC_COLOR` match.

## Testing

- `npm test`