### PR TITLE
Enforce user-specified result counts in AI Search

### DIFF
--- a/src/ClaudeAPI.js
+++ b/src/ClaudeAPI.js
@@ -97,6 +97,10 @@ var UNIFIED_SYSTEM_PROMPT =
   '{"action":"semantic_search","rag_supported":false,"queries":["Day of Judgment and resurrection in Meccan surahs","Yawm al-Qiyamah warnings to disbelievers","descriptions of the Hereafter in early revelations"],"references":[{"surah":82,"ayah":1},{"surah":81,"ayah":1},{"surah":56,"ayah":1},{"surah":78,"ayah":1},{"surah":99,"ayah":1}]}\n\n' +
   'User: "5 ayahs about forgiveness"\n' +
   '{"action":"semantic_search","rag_supported":true,"queries":["Allah\'s forgiveness and pardon for sins","seeking forgiveness and repentance tawbah istighfar","divine mercy toward those who repent"],"references":[{"surah":39,"ayah":53},{"surah":4,"ayah":110},{"surah":3,"ayah":135}],"limit":5}\n\n' +
+  'User: "the ayah about greed"\n' +
+  '{"action":"semantic_search","rag_supported":true,"queries":["greed and love of wealth","hoarding riches and miserliness","insatiable desire for worldly possessions"],"references":[{"surah":102,"ayah":1},{"surah":104,"ayah":2},{"surah":3,"ayah":180}],"limit":1}\n\n' +
+  'User: "a single verse on patience"\n' +
+  '{"action":"semantic_search","rag_supported":true,"queries":["patience sabr in hardship","steadfastness and perseverance through trials","enduring difficulty with faith"],"references":[{"surah":2,"ayah":153},{"surah":3,"ayah":200},{"surah":2,"ayah":155}],"limit":1}\n\n' +
   'User: "3 ayahs from baqara about patience and 2 from imran about love"\n' +
   '{"action":"clarify","message":"I can search one topic at a time. Which would you like first — ayahs about patience from Al-Baqarah, or ayahs about love from Ali \'Imran?"}\n\n' +
   'User: "show me Al-Imran 190 to 194"\n' +
@@ -111,10 +115,15 @@ var UNIFIED_SYSTEM_PROMPT =
   '{"action":"clarify","message":"Surah 116 is not a valid surah number. The Quran has 114 surahs (1-114). Which surah did you mean?"}\n' +
   '</examples>';
 
-var RAG_RERANK_SYSTEM_PROMPT =
-  'You are a Quran relevance ranker. Given a user\'s search query and a list of candidate ayahs, return the 10 most relevant ayahs ranked by how directly they address the user\'s intent.\n\n' +
-  'Return ONLY a JSON array of ayah keys in order of relevance, most relevant first.\n' +
-  'Example: ["30:21","4:19","2:231"]';
+var RAG_RERANK_DEFAULT_N = 10;
+
+function _buildRagRerankSystemPrompt_(n) {
+  var count = (Number.isInteger(n) && n > 0) ? n : RAG_RERANK_DEFAULT_N;
+  return 'You are a Quran relevance ranker. Given a user\'s search query and a list of candidate ayahs, return the ' + count + ' most relevant ayahs ranked by how directly they address the user\'s intent.\n\n' +
+    'Return EXACTLY ' + count + ' ayahs (fewer only if the candidate list is shorter).\n' +
+    'Return ONLY a JSON array of ayah keys in order of relevance, most relevant first.\n' +
+    'Example: ["30:21","4:19","2:231"]';
+}
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -245,6 +254,13 @@ function _handleSemanticSearch(classified) {
 
   if (!validRefs.length) {
     return { type: 'error', error: 'No valid results found. Try a different query.' };
+  }
+
+  var userLimit = (classified.limit && Number.isInteger(classified.limit) && classified.limit > 0)
+    ? classified.limit : null;
+  if (userLimit && validRefs.length > userLimit) {
+    Logger.log('[CLAUDE SEARCH] Applying user limit: ' + userLimit + ' (from ' + validRefs.length + ').');
+    validRefs = validRefs.slice(0, userLimit);
   }
 
   var merged = _mergeConsecutiveReferences(validRefs);
@@ -457,9 +473,10 @@ function _trimConversationContext(messages) {
  * @param {string} apiKey - Anthropic API key
  * @param {string} userQuery - User search query for reranking
  * @param {string} candidateBlock - Lines "surah:ayah — translation"
+ * @param {number} [targetN] - Target number of ayahs to return (defaults to RAG_RERANK_DEFAULT_N)
  * @return {string|null} Model text, or null on HTTP/body failure
  */
-function _callClaudeForRagRerank_(apiKey, userQuery, candidateBlock) {
+function _callClaudeForRagRerank_(apiKey, userQuery, candidateBlock, targetN) {
   if (!apiKey || !candidateBlock || !String(candidateBlock).trim()) {
     return null;
   }
@@ -473,7 +490,7 @@ function _callClaudeForRagRerank_(apiKey, userQuery, candidateBlock) {
     model: CLAUDE_MODEL,
     max_tokens: CLAUDE_RAG_RERANK_MAX_TOKENS,
     temperature: 0,
-    system: RAG_RERANK_SYSTEM_PROMPT,
+    system: _buildRagRerankSystemPrompt_(targetN),
     messages: [{ role: 'user', content: userContent }]
   };
 

--- a/src/ClaudeAPI.js
+++ b/src/ClaudeAPI.js
@@ -72,6 +72,10 @@ var UNIFIED_SYSTEM_PROMPT =
   'Do not guess the closest match.\n' +
   '- Surah numbers must be between 1 and 114. If the user requests a surah number outside this range ' +
   '(e.g. surah 116, surah 0, surah 200), always use clarify to tell them it is not valid and ask which surah they meant.\n' +
+  '- CRITICAL INSTRUCTION FOR RANGES: You are prone to an off-by-one error when calculating the "last N ayahs" of a surah. ' +
+  'When a user asks for the last N ayahs, you MUST calculate the start ayah using this exact formula: (Total Ayahs - N) + 1. ' +
+  'For example, if a surah has 45 ayahs and the user asks for the last 5, the start ayah is 41 (45 - 5 + 1 = 41). ' +
+  'Return the range 41 to 45.\n' +
   '- Prefer clarify over guessing when input is ambiguous.\n' +
   '</guidelines>\n\n' +
   '<examples>\n' +
@@ -111,6 +115,10 @@ var UNIFIED_SYSTEM_PROMPT =
   '{"action":"fetch_ayah","references":[{"surah":2,"ayahStart":1,"ayahEnd":286}]}\n\n' +
   'User: "show me Surah Al-Fatiha"\n' +
   '{"action":"fetch_ayah","references":[{"surah":1,"ayahStart":1,"ayahEnd":7}]}\n\n' +
+  'User: "last 5 verses of Al-Hashr"\n' +
+  '{"action":"fetch_ayah","references":[{"surah":59,"ayahStart":20,"ayahEnd":24}]}\n\n' +
+  'User: "first 3 verses of Al-Baqarah"\n' +
+  '{"action":"fetch_ayah","references":[{"surah":2,"ayahStart":1,"ayahEnd":3}]}\n\n' +
   'User: "show me surah 116"\n' +
   '{"action":"clarify","message":"Surah 116 is not a valid surah number. The Quran has 114 surahs (1-114). Which surah did you mean?"}\n' +
   '</examples>';

--- a/src/RagService.js
+++ b/src/RagService.js
@@ -500,7 +500,7 @@ function _handleRagSearch(classified, originalUserQueryForRerank) {
     if (!claudeKey) {
       Logger.log('[RAG SEARCH] WARN: Claude API key missing — skipping rerank, using Pinecone order.');
     } else {
-      var rawRerank = _callClaudeForRagRerank_(claudeKey, userQueryForRerank, candidateBlock);
+      var rawRerank = _callClaudeForRagRerank_(claudeKey, userQueryForRerank, candidateBlock, finalCap);
       if (!rawRerank) {
         Logger.log('[RAG SEARCH] WARN: Claude rerank returned empty or HTTP error — using Pinecone order.');
       } else {
@@ -513,6 +513,14 @@ function _handleRagSearch(classified, originalUserQueryForRerank) {
   }
 
   var finalFlat = _finalizeRagAyahRefs_(pool, rerankedKeys, finalCap);
+
+  // Defensive guard: enforce finalCap before merging consecutive ayahs so that
+  // a reranker returning extras cannot inflate a range group past the user's N.
+  if (finalFlat.length > finalCap) {
+    Logger.log('[RAG SEARCH] WARN: finalFlat exceeded cap (' + finalFlat.length + ' > ' + finalCap + '), truncating.');
+    finalFlat = finalFlat.slice(0, finalCap);
+  }
+
   var finalKeysForLog = [];
   for (var fi = 0; fi < finalFlat.length; fi++) {
     finalKeysForLog.push(finalFlat[fi].surah + ':' + finalFlat[fi].ayah);

--- a/src/sidebar/js/tab-ai-search-js.html
+++ b/src/sidebar/js/tab-ai-search-js.html
@@ -7,6 +7,8 @@
 var _conversationMessages = [];
 /** True only while an AI search RPC is in flight (not when blocked by daily quota). */
 var _aiSearchAwaitingResponse = false;
+/** True only while "Start new chat" quota refresh is pending. */
+var _aiResetAwaitingQuotaRefresh = false;
 
 var AI_DAILY_LIMIT_MESSAGE = 'Daily AI limit reached. Try again tomorrow.';
 var AI_DAILY_LIMIT_ERROR_RE = /^Daily AI limit reached\. Try again tomorrow\.$/;
@@ -99,7 +101,7 @@ function updateNewChatVisibility() {
     btn.disabled = true;
     return;
   }
-  var busy = _aiSearchAwaitingResponse;
+  var busy = _aiSearchAwaitingResponse || _aiResetAwaitingQuotaRefresh;
   btn.disabled = busy || !aiSearchPanelIsDirty();
 }
 
@@ -140,6 +142,8 @@ function applyAiSearchQuotaFromServer(allowed) {
 
   _aiSearchQuotaBlocked = !allowed;
   _aiSearchAwaitingResponse = false;
+  _aiResetAwaitingQuotaRefresh = false;
+  removeAiSearchLoader('ai-reset-loading');
 
   if (queryEl) queryEl.disabled = false;
   if (btnSend) btnSend.disabled = !allowed;
@@ -225,6 +229,22 @@ function hideAIWelcome() {
   if (el) el.classList.add('hidden');
 }
 
+function showAiSearchLoader(containerEl, loaderId) {
+  if (!containerEl || !loaderId) return;
+  if (document.getElementById(loaderId)) return;
+  var loadingWrap = document.createElement('div');
+  loadingWrap.id = loaderId;
+  loadingWrap.className = 'ai-search-loading';
+  loadingWrap.innerHTML = '<div class="startup-spinner" aria-hidden="true"></div>';
+  containerEl.appendChild(loadingWrap);
+}
+
+function removeAiSearchLoader(loaderId) {
+  if (!loaderId) return;
+  var pending = document.getElementById(loaderId);
+  if (pending) pending.remove();
+}
+
 function initAISearchTab() {
   var queryEl = document.getElementById('ai-search-query');
   var btnSend = document.getElementById('btn-ai-search');
@@ -270,11 +290,7 @@ function initAISearchTab() {
     showAIQueryBar(query);
     updateNewChatVisibility();
 
-    var loadingWrap = document.createElement('div');
-    loadingWrap.id = 'ai-loading';
-    loadingWrap.className = 'ai-search-loading';
-    loadingWrap.innerHTML = '<div class="startup-spinner" aria-hidden="true"></div>';
-    resultsEl.appendChild(loadingWrap);
+    showAiSearchLoader(resultsEl, 'ai-loading');
     updateNewChatVisibility();
 
     setEnabled(false);
@@ -283,8 +299,7 @@ function initAISearchTab() {
 
     google.script.run
       .withSuccessHandler(function(response) {
-        var pending = document.getElementById('ai-loading');
-        if (pending) pending.remove();
+        removeAiSearchLoader('ai-loading');
         setEnabled(true);
 
         if (response && response.rawResponse) {
@@ -294,8 +309,7 @@ function initAISearchTab() {
         handleAIResponse(response);
       })
       .withFailureHandler(function() {
-        var pending = document.getElementById('ai-loading');
-        if (pending) pending.remove();
+        removeAiSearchLoader('ai-loading');
         setEnabled(true);
         _conversationMessages.pop();
         updateNewChatVisibility();
@@ -406,6 +420,7 @@ function initAISearchTab() {
 function clearAISearch() {
   _conversationMessages = [];
   _aiSearchAwaitingResponse = false;
+  _aiResetAwaitingQuotaRefresh = true;
   pagClear('ai-search');
   var queryEl = document.getElementById('ai-search-query');
   var resultsEl = document.getElementById('ai-search-results');
@@ -420,6 +435,9 @@ function clearAISearch() {
     emptyEl.textContent = '';
   }
   hideAIQueryBar();
+  hideAIWelcome();
+  showAiSearchLoader(resultsEl, 'ai-reset-loading');
+  updateNewChatVisibility();
   refreshAiSearchComposerEnabled(true);
 }
 </script>

--- a/src/sidebar/sidebar-css.html
+++ b/src/sidebar/sidebar-css.html
@@ -522,7 +522,7 @@
   .bottom-bar {
     flex-shrink: 0;
     border-top: 1px solid var(--color-border);
-    padding: var(--space-xs);
+    padding: var(--space-xs) var(--space-sm);
     background: var(--color-bg-secondary);
   }
   .bottom-bar-inner {
@@ -616,9 +616,9 @@
   }
   .bottom-bar-action:hover { color: var(--color-text-primary); background: var(--color-bg-hover); }
   .bottom-bar-action svg { width: 16px; height: 16px; flex-shrink: 0; display: block; }
-  #btn-bottom-settings { color: var(--color-text-secondary); }
+  #btn-bottom-settings { color: var(--color-text-secondary); margin-right: -5px; }
   #btn-bottom-settings:hover { color: var(--color-text-primary); }
-  #btn-bottom-settings svg { width: 16px; height: 16px; display: block; }
+  #btn-bottom-settings svg { width: 18px; height: 18px; display: block; }
   .sidebar-toast-host {
     position: fixed;
     left: 50%;

--- a/src/tests/ClaudeAPI.test.gs
+++ b/src/tests/ClaudeAPI.test.gs
@@ -414,6 +414,44 @@ function runClaudeAPITests() {
     expect(result.references[0].surah).toBe(1);
   });
 
+  it('applies classified.limit before merging (single result)', function () {
+    var classified = {
+      limit: 1,
+      references: [{ surah: 1, ayah: 1 }, { surah: 2, ayah: 255 }, { surah: 3, ayah: 190 }]
+    };
+    var result = _handleSemanticSearch(classified);
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(1);
+    expect(result.references[0].surah).toBe(1);
+    expect(result.references[0].ayahStart).toBe(1);
+    expect(result.references[0].ayahEnd).toBe(1);
+  });
+
+  it('applies classified.limit=3 and truncates before consecutive merge', function () {
+    var classified = {
+      limit: 3,
+      references: [
+        { surah: 2, ayah: 1 }, { surah: 2, ayah: 2 }, { surah: 2, ayah: 3 }, { surah: 2, ayah: 4 }
+      ]
+    };
+    var result = _handleSemanticSearch(classified);
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(1);
+    expect(result.references[0].surah).toBe(2);
+    expect(result.references[0].ayahStart).toBe(1);
+    expect(result.references[0].ayahEnd).toBe(3);
+  });
+
+  it('ignores invalid classified.limit values', function () {
+    var classified = {
+      limit: 0,
+      references: [{ surah: 1, ayah: 1 }, { surah: 2, ayah: 255 }]
+    };
+    var result = _handleSemanticSearch(classified);
+    expect(result.type).toBe('references');
+    expect(result.references.length).toBe(2);
+  });
+
   // ── _handleFetchAyahAsReferences (unit — returns merged groups) ────────────
 
   results.push('\n_handleFetchAyahAsReferences()');

--- a/src/tests/RagService.test.gs
+++ b/src/tests/RagService.test.gs
@@ -288,6 +288,25 @@ function runRagServiceTests() {
     expect(out).arrayLength(2);
   });
 
+  // ── Rerank prompt N parameterization (unit) ───────────────────────────────
+
+  results.push('\n_buildRagRerankSystemPrompt_()');
+
+  it('includes user-requested N in the rerank prompt', function () {
+    var prompt = _buildRagRerankSystemPrompt_(3);
+    expect(prompt.indexOf('return the 3 most relevant') >= 0).toBe(true);
+    expect(prompt.indexOf('EXACTLY 3 ayahs') >= 0).toBe(true);
+  });
+
+  it('falls back to default N=10 for invalid inputs', function () {
+    var prompt1 = _buildRagRerankSystemPrompt_(null);
+    var prompt2 = _buildRagRerankSystemPrompt_(0);
+    var prompt3 = _buildRagRerankSystemPrompt_(-5);
+    expect(prompt1.indexOf('return the 10 most relevant') >= 0).toBe(true);
+    expect(prompt2.indexOf('return the 10 most relevant') >= 0).toBe(true);
+    expect(prompt3.indexOf('return the 10 most relevant') >= 0).toBe(true);
+  });
+
   // ── Property key getters (unit) ───────────────────────────────────────────
 
   results.push('\nProperty key getters');


### PR DESCRIPTION
Closes #159

## Summary
- Apply `classified.limit` in `_handleSemanticSearch` (Claude-references fallback path — the primary bug)
- Parameterize rerank prompt N via `_buildRagRerankSystemPrompt_`; pass `finalCap` into `_callClaudeForRagRerank_`
- Defensive truncate on `finalFlat` before consecutive-range merge in `_handleRagSearch` (so a single range group cannot exceed N)
- Add classification prompt examples for "the ayah about X" / "a single verse on X" → `limit:1`

Leans on the existing `classified.limit` field (Claude already extracts counts from NL) rather than adding a parallel regex parser.

## Test plan
- [x] `npm test` passes
- [ ] `runClaudeAPITests` + `runRagServiceTests` pass in Apps Script editor
- [ ] Manual: "the ayah about greed" → 1 card
- [ ] Manual: "a single verse on patience" → 1 card
- [ ] Manual: "5 ayahs about forgiveness" → 5 cards (regression)
- [ ] Manual: "verses about patience" (no count) → unchanged default
- [ ] Manual: juz-30 query with count → respects limit (verifies fallback path fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)