### PR TITLE
RAG rerank: translation-only context for Haiku

### DIFF
--- a/src/ClaudeAPI.js
+++ b/src/ClaudeAPI.js
@@ -153,7 +153,7 @@ function _aiSearchDedupeKey_(messages) {
 function _buildRagRerankSystemPrompt_(n) {
   var count = (Number.isInteger(n) && n > 0) ? n : RAG_RERANK_DEFAULT_N;
   return 'You are a Quran relevance ranker. Given a user\'s search query and a list of candidate ayahs, return the ' + count + ' most relevant ayahs ranked by how directly they address the user\'s intent.\n\n' +
-    'Each candidate is presented as its surah:ayah key on its own line, followed by a block containing the English translation, tafseer, themes, and keywords. Base your ranking on the combined signal across all of these fields — not translation alone.\n\n' +
+    'Each candidate is presented as its surah:ayah key on its own line, followed by the English translation for that ayah. Rank by how well that text matches the user\'s query.\n\n' +
     'Return EXACTLY ' + count + ' ayahs (fewer only if the candidate list is shorter).\n' +
     'Return ONLY a JSON array of ayah keys in order of relevance, most relevant first.\n' +
     'Example: ["30:21","4:19","2:231"]';
@@ -525,7 +525,7 @@ function _trimConversationContext(messages) {
  * Calls Claude to rerank RAG candidate ayahs by English translation relevance.
  * @param {string} apiKey - Anthropic API key
  * @param {string} userQuery - User search query for reranking
- * @param {string} candidateBlock - Lines "surah:ayah — translation"
+ * @param {string} candidateBlock - surah:ayah per candidate, then English translation lines
  * @param {number} [targetN] - Target number of ayahs to return (defaults to RAG_RERANK_DEFAULT_N)
  * @return {string|null} Model text, or null on HTTP/body failure
  */

--- a/src/RagService.js
+++ b/src/RagService.js
@@ -81,6 +81,27 @@ function _truncateForRagLog_(s) {
 }
 
 /**
+ * Returns the English translation segment from Pinecone composite_text for Haiku rerank only.
+ * Strips tafseer, themes, and keywords to reduce prompt size. If there is no "Translation:"
+ * marker, returns the full trimmed string (legacy / test payloads).
+ * @param {string} s - Raw composite_text from metadata
+ * @return {string} Text to show under each surah:ayah in the rerank prompt, or '' if empty
+ */
+function _translationFromRerankContext_(s) {
+  if (s == null || typeof s !== 'string') return '';
+  var t = s.replace(/\r\n/g, '\n').trim();
+  if (!t) return '';
+  var transTag = 'translation:';
+  var idx = t.toLowerCase().indexOf(transTag);
+  if (idx === -1) return t;
+  var after = t.substring(idx + transTag.length);
+  var next = after.search(/\n\s*(?:Tafseer|Themes|Keywords)\s*:/i);
+  var body = next === -1 ? after : after.substring(0, next);
+  var trimmed = body.trim();
+  return trimmed || t;
+}
+
+/**
  * Merges Pinecone match lists from multiple query vectors: one row per ayah (max score wins).
  * @param {Array<{queryIndex: number, queryText: string, matches: Array<{score: number, metadata: Object}>}>} runs
  * @return {Array<{surah: number, ayah: number, score: number, winningQueryIndex: number, winningQueryText: string, compositeText: string}>}
@@ -470,8 +491,9 @@ function _handleRagSearch(classified, originalUserQueryForRerank) {
       var pr = pool[li];
       var pkey = pr.surah + ':' + pr.ayah;
       var ctx = (pr.compositeText && String(pr.compositeText).trim())
-        ? String(pr.compositeText)
-        : '[context unavailable]';
+        ? _translationFromRerankContext_(String(pr.compositeText))
+        : '';
+      if (!ctx) ctx = '[context unavailable]';
       lines.push(pkey + '\n' + ctx);
     }
     var candidateBlock = lines.join('\n\n');

--- a/src/tests/RagService.test.gs
+++ b/src/tests/RagService.test.gs
@@ -316,6 +316,42 @@ function runRagServiceTests() {
     expect(out).arrayLength(2);
   });
 
+  // ── Translation extraction for Haiku rerank (unit) ───────────────────────
+
+  results.push('\n_translationFromRerankContext_()');
+
+  it('returns text after Translation: and before Tafseer', function () {
+    var sample = 'Surah Al-Baqarah (2), Ayah 261\n' +
+      'Translation: The likeness of those who spend.\n' +
+      'Tafseer: The example of the reward.\n' +
+      'Themes: Parable of charity\n' +
+      'Keywords: x';
+    expect(_translationFromRerankContext_(sample)).toBe('The likeness of those who spend.');
+  });
+
+  it('stops at Themes or Keywords when Tafseer is absent', function () {
+    var t = 'Translation: One line.\nThemes: t1';
+    expect(_translationFromRerankContext_(t)).toBe('One line.');
+  });
+
+  it('returns full trimmed string when there is no Translation: marker', function () {
+    expect(_translationFromRerankContext_('  AYAT AL-KURSI BLOCK  ')).toBe('AYAT AL-KURSI BLOCK');
+  });
+
+  it('returns translation to end of string when no Tafseer/Themes/Keywords', function () {
+    expect(_translationFromRerankContext_('Header\nTranslation: Only this part')).toBe('Only this part');
+  });
+
+  it('returns empty for blank or null composite', function () {
+    expect(_translationFromRerankContext_('   ')).toBe('');
+    expect(_translationFromRerankContext_(null)).toBe('');
+  });
+
+  it('falls back to full composite when Translation body is empty', function () {
+    var s = 'Surah 1:1\nTranslation:\nTafseer: y';
+    expect(_translationFromRerankContext_(s)).toBe(s);
+  });
+
   // ── Rerank prompt N parameterization (unit) ───────────────────────────────
 
   results.push('\n_buildRagRerankSystemPrompt_()');
@@ -333,6 +369,13 @@ function runRagServiceTests() {
     expect(prompt1.indexOf('return the 10 most relevant') >= 0).toBe(true);
     expect(prompt2.indexOf('return the 10 most relevant') >= 0).toBe(true);
     expect(prompt3.indexOf('return the 10 most relevant') >= 0).toBe(true);
+  });
+
+  it('describes English translation only, not tafseer or themes in the input', function () {
+    var p = _buildRagRerankSystemPrompt_(4);
+    expect(p.toLowerCase().indexOf('tafseer') === -1).toBe(true);
+    expect(p.indexOf('Each candidate is presented as its surah:ayah key') >= 0).toBe(true);
+    expect(p.indexOf('English translation for that ayah') >= 0).toBe(true);
   });
 
   // ── Property key getters (unit) ───────────────────────────────────────────


### PR DESCRIPTION
Closes #163

Haiku rerank no longer receives full Pinecone `composite_text` (tafseer, themes, keywords). It receives the English segment after `Translation:` when present, with fallback to the full string for legacy payloads.

- `RagService.js`: `_translationFromRerankContext_` and use in candidate block
- `ClaudeAPI.js`: align rerank system prompt and JSDoc
- GAS unit tests for extraction and prompt contract

Made with [Cursor](https://cursor.com)