### PR TITLE
feat(#167): Sidebar toasts for insert errors and server messages

### DIFF
--- a/src/DocumentService.js
+++ b/src/DocumentService.js
@@ -332,7 +332,7 @@ function insertParagraphsAtPosition_(body, doc, paragraphsToInsert, formatState)
  */
 function insertAyah(ayahData, formatState, settings) {
   if (!ayahData || !ayahData.surah || !ayahData.ayah) {
-    return { success: false, message: 'Invalid ayah data' };
+    return { success: false, message: 'Missing verse details. Choose a surah and ayah, then try again.' };
   }
 
   var doc = DocumentApp.getActiveDocument();
@@ -394,7 +394,7 @@ function insertAyah(ayahData, formatState, settings) {
  */
 function insertAyahRange(rangeData, formatState, settings) {
   if (!rangeData || !rangeData.surah || !rangeData.ayahStart) {
-    return { success: false, message: 'Invalid range data.' };
+    return { success: false, message: 'Missing range details. Check From and To, then try again.' };
   }
 
   var doc    = DocumentApp.getActiveDocument();

--- a/src/RagService.js
+++ b/src/RagService.js
@@ -81,9 +81,34 @@ function _truncateForRagLog_(s) {
 }
 
 /**
+ * English/context string from Pinecone metadata for merge + rerank prompts.
+ * Prefers composite_text; if missing or whitespace-only, uses theme_tags (string or string array).
+ * @param {Object} meta - Pinecone match metadata
+ * @return {string}
+ */
+function _ragMetadataCompositeText_(meta) {
+  if (!meta) return '';
+  var ct = meta.composite_text;
+  if (ct != null && String(ct).trim() !== '') {
+    return String(ct);
+  }
+  var tags = meta.theme_tags;
+  if (tags == null) return '';
+  if (Array.isArray(tags)) {
+    var parts = [];
+    for (var i = 0; i < tags.length; i++) {
+      var t = tags[i];
+      if (t != null && String(t).trim() !== '') parts.push(String(t).trim());
+    }
+    return parts.join(' ');
+  }
+  return String(tags).trim();
+}
+
+/**
  * Merges Pinecone match lists from multiple query vectors: one row per ayah (max score wins).
  * @param {Array<{queryIndex: number, queryText: string, matches: Array<{score: number, metadata: Object}>}>} runs
- * @return {Array<{surah: number, ayah: number, score: number, winningQueryIndex: number, winningQueryText: string, compositeText: string}>}
+ * @return {Array<{surah: number, ayah: number, score: number, winningQueryIndex: number, winningQueryText: string, compositeText: string}>} compositeText from metadata composite_text or theme_tags
  */
 function _mergeRagMatchesByAyah_(runs) {
   var best = {};
@@ -109,7 +134,7 @@ function _mergeRagMatchesByAyah_(runs) {
           ayah: a,
           winningQueryIndex: qi,
           winningQueryText: qtext,
-          compositeText: (meta.composite_text != null ? String(meta.composite_text) : '')
+          compositeText: _ragMetadataCompositeText_(meta)
         };
       }
     }

--- a/src/sidebar/js/render-helpers.html
+++ b/src/sidebar/js/render-helpers.html
@@ -83,18 +83,57 @@ function largeRangeModalOnContinue_() {
 function runRangeInsertWithHandlers_(btn, rangeData, fs) {
   google.script.run
     .withSuccessHandler(function(result) {
-      if (result && !result.success) {
-        console.warn('Range insert warning:', result.message);
-      }
-      btn.disabled = false;
-      btn.classList.remove('btn-loading');
+      onInsertComplete_(btn, result, null);
     })
     .withFailureHandler(function(err) {
-      btn.disabled = false;
-      btn.classList.remove('btn-loading');
-      console.error('Range insert failed:', err);
+      onInsertComplete_(btn, null, err);
     })
     .insertAyahRange(rangeData, fs, _settings);
+}
+
+/**
+ * True when insert succeeded with extra user-facing copy (e.g. font fallback warning).
+ * @param {string} msg
+ * @return {boolean}
+ */
+function insertResultHasAuxiliaryMessage_(msg) {
+  if (!msg || typeof msg !== 'string') return false;
+  if (msg === 'Ayah inserted.' || msg === 'Range inserted.') return false;
+  return msg.indexOf('Ayah inserted. ') === 0 || msg.indexOf('Range inserted. ') === 0;
+}
+
+/**
+ * @param {HTMLButtonElement|null} btn
+ * @param {Object|null} result
+ * @param {*} err
+ */
+function onInsertComplete_(btn, result, err) {
+  if (btn) {
+    btn.disabled = false;
+    btn.classList.remove('btn-loading');
+  }
+  if (err) {
+    var em = typeof window.userFacingRpcErrorMessage === 'function'
+      ? window.userFacingRpcErrorMessage(err)
+      : 'Insert failed.';
+    if (typeof window.showSidebarToast === 'function') {
+      window.showSidebarToast(em, { variant: 'error' });
+    }
+    console.error('Insert failed:', err);
+    return;
+  }
+  if (result && !result.success) {
+    if (typeof window.showSidebarToast === 'function') {
+      window.showSidebarToast(result.message || 'Could not insert.', { variant: 'error' });
+    }
+    console.warn('Insert warning:', result.message);
+    return;
+  }
+  if (result && result.success && insertResultHasAuxiliaryMessage_(result.message)) {
+    if (typeof window.showSidebarToast === 'function') {
+      window.showSidebarToast(result.message, { variant: 'info', durationMs: 5200 });
+    }
+  }
 }
 
 (function initLargeRangeInsertModal_() {
@@ -227,16 +266,10 @@ function onInsertClick(e) {
 
   google.script.run
     .withSuccessHandler(function(result) {
-      if (result && !result.success) {
-        console.warn('Insert warning:', result.message);
-      }
-      btn.disabled = false;
-      btn.classList.remove('btn-loading');
+      onInsertComplete_(btn, result, null);
     })
     .withFailureHandler(function(err) {
-      btn.disabled = false;
-      btn.classList.remove('btn-loading');
-      console.error('Insert failed:', err);
+      onInsertComplete_(btn, null, err);
     })
     .insertAyah(ayahData, fs, _settings);
 }

--- a/src/sidebar/js/sidebar-js.html
+++ b/src/sidebar/js/sidebar-js.html
@@ -150,16 +150,11 @@
   var TOAST_DEFAULT_MS = 4400;
   var TOAST_ERROR_MS = 5600;
 
+  /** Shown for insert RPC failures; raw errors stay in the console only. */
+  var INSERT_RPC_USER_MESSAGE = 'Couldn\'t insert. Click in the document and try again.';
+
   function userFacingRpcErrorMessage(err) {
-    if (err == null) return 'Something went wrong. Please try again.';
-    if (typeof err === 'string') {
-      var s = err.trim();
-      return s || 'Something went wrong. Please try again.';
-    }
-    if (typeof err.message === 'string' && err.message.trim()) {
-      return err.message.trim();
-    }
-    return 'Something went wrong. Please try again.';
+    return INSERT_RPC_USER_MESSAGE;
   }
 
   /**

--- a/src/sidebar/js/sidebar-js.html
+++ b/src/sidebar/js/sidebar-js.html
@@ -142,4 +142,100 @@
   }
 
 })();
+
+(function sidebarToast_() {
+  'use strict';
+
+  var TOAST_MAX_LEN = 380;
+  var TOAST_DEFAULT_MS = 4400;
+  var TOAST_ERROR_MS = 5600;
+
+  function userFacingRpcErrorMessage(err) {
+    if (err == null) return 'Something went wrong. Please try again.';
+    if (typeof err === 'string') {
+      var s = err.trim();
+      return s || 'Something went wrong. Please try again.';
+    }
+    if (typeof err.message === 'string' && err.message.trim()) {
+      return err.message.trim();
+    }
+    return 'Something went wrong. Please try again.';
+  }
+
+  /**
+   * @param {string} message
+   * @param {{ variant?: string, durationMs?: number }=} opts
+   */
+  function showSidebarToast(message, opts) {
+    opts = opts || {};
+    var variant = opts.variant === 'error' || opts.variant === 'info' || opts.variant === 'neutral'
+      ? opts.variant
+      : 'neutral';
+    var durationBase = variant === 'error' ? TOAST_ERROR_MS : TOAST_DEFAULT_MS;
+    var durationMs = typeof opts.durationMs === 'number' && opts.durationMs >= 0
+      ? opts.durationMs
+      : durationBase;
+
+    var text = String(message == null ? '' : message).replace(/\s+/g, ' ').trim();
+    if (!text) return;
+
+    if (text.length > TOAST_MAX_LEN) {
+      text = text.slice(0, TOAST_MAX_LEN - 1) + '\u2026';
+    }
+
+    var host = document.getElementById('sidebar-toast-host');
+    if (!host) return;
+
+    var el = document.createElement('div');
+    el.className = 'sidebar-toast sidebar-toast--' + variant;
+
+    if (variant === 'error') {
+      el.setAttribute('role', 'alert');
+    } else {
+      el.setAttribute('role', 'status');
+    }
+
+    var strip = document.createElement('span');
+    strip.className = 'sidebar-toast__strip';
+    strip.setAttribute('aria-hidden', 'true');
+
+    var p = document.createElement('p');
+    p.className = 'sidebar-toast__text';
+    p.textContent = text;
+
+    el.appendChild(strip);
+    el.appendChild(p);
+
+    host.appendChild(el);
+
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        el.classList.add('sidebar-toast--visible');
+      });
+    });
+
+    window.setTimeout(function() {
+      dismissToast_(el);
+    }, durationMs);
+  }
+
+  /**
+   * @param {HTMLElement} node
+   */
+  function dismissToast_(node) {
+    if (!node.parentNode) return;
+    node.classList.remove('sidebar-toast--visible');
+    node.classList.add('sidebar-toast--leaving');
+    var motionMs = 220;
+    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      motionMs = 30;
+    }
+    window.setTimeout(function() {
+      if (node.parentNode) node.parentNode.removeChild(node);
+    }, motionMs);
+  }
+
+  window.userFacingRpcErrorMessage = userFacingRpcErrorMessage;
+  window.showSidebarToast = showSidebarToast;
+})();
 </script>

--- a/src/sidebar/js/tab-ai-search-js.html
+++ b/src/sidebar/js/tab-ai-search-js.html
@@ -60,7 +60,7 @@ function showAiSearchEmptyError(emptyEl, message) {
     row.appendChild(tip);
     emptyEl.appendChild(row);
   } else {
-    emptyEl.textContent = message;
+    emptyEl.textContent = 'Something went wrong. Please try again.';
   }
   emptyEl.classList.remove('hidden');
 }
@@ -329,6 +329,9 @@ function initAISearchTab() {
     }
 
     if (response.type === 'error') {
+      if (!isAiDailyLimitErrorMessage(response.error)) {
+        console.warn('AI search error:', response.error);
+      }
       showAiSearchEmptyError(emptyEl, response.error);
       if (isAiDailyLimitErrorMessage(response.error)) {
         _aiSearchAwaitingResponse = false;

--- a/src/sidebar/sidebar-css.html
+++ b/src/sidebar/sidebar-css.html
@@ -627,24 +627,74 @@
     z-index: 400;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    align-items: center;
+    gap: var(--space-sm);
+    width: calc(100% - 2 * var(--sidebar-inline));
+    max-width: 312px;
     pointer-events: none;
+    box-sizing: border-box;
   }
   .sidebar-toast {
-    background: #2b2b2b;
-    color: #fff;
-    padding: 8px 12px;
-    border-radius: var(--radius-sm);
-    box-shadow: var(--shadow-md);
-    font-size: 12px;
-    line-height: 1.4;
-    max-width: 300px;
-    text-align: center;
-    opacity: 1;
-    transition: opacity 0.2s ease;
-  }
-  .sidebar-toast.sidebar-toast-hide {
+    --toast-strip: var(--color-primary);
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-sm);
+    width: 100%;
+    margin: 0;
+    padding: var(--space-md) var(--space-md) var(--space-md) var(--space-sm);
+    background: var(--color-bg);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow:
+      0 1px 2px rgba(26, 26, 46, 0.04),
+      0 8px 24px rgba(26, 26, 46, 0.1);
+    font-size: 13px;
+    line-height: 1.45;
+    text-align: left;
     opacity: 0;
+    transform: translateY(8px);
+    transition:
+      opacity 0.26s cubic-bezier(0.22, 1, 0.36, 1),
+      transform 0.26s cubic-bezier(0.22, 1, 0.36, 1);
+    box-sizing: border-box;
+  }
+  .sidebar-toast.sidebar-toast--visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .sidebar-toast.sidebar-toast--leaving {
+    opacity: 0;
+    transform: translateY(6px);
+    transition: opacity 0.18s ease, transform 0.18s ease;
+  }
+  .sidebar-toast__strip {
+    flex: 0 0 3px;
+    width: 3px;
+    align-self: stretch;
+    min-height: 2.5em;
+    margin-top: 2px;
+    border-radius: var(--radius-full);
+    background: var(--toast-strip);
+  }
+  .sidebar-toast__text {
+    margin: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: inherit;
+    line-height: inherit;
+    color: var(--color-text-primary);
+  }
+  .sidebar-toast--info { --toast-strip: var(--color-primary); }
+  .sidebar-toast--neutral { --toast-strip: #64748b; }
+  .sidebar-toast--error { --toast-strip: var(--color-error); }
+  @media (prefers-reduced-motion: reduce) {
+    .sidebar-toast {
+      transition-duration: 0.01ms;
+    }
+    .sidebar-toast.sidebar-toast--leaving {
+      transition-duration: 0.01ms;
+    }
   }
 
   /* Large-range insert confirmation (in-sidebar modal) */

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -45,6 +45,8 @@
       <?!= include_('sidebar/components/settings-panel') ?>
     </div>
 
+    <div id="sidebar-toast-host" class="sidebar-toast-host" aria-live="polite" aria-relevant="additions text"></div>
+
     <div id="large-range-modal" class="large-range-modal hidden" role="dialog" aria-modal="true" aria-labelledby="large-range-modal-title" aria-describedby="large-range-modal-desc" aria-hidden="true">
       <div class="large-range-modal__backdrop" id="large-range-modal-backdrop" aria-hidden="true"></div>
       <div class="large-range-modal__panel">

--- a/src/tests/RagService.test.gs
+++ b/src/tests/RagService.test.gs
@@ -99,6 +99,39 @@ function runRagServiceTests() {
     expect(out[0]).toBe('from array');
   });
 
+  results.push('\n_ragMetadataCompositeText_()');
+
+  it('returns composite_text when set and non-whitespace', function () {
+    expect(_ragMetadataCompositeText_({ composite_text: '  hello  ' })).toBe('  hello  ');
+  });
+
+  it('joins theme_tags array when composite_text absent', function () {
+    expect(
+      _ragMetadataCompositeText_({ theme_tags: [' first ', '', 'second'] })
+    ).toBe('first second');
+  });
+
+  it('uses theme_tags string when composite_text absent', function () {
+    expect(_ragMetadataCompositeText_({ theme_tags: ' single tag ' })).toBe('single tag');
+  });
+
+  it('prefers composite_text over theme_tags', function () {
+    expect(
+      _ragMetadataCompositeText_({ composite_text: 'A', theme_tags: ['B'] })
+    ).toBe('A');
+  });
+
+  it('falls back to theme_tags when composite_text is whitespace-only', function () {
+    expect(
+      _ragMetadataCompositeText_({ composite_text: '  \n', theme_tags: ['from tags'] })
+    ).toBe('from tags');
+  });
+
+  it('returns empty string when no usable fields', function () {
+    expect(_ragMetadataCompositeText_({})).toBe('');
+    expect(_ragMetadataCompositeText_(null)).toBe('');
+  });
+
   results.push('\n_mergeRagMatchesByAyah_()');
 
   it('keeps higher score when same ayah appears from two query runs', function () {
@@ -156,7 +189,7 @@ function runRagServiceTests() {
     expect(merged[1].compositeText).toBe('FATIHA 1 BLOCK');
   });
 
-  it('defaults compositeText to empty string when metadata.composite_text is absent', function () {
+  it('defaults compositeText to empty when no composite_text or theme_tags', function () {
     var runs = [
       {
         queryIndex: 0,
@@ -166,6 +199,23 @@ function runRagServiceTests() {
     ];
     var merged = _mergeRagMatchesByAyah_(runs);
     expect(merged[0].compositeText).toBe('');
+  });
+
+  it('maps theme_tags into compositeText when composite_text absent', function () {
+    var runs = [
+      {
+        queryIndex: 0,
+        queryText: 'q',
+        matches: [
+          {
+            score: 0.9,
+            metadata: { surah_number: 70, ayah_number: 5, theme_tags: ['tag one', 'tag two'] }
+          }
+        ]
+      }
+    ];
+    var merged = _mergeRagMatchesByAyah_(runs);
+    expect(merged[0].compositeText).toBe('tag one tag two');
   });
 
   results.push('\n_finalizeRagAyahRefs_()');
@@ -400,12 +450,95 @@ function runRagServiceTests() {
       var matches = _queryPinecone(pineconeHost, pineconeKey, embedding);
       expect(Array.isArray(matches)).toBe(true);
       expect(matches.length).toBeGreaterThan(0);
-      var first = matches[0];
-      expect(typeof first.score).toBe('number');
-      expect(first.metadata !== null && first.metadata !== undefined).toBe(true);
-      expect(typeof first.metadata.surah_number).toBe('number');
-      expect(typeof first.metadata.ayah_number).toBe('number');
-      expect(typeof first.metadata.composite_text === 'string' && first.metadata.composite_text.length > 0).toBe(true);
+
+      function metadataKeyList(meta) {
+        var keys = [];
+        if (meta == null) return keys;
+        for (var k in meta) {
+          if (Object.prototype.hasOwnProperty.call(meta, k)) keys.push(k);
+        }
+        keys.sort();
+        return keys;
+      }
+
+      function matchForErrorLog(m) {
+        var out = { id: m.id, score: m.score, scoreType: typeof m.score, metadata: {} };
+        var meta = m.metadata;
+        if (!meta) return out;
+        for (var k in meta) {
+          if (!Object.prototype.hasOwnProperty.call(meta, k)) continue;
+          var v = meta[k];
+          if (k === 'composite_text' && v != null && String(v).length > 160) {
+            out.metadata[k] = String(v).slice(0, 160) + '…';
+          } else {
+            out.metadata[k] = v;
+          }
+        }
+        return out;
+      }
+
+      // Pinecone often returns metadata scalars as strings; RagService uses parseInt like production.
+      var ok = false;
+      var diagnosticLines = [];
+      var maxSamples = Math.min(matches.length, 5);
+      for (var i = 0; i < matches.length; i++) {
+        var m = matches[i];
+        var issues = [];
+        if (typeof m.score !== 'number') {
+          issues.push('score is not a number (type=' + typeof m.score + ', value=' + JSON.stringify(m.score) + ')');
+        }
+        var meta = m.metadata;
+        if (meta == null) {
+          issues.push('metadata is null or undefined');
+        } else {
+          var s = parseInt(meta.surah_number, 10);
+          var a = parseInt(meta.ayah_number, 10);
+          if (!(s >= 1 && s <= 114 && a >= 1)) {
+            issues.push(
+              'surah_number/ayah_number out of range (parsed surah=' + s + ', ayah=' + a +
+                '; raw surah_number=' + JSON.stringify(meta.surah_number) +
+                ', ayah_number=' + JSON.stringify(meta.ayah_number) + ')'
+            );
+          }
+          var ctx = _ragMetadataCompositeText_(meta);
+          if (!ctx || String(ctx).trim() === '') {
+            issues.push(
+              'no non-empty composite_text or theme_tags (RagService._ragMetadataCompositeText_)'
+            );
+          }
+        }
+        if (i < maxSamples) {
+          diagnosticLines.push('  match[' + i + ' id=' + (m.id != null ? m.id : '?') + ']: ' + issues.join('; '));
+        }
+        if (issues.length === 0) {
+          ok = true;
+          break;
+        }
+      }
+
+      var firstKeys = metadataKeyList(matches[0] && matches[0].metadata);
+      Logger.log(
+        '[RagService integration] _queryPinecone: ' +
+          matches.length +
+          ' match(es); first match metadata keys: ' +
+          JSON.stringify(firstKeys)
+      );
+
+      if (!ok) {
+        throw new Error(
+          'Expected at least one Pinecone match with: numeric score, metadata.surah_number/ayah_number ' +
+            'parsable to surah 1–114 and ayah ≥ 1, and non-empty context from composite_text or theme_tags ' +
+            '(same contract as RagService._ragMetadataCompositeText_). ' +
+            'Got ' +
+            matches.length +
+            ' match(es). First match metadata keys: ' +
+            JSON.stringify(firstKeys) +
+            '. Sample row diagnostics:\n' +
+            diagnosticLines.join('\n') +
+            '\nFirst match (composite_text truncated in log): ' +
+            JSON.stringify(matchForErrorLog(matches[0]))
+        );
+      }
     });
 
     results.push('\n_handleRagSearch() — integration');


### PR DESCRIPTION
Adds an in-sidebar toast stack with modern SaaS styling (light surface, layered shadow, accent strip, motion-safe transitions) and wires Qur’an insert RPC completion so users see failures and non-fatal server copy (e.g. font fallback) instead of only console output.

**Changes**
- `#sidebar-toast-host` in the sidebar shell; `showSidebarToast` / `userFacingRpcErrorMessage` on `window` ([`src/sidebar/js/sidebar-js.html`](src/sidebar/js/sidebar-js.html)).
- Token-aligned toast styles ([`src/sidebar/sidebar-css.html`](src/sidebar/sidebar-css.html)).
- `onInsertComplete_` centralizes insert success/error handling and optional info toast when the server adds text after “Ayah inserted.” / “Range inserted.” ([`src/sidebar/js/render-helpers.html`](src/sidebar/js/render-helpers.html)).

Closes #167.