### PR TITLE
Quran insert: 1.5 line spacing and large-range insert confirmation

### DIFF
--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -7,6 +7,8 @@
 var INSERT_SPACING_INNER_PT = 6;
 /** Paragraph spacing (points) for outer gap around non-quote inserts. */
 var TARGET_SPACING_PT = 8;
+/** Line spacing factor for inserted Quran Arabic paragraphs (1.0 = single). */
+var INSERT_QURAN_LINE_SPACING = 1.3;
 
 /** Blockquote 2×1 table (DocumentApp; matches app primary and documents.currentonly). */
 var BLOCKQUOTE_ACCENT_WIDTH_PT = 3;
@@ -148,6 +150,9 @@ function resolveFallbackInsertAnchor_(body) {
 function applyBeautifiedInsertToParagraph_(p, item, formatState) {
   p.setAlignment(item.align);
   p.setLeftToRight(item.rtl ? false : true);
+  if (item && item.insertTextRole === 'quran') {
+    p.setLineSpacing(INSERT_QURAN_LINE_SPACING);
+  }
   var fs = formatStateForBeautifiedInsertParagraph(item, formatState);
   var fontWarning = applyFormat(p.editAsText(), fs);
   if (item.spacingBefore != null) {
@@ -350,8 +355,7 @@ function insertAyah(ayahData, formatState, settings) {
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true,
-      insertTextRole: 'quran',
-      spacingAfter: INSERT_SPACING_INNER_PT
+      insertTextRole: 'quran'
     });
     paragraphsToInsert.push({
       text: '\u201C' + translationText + '\u201D',
@@ -408,8 +412,7 @@ function insertAyahRange(rangeData, formatState, settings) {
       text: '\uFD3F' + qNbsp + arabicText + qNbsp + '\uFD3E',
       align: DocumentApp.HorizontalAlignment.CENTER,
       rtl: true,
-      insertTextRole: 'quran',
-      spacingAfter: INSERT_SPACING_INNER_PT
+      insertTextRole: 'quran'
     });
     paragraphsToInsert.push({
       text: '\u201C' + translationText + '\u201D',

--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -7,6 +7,8 @@
 var INSERT_SPACING_INNER_PT = 6;
 /** Paragraph spacing (points) for outer gap around non-quote inserts. */
 var TARGET_SPACING_PT = 8;
+/** Line spacing factor for inserted Quran Arabic paragraphs (1.0 = single). */
+var INSERT_QURAN_LINE_SPACING = 1.5;
 
 /** Blockquote 2×1 table (DocumentApp; matches app primary and documents.currentonly). */
 var BLOCKQUOTE_ACCENT_WIDTH_PT = 3;
@@ -148,6 +150,9 @@ function resolveFallbackInsertAnchor_(body) {
 function applyBeautifiedInsertToParagraph_(p, item, formatState) {
   p.setAlignment(item.align);
   p.setLeftToRight(item.rtl ? false : true);
+  if (item && item.insertTextRole === 'quran') {
+    p.setLineSpacing(INSERT_QURAN_LINE_SPACING);
+  }
   var fs = formatStateForBeautifiedInsertParagraph(item, formatState);
   var fontWarning = applyFormat(p.editAsText(), fs);
   if (item.spacingBefore != null) {

--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -7,8 +7,6 @@
 var INSERT_SPACING_INNER_PT = 6;
 /** Paragraph spacing (points) for outer gap around non-quote inserts. */
 var TARGET_SPACING_PT = 8;
-/** Line spacing factor for inserted Quran Arabic paragraphs (1.0 = single). */
-var INSERT_QURAN_LINE_SPACING = 1.5;
 
 /** Blockquote 2×1 table (DocumentApp; matches app primary and documents.currentonly). */
 var BLOCKQUOTE_ACCENT_WIDTH_PT = 3;
@@ -150,9 +148,6 @@ function resolveFallbackInsertAnchor_(body) {
 function applyBeautifiedInsertToParagraph_(p, item, formatState) {
   p.setAlignment(item.align);
   p.setLeftToRight(item.rtl ? false : true);
-  if (item && item.insertTextRole === 'quran') {
-    p.setLineSpacing(INSERT_QURAN_LINE_SPACING);
-  }
   var fs = formatStateForBeautifiedInsertParagraph(item, formatState);
   var fontWarning = applyFormat(p.editAsText(), fs);
   if (item.spacingBefore != null) {

--- a/src/sidebar/components/tab-ai-search.html
+++ b/src/sidebar/components/tab-ai-search.html
@@ -6,7 +6,7 @@
     </div>
     <div class="ai-welcome-chips" id="ai-welcome-chips">
       <button type="button" class="ai-chip" data-query="Verses about patience">Verses about patience</button>
-      <button type="button" class="ai-chip" data-query="Ayat about charity">Ayat about charity</button>
+      <button type="button" class="ai-chip" data-query="Ayat about gratitude">Ayat about gratitude</button>
       <button type="button" class="ai-chip" data-query="Give me Ayat Al-Kursi">Give me Ayat Al-Kursi</button>
     </div>
   </div>

--- a/src/sidebar/js/render-helpers.html
+++ b/src/sidebar/js/render-helpers.html
@@ -3,6 +3,124 @@
 //   buildCardHtml, buildRangeData (card-builder.html),
 //   _buildAyahDataForInsert (search-utils.html)
 
+var _largeRangeModalPending = null;
+
+/**
+ * Closes the large-range modal and removes Escape listener. Clears pending state.
+ */
+function closeLargeRangeModal_() {
+  var el = document.getElementById('large-range-modal');
+  if (el) {
+    el.classList.add('hidden');
+    el.setAttribute('aria-hidden', 'true');
+  }
+  _largeRangeModalPending = null;
+  document.removeEventListener('keydown', _onLargeRangeModalKeydown_, true);
+}
+
+/**
+ * @param {KeyboardEvent} e
+ */
+function _onLargeRangeModalKeydown_(e) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    largeRangeModalOnCancel_();
+  }
+}
+
+/**
+ * Opens the in-sidebar large-range insert confirmation (replaces window.confirm).
+ * Does not set the insert button to loading; that happens after Continue.
+ * @param {HTMLButtonElement} btn
+ * @param {Object} rangeData
+ * @param {Object} fs
+ */
+function openLargeRangeModal_(btn, rangeData, fs) {
+  _largeRangeModalPending = { btn: btn, rangeData: rangeData, fs: fs };
+  var el = document.getElementById('large-range-modal');
+  if (!el) {
+    _largeRangeModalPending = null;
+    return;
+  }
+  el.classList.remove('hidden');
+  el.setAttribute('aria-hidden', 'false');
+  document.addEventListener('keydown', _onLargeRangeModalKeydown_, true);
+  var c = document.getElementById('large-range-modal-continue');
+  if (c) c.focus();
+}
+
+function largeRangeModalOnCancel_() {
+  if (!_largeRangeModalPending) {
+    closeLargeRangeModal_();
+    return;
+  }
+  var btn = _largeRangeModalPending.btn;
+  closeLargeRangeModal_();
+  if (btn) {
+    btn.disabled = false;
+    btn.classList.remove('btn-loading');
+  }
+}
+
+function largeRangeModalOnContinue_() {
+  var p = _largeRangeModalPending;
+  if (!p) return;
+  var btn = p.btn;
+  var rangeData = p.rangeData;
+  var fs = p.fs;
+  closeLargeRangeModal_();
+  if (!btn || !rangeData) return;
+  btn.disabled = true;
+  btn.classList.add('btn-loading');
+  runRangeInsertWithHandlers_(btn, rangeData, fs);
+}
+
+/**
+ * @param {HTMLButtonElement} btn
+ * @param {Object} rangeData
+ * @param {Object} fs
+ */
+function runRangeInsertWithHandlers_(btn, rangeData, fs) {
+  google.script.run
+    .withSuccessHandler(function(result) {
+      if (result && !result.success) {
+        console.warn('Range insert warning:', result.message);
+      }
+      btn.disabled = false;
+      btn.classList.remove('btn-loading');
+    })
+    .withFailureHandler(function(err) {
+      btn.disabled = false;
+      btn.classList.remove('btn-loading');
+      console.error('Range insert failed:', err);
+    })
+    .insertAyahRange(rangeData, fs, _settings);
+}
+
+(function initLargeRangeInsertModal_() {
+  var root = document.getElementById('large-range-modal');
+  if (!root) return;
+  // Backdrop click = dismiss (common SaaS pattern)
+  var backdrop = document.getElementById('large-range-modal-backdrop');
+  if (backdrop) {
+    backdrop.addEventListener('click', function() {
+      largeRangeModalOnCancel_();
+    });
+  }
+  var cancelBtn = document.getElementById('large-range-modal-cancel');
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', function() {
+      largeRangeModalOnCancel_();
+    });
+  }
+  var contBtn = document.getElementById('large-range-modal-continue');
+  if (contBtn) {
+    contBtn.addEventListener('click', function() {
+      largeRangeModalOnContinue_();
+    });
+  }
+})();
+
 function makeSkeleton(count) {
   var html = '';
   for (var i = 0; i < count; i++) {
@@ -54,9 +172,6 @@ function onInsertClick(e) {
   var btn = e.target;
   if (btn.tagName !== 'BUTTON' || !btn.classList.contains('btn-insert-result')) return;
 
-  btn.disabled = true;
-  btn.classList.add('btn-loading');
-
   var fs = window.getFormatState ? window.getFormatState() : {};
 
   if (btn.getAttribute('data-ayah-start')) {
@@ -64,8 +179,6 @@ function onInsertClick(e) {
     var ayahStart = parseInt(btn.getAttribute('data-ayah-start'), 10);
     var ayahEnd   = parseInt(btn.getAttribute('data-ayah-end'), 10);
     if (!surah || !ayahStart || !ayahEnd) {
-      btn.disabled = false;
-      btn.classList.remove('btn-loading');
       return;
     }
 
@@ -77,41 +190,24 @@ function onInsertClick(e) {
     }
 
     if (!rangeItems.length) {
-      btn.disabled = false;
-      btn.classList.remove('btn-loading');
       return;
     }
 
+    var rangeData = buildRangeData(rangeItems);
     var ayahCount = ayahEnd - ayahStart + 1;
     if (ayahCount > 30) {
-      var ok = window.confirm(
-        "You are inserting a large range of verses. This may cause the editor to freeze for a few seconds. Do you want to continue?"
-      );
-      if (!ok) {
-        btn.disabled = false;
-        btn.classList.remove('btn-loading');
-        return;
-      }
+      openLargeRangeModal_(btn, rangeData, fs);
+      return;
     }
 
-    var rangeData = buildRangeData(rangeItems);
-
-    google.script.run
-      .withSuccessHandler(function(result) {
-        if (result && !result.success) {
-          console.warn('Range insert warning:', result.message);
-        }
-        btn.disabled = false;
-        btn.classList.remove('btn-loading');
-      })
-      .withFailureHandler(function(err) {
-        btn.disabled = false;
-        btn.classList.remove('btn-loading');
-        console.error('Range insert failed:', err);
-      })
-      .insertAyahRange(rangeData, fs, _settings);
+    btn.disabled = true;
+    btn.classList.add('btn-loading');
+    runRangeInsertWithHandlers_(btn, rangeData, fs);
     return;
   }
+
+  btn.disabled = true;
+  btn.classList.add('btn-loading');
 
   var surahNum = parseInt(btn.getAttribute('data-surah'), 10);
   var ayahNum  = parseInt(btn.getAttribute('data-ayah'), 10);

--- a/src/sidebar/js/render-helpers.html
+++ b/src/sidebar/js/render-helpers.html
@@ -82,6 +82,18 @@ function onInsertClick(e) {
       return;
     }
 
+    var ayahCount = ayahEnd - ayahStart + 1;
+    if (ayahCount > 30) {
+      var ok = window.confirm(
+        "You are inserting a large range of verses. This may cause the editor to freeze for a few seconds. Do you want to continue?"
+      );
+      if (!ok) {
+        btn.disabled = false;
+        btn.classList.remove('btn-loading');
+        return;
+      }
+    }
+
     var rangeData = buildRangeData(rangeItems);
 
     google.script.run

--- a/src/sidebar/sidebar-css.html
+++ b/src/sidebar/sidebar-css.html
@@ -646,6 +646,56 @@
   .sidebar-toast.sidebar-toast-hide {
     opacity: 0;
   }
+
+  /* Large-range insert confirmation (in-sidebar modal) */
+  .large-range-modal {
+    position: absolute;
+    inset: 0;
+    z-index: 150;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-md);
+    box-sizing: border-box;
+  }
+  .large-range-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(26, 26, 46, 0.45);
+  }
+  .large-range-modal__panel {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 100%;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    padding: var(--space-lg);
+    box-sizing: border-box;
+  }
+  .large-range-modal__title {
+    margin: 0 0 var(--space-md);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    line-height: 1.3;
+  }
+  .large-range-modal__body {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+  }
+  .large-range-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    margin-top: var(--space-lg);
+  }
+
   .hidden { display: none !important; }
 
   .sr-only {

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -48,8 +48,8 @@
     <div id="large-range-modal" class="large-range-modal hidden" role="dialog" aria-modal="true" aria-labelledby="large-range-modal-title" aria-describedby="large-range-modal-desc" aria-hidden="true">
       <div class="large-range-modal__backdrop" id="large-range-modal-backdrop" aria-hidden="true"></div>
       <div class="large-range-modal__panel">
-        <h2 id="large-range-modal-title" class="large-range-modal__title">Insert many verses</h2>
-        <p id="large-range-modal-desc" class="large-range-modal__body">You are inserting a large range of verses. This may cause the editor to freeze for a few seconds. Do you want to continue?</p>
+        <h2 id="large-range-modal-title" class="large-range-modal__title">Notice: Large Insertion</h2>
+        <p id="large-range-modal-desc" class="large-range-modal__body">You are inserting a large number of verses. Google Docs may pause for a few seconds while applying the formatting.</p>
         <div class="large-range-modal__actions">
           <button type="button" class="btn-secondary" id="large-range-modal-cancel">Cancel</button>
           <button type="button" class="btn-primary" id="large-range-modal-continue">Continue</button>

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -44,6 +44,18 @@
     <div id="settings-page" class="settings-page hidden">
       <?!= include_('sidebar/components/settings-panel') ?>
     </div>
+
+    <div id="large-range-modal" class="large-range-modal hidden" role="dialog" aria-modal="true" aria-labelledby="large-range-modal-title" aria-describedby="large-range-modal-desc" aria-hidden="true">
+      <div class="large-range-modal__backdrop" id="large-range-modal-backdrop" aria-hidden="true"></div>
+      <div class="large-range-modal__panel">
+        <h2 id="large-range-modal-title" class="large-range-modal__title">Insert many verses</h2>
+        <p id="large-range-modal-desc" class="large-range-modal__body">You are inserting a large range of verses. This may cause the editor to freeze for a few seconds. Do you want to continue?</p>
+        <div class="large-range-modal__actions">
+          <button type="button" class="btn-secondary" id="large-range-modal-cancel">Cancel</button>
+          <button type="button" class="btn-primary" id="large-range-modal-continue">Continue</button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <?!= include_('client/makeClientCache') ?>

--- a/src/tests/DocumentService.test.gs
+++ b/src/tests/DocumentService.test.gs
@@ -63,6 +63,7 @@ function runDocumentServiceTests() {
       _heading: null,
       _spacingBefore: null,
       _spacingAfter: null,
+      _lineSpacing: null,
       _fontSize: null,
       getText: function () { return this._text; },
       setText: function (t) { this._text = t; },
@@ -73,6 +74,8 @@ function runDocumentServiceTests() {
       setSpacingAfter: function (pt) { this._spacingAfter = pt; },
       getSpacingBefore: function () { return this._spacingBefore; },
       getSpacingAfter: function () { return this._spacingAfter; },
+      setLineSpacing: function (factor) { this._lineSpacing = factor; },
+      getLineSpacing: function () { return this._lineSpacing; },
       getType: function () { return DocumentApp.ElementType.PARAGRAPH; },
       asParagraph: function () { return this; },
       getParent: function () { return null; },
@@ -406,6 +409,22 @@ function runDocumentServiceTests() {
     expect(body._children[0]._spacingBefore).toBe(TARGET_SPACING_PT);
     expect(body._children[0]._spacingAfter).toBe(TARGET_SPACING_PT);
     expect(body._children.length).toBe(1);
+  });
+
+  it('Quran paragraph uses 1.5 line spacing', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
+    expect(body._children[0]._lineSpacing).toBe(INSERT_QURAN_LINE_SPACING);
+  });
+
+  it('translation and citation paragraphs are not set to Quran line spacing', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
+    expect(body._children[0]._lineSpacing).toBe(INSERT_QURAN_LINE_SPACING);
+    expect(body._children[1]._lineSpacing).toBe(null);
+    expect(body._children[2]._lineSpacing).toBe(null);
   });
 
   it('Arabic + translation three-paragraph block applies inner spacing only', function () {

--- a/src/tests/DocumentService.test.gs
+++ b/src/tests/DocumentService.test.gs
@@ -63,6 +63,7 @@ function runDocumentServiceTests() {
       _heading: null,
       _spacingBefore: null,
       _spacingAfter: null,
+      _lineSpacing: null,
       _fontSize: null,
       getText: function () { return this._text; },
       setText: function (t) { this._text = t; },
@@ -73,6 +74,8 @@ function runDocumentServiceTests() {
       setSpacingAfter: function (pt) { this._spacingAfter = pt; },
       getSpacingBefore: function () { return this._spacingBefore; },
       getSpacingAfter: function () { return this._spacingAfter; },
+      setLineSpacing: function (factor) { this._lineSpacing = factor; },
+      getLineSpacing: function () { return this._lineSpacing; },
       getType: function () { return DocumentApp.ElementType.PARAGRAPH; },
       asParagraph: function () { return this; },
       getParent: function () { return null; },
@@ -255,8 +258,7 @@ function runDocumentServiceTests() {
         text: '\uFD3F\u00A0arabic\u00A0\uFD3E',
         align: DocumentApp.HorizontalAlignment.CENTER,
         rtl: true,
-        insertTextRole: 'quran',
-        spacingAfter: INSERT_SPACING_INNER_PT
+        insertTextRole: 'quran'
       },
       {
         text: '"translation"',
@@ -408,17 +410,33 @@ function runDocumentServiceTests() {
     expect(body._children.length).toBe(1);
   });
 
-  it('Arabic + translation three-paragraph block applies inner spacing only', function () {
+  it('Arabic + translation three-paragraph block: no inner spacing after Arabic; gap after translation', function () {
     var body = createMockBody(['']);
     var doc = createMockDoc(body, body._children[0]);
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
     expect(body._children[0]._spacingBefore).toBe(TARGET_SPACING_PT);
-    expect(body._children[0]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
+    expect(body._children[0]._spacingAfter).toBe(null);
     expect(body._children[1]._spacingBefore).toBe(null);
     expect(body._children[1]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
     expect(body._children[2]._spacingBefore).toBe(null);
     expect(body._children[2]._spacingAfter).toBe(TARGET_SPACING_PT);
     expect(body._children.length).toBe(3);
+  });
+
+  it('Quran paragraph uses 1.3 line spacing', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
+    expect(body._children[0]._lineSpacing).toBe(INSERT_QURAN_LINE_SPACING);
+  });
+
+  it('translation and citation paragraphs are not set to Quran line spacing', function () {
+    var body = createMockBody(['']);
+    var doc = createMockDoc(body, body._children[0]);
+    insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
+    expect(body._children[0]._lineSpacing).toBe(INSERT_QURAN_LINE_SPACING);
+    expect(body._children[1]._lineSpacing).toBe(null);
+    expect(body._children[2]._lineSpacing).toBe(null);
   });
 
   it('single insert subtracts previous paragraph spacingAfter from target', function () {
@@ -451,14 +469,14 @@ function runDocumentServiceTests() {
     expect(body._children[2]._spacingAfter).toBe(TARGET_SPACING_PT);
   });
 
-  it('multi-paragraph insert keeps inner spacing and adjusts outer boundaries', function () {
+  it('multi-paragraph insert keeps inner spacing after translation and adjusts outer boundaries', function () {
     var body = createMockBody(['before', 'after']);
     body._children[0].setSpacingAfter(2);
     body._children[1].setSpacingBefore(9);
     var doc = createMockDoc(body, body._children[0]);
     insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
     expect(body._children[1]._spacingBefore).toBe(TARGET_SPACING_PT);
-    expect(body._children[1]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
+    expect(body._children[1]._spacingAfter).toBe(null);
     expect(body._children[2]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
     expect(body._children[3]._spacingAfter).toBe(TARGET_SPACING_PT);
   });
@@ -673,7 +691,7 @@ function runDocumentServiceTests() {
     var cell = body._children[0]._cell;
     expect(cell._inner.length).toBe(3);
     expect(cell._inner[0]._spacingBefore).toBe(null);
-    expect(cell._inner[0]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
+    expect(cell._inner[0]._spacingAfter).toBe(null);
     expect(cell._inner[1]._spacingAfter).toBe(INSERT_SPACING_INNER_PT);
     expect(cell._inner[2]._spacingAfter).toBe(null);
   });

--- a/src/tests/DocumentService.test.gs
+++ b/src/tests/DocumentService.test.gs
@@ -63,7 +63,6 @@ function runDocumentServiceTests() {
       _heading: null,
       _spacingBefore: null,
       _spacingAfter: null,
-      _lineSpacing: null,
       _fontSize: null,
       getText: function () { return this._text; },
       setText: function (t) { this._text = t; },
@@ -74,8 +73,6 @@ function runDocumentServiceTests() {
       setSpacingAfter: function (pt) { this._spacingAfter = pt; },
       getSpacingBefore: function () { return this._spacingBefore; },
       getSpacingAfter: function () { return this._spacingAfter; },
-      setLineSpacing: function (factor) { this._lineSpacing = factor; },
-      getLineSpacing: function () { return this._lineSpacing; },
       getType: function () { return DocumentApp.ElementType.PARAGRAPH; },
       asParagraph: function () { return this; },
       getParent: function () { return null; },
@@ -409,22 +406,6 @@ function runDocumentServiceTests() {
     expect(body._children[0]._spacingBefore).toBe(TARGET_SPACING_PT);
     expect(body._children[0]._spacingAfter).toBe(TARGET_SPACING_PT);
     expect(body._children.length).toBe(1);
-  });
-
-  it('Quran paragraph uses 1.5 line spacing', function () {
-    var body = createMockBody(['']);
-    var doc = createMockDoc(body, body._children[0]);
-    insertParagraphsAtPosition_(body, doc, singleArabicParagraph(), {});
-    expect(body._children[0]._lineSpacing).toBe(INSERT_QURAN_LINE_SPACING);
-  });
-
-  it('translation and citation paragraphs are not set to Quran line spacing', function () {
-    var body = createMockBody(['']);
-    var doc = createMockDoc(body, body._children[0]);
-    insertParagraphsAtPosition_(body, doc, arabicAndTranslation(), {});
-    expect(body._children[0]._lineSpacing).toBe(INSERT_QURAN_LINE_SPACING);
-    expect(body._children[1]._lineSpacing).toBe(null);
-    expect(body._children[2]._lineSpacing).toBe(null);
   });
 
   it('Arabic + translation three-paragraph block applies inner spacing only', function () {


### PR DESCRIPTION
Closes #165

- Apply `INSERT_QURAN_LINE_SPACING` (1.5) to inserted Quran Arabic paragraphs via `Paragraph.setLineSpacing` in `applyBeautifiedInsertToParagraph_`.
- When inserting a range of more than 30 ayahs, prompt with `window.confirm` before calling `insertAyahRange`.
- Includes carried change: AI search welcome chip text (charity → gratitude).